### PR TITLE
Feature/revert public url env change

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build front-end files and move to server
         run: |
-          PUBLIC_URL="$SERVER_URL" REACT_APP_SERVER_BASE_PATH="$SERVER_BASE_PATH" npm run build
+          REACT_APP_SERVER_BASE_PATH="$SERVER_BASE_PATH" npm run build
           rm ../server/app/public/index.html
           cd build
           mv * ../../server/app/public


### PR DESCRIPTION
Setting `PUBLIC_URL` before the client app's build caused a redirect loop with basic auth, so reverting that change until basic auth can be removed and a banner displayed at the top of the page indicating it's still in development.