### PR TITLE
Feature/explicitly set node env in cf manifests

### DIFF
--- a/app/manifest-dev.yml
+++ b/app/manifest-dev.yml
@@ -12,5 +12,6 @@ applications:
     command: node app/index.js
     env:
       CLOUD_SPACE: development
+      NODE_ENV: production
       LOGGER_LEVEL: DEBUG
       OPTIMIZE_MEMORY: true

--- a/app/manifest-production.yml
+++ b/app/manifest-production.yml
@@ -14,5 +14,6 @@ applications:
     path: /
     env:
       CLOUD_SPACE: production
+      NODE_ENV: production
       LOGGER_LEVEL: INFO
       OPTIMIZE_MEMORY: true

--- a/app/manifest-staging.yml
+++ b/app/manifest-staging.yml
@@ -13,5 +13,6 @@ applications:
     path: /
     env:
       CLOUD_SPACE: staging
+      NODE_ENV: production
       LOGGER_LEVEL: INFO
       OPTIMIZE_MEMORY: true


### PR DESCRIPTION
Explicitly set NODE_ENV to production in CF manifest files for all Cloud.gov spaces