### PR TITLE
Feature/update client route logic

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -1,4 +1,10 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import {
+  BrowserRouter,
+  Navigate,
+  Routes,
+  Route,
+  useLocation,
+} from "react-router-dom";
 import "uswds/css/uswds.css";
 import "uswds/js/uswds.js";
 // ---
@@ -9,15 +15,32 @@ import Forms from "routes/forms";
 import Form from "routes/form";
 import NotFound from "routes/notFound";
 
-export default function App() {
+function ProtectedRoutes({ children }: { children: JSX.Element }) {
+  const { pathname } = useLocation();
   const { isAuthenticated } = useUserState();
 
-  if (!isAuthenticated) return <Login />;
+  if (!isAuthenticated) {
+    return (
+      <Navigate to="/login" state={{ redirectedFrom: pathname }} replace />
+    );
+  }
 
+  return children;
+}
+
+export default function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Dashboard />}>
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/"
+          element={
+            <ProtectedRoutes>
+              <Dashboard />
+            </ProtectedRoutes>
+          }
+        >
           <Route index element={<Forms />} />
           <Route path="rebate/:id" element={<Form />} />
           <Route path="*" element={<NotFound />} />

--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -1,10 +1,11 @@
-import { Link, Outlet } from "react-router-dom";
+import { Link, Outlet, useNavigate } from "react-router-dom";
 import icons from "uswds/img/sprite.svg";
 // ---
 import { useApiState, fetchData } from "contexts/api";
 import { useUserState, useUserDispatch } from "contexts/user";
 
 export default function Dashboard() {
+  const navigate = useNavigate();
   const { apiUrl } = useApiState();
   const { epaUserData } = useUserState();
   const dispatch = useUserDispatch();
@@ -43,6 +44,7 @@ export default function Dashboard() {
               fetchData(`${apiUrl}/api/v1/logout`)
                 .then((logoutRes) => {
                   dispatch({ type: "USER_SIGN_OUT" });
+                  navigate("/");
                 })
                 .catch((logoutErr) => {
                   console.error("Error logging user out");

--- a/app/client/src/components/login.tsx
+++ b/app/client/src/components/login.tsx
@@ -1,11 +1,21 @@
+import { useLocation, useNavigate } from "react-router-dom";
 import icons from "uswds/img/sprite.svg";
 // ---
 import { useApiState, fetchData } from "contexts/api";
 import { useUserDispatch } from "contexts/user";
 
+type LocationState = {
+  redirectedFrom: string;
+};
+
 export default function Login() {
+  const location = useLocation();
+  const navigate = useNavigate();
   const { apiUrl } = useApiState();
   const dispatch = useUserDispatch();
+
+  // page user was previously on before they were redirected to "/login"
+  const destination = (location.state as LocationState).redirectedFrom || "/";
 
   return (
     <div className="margin-top-2 bg-base-lightest">
@@ -32,6 +42,11 @@ export default function Login() {
                     });
 
                     dispatch({ type: "USER_SIGN_IN" });
+
+                    // NOTE: { replace: true } passed so an entry for "/login"
+                    // isn't added to the history stack, so the user can click
+                    // the back button and not go back to this login page
+                    navigate(destination, { replace: true });
                   })
                   .catch((bapErr) => {
                     console.error("Error fetching SAM user data");


### PR DESCRIPTION
Updates client app's routes to begin protecting routes (still weakly, as it's relying only on a state variable set in a React Context component – will need to more tightly integrate/authenticate from the server app).

This PR isn't dependent on #9 but should probably get merged in after that one, as #9 fixes the error caused by the missing environment variable in production that sets the `apiUrl` in the client app.