### PR TITLE
Feature/begin to use formio submission data

### DIFF
--- a/app/client/src/contexts/user.tsx
+++ b/app/client/src/contexts/user.tsx
@@ -10,10 +10,11 @@ type Props = {
   children: ReactNode;
 };
 
-type EPAUserData = {
+export type EPAUserData = {
   givenname: string;
   mail: string;
   memberof: string;
+  uid: string;
 };
 
 export type SAMUserData = {

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -74,8 +74,10 @@ router.get("/rebate-form-submissions", ensureAuthenticated, (req, res) => {
     .get(`${formioProjectUrl}/${formioFormId}/submission`, formioHeaders)
     .then((axiosRes) => axiosRes.data)
     .then((submissions) => {
-      return submissions.map((sub) => {
-        const { _id, _fid, form, project, created, modified, data } = sub;
+      return submissions.map((submission) => {
+        const { _id, _fid, form, project, state, created, modified, data } =
+          submission;
+
         return {
           // --- metadata fields ---
           _id,
@@ -84,14 +86,14 @@ router.get("/rebate-form-submissions", ensureAuthenticated, (req, res) => {
           project,
           created,
           // --- form fields ---
-          formType: "rebate-application", // predefined form types: "rebate-application" | "payment-request" | "close-out" ?
-          uei: "############", // 12 digits?
-          eft: "#########", // 9 digits?
-          ueiEntityName: "(Some Business Name Here)",
-          schoolDistrictName: "(School District Name Here)",
-          lastUpdatedBy: data.name,
+          formType: "rebate-application", // TODO: hard-coded for now. where does this come from?
+          uei: data.applicantUEI,
+          eft: "#########", // TODO: this needs to be in the form
+          ueiEntityName: data.applicantOrganizationName,
+          schoolDistrictName: data.ncesName,
+          lastUpdatedBy: data.sam_hidden_name,
           lastUpdatedDate: modified,
-          status: "draft", // predefined set of states: "submitted" | "draft" ?
+          status: state, // TODO: get full list of predefined set of states: "submitted" | "draft" ?
         };
       });
     })


### PR DESCRIPTION
Updates user's dashboard table to display submission data from form fields (at least the ones we currently have), and updates the "new rebate form" to populate SAM.gov fields (from the user's selection from the modal) and adds their email address to a hidden field, which will be used in the "Updated by" column of the dashboard table, once form is submitted.