### PR TITLE
Feature/rename rebate forms in table

### DIFF
--- a/app/client/src/contexts/forms.tsx
+++ b/app/client/src/contexts/forms.tsx
@@ -24,8 +24,7 @@ type RebateFormSubmission = {
   created: string; // datetime string created
   modified: string; // datetime string modified
   // --- form fields ---
-
-  formType: "rebate-application" | "payment-request" | "close-out";
+  formType: "Rebate" | "Payment Request" | "Close-Out";
   uei: string;
   eft: string;
   ueiEntityName: string;

--- a/app/client/src/routes/allRebateForms.tsx
+++ b/app/client/src/routes/allRebateForms.tsx
@@ -126,15 +126,7 @@ export default function AllRebateForms() {
                     </span>
                   </Link>
                 </th>
-                <th>
-                  {formType === "rebate-application"
-                    ? "Rebate Application"
-                    : formType === "payment-request"
-                    ? "Payment Request"
-                    : formType === "close-out"
-                    ? "Close-Out"
-                    : ""}
-                </th>
+                <th>{formType}</th>
                 <th>{uei}</th>
                 <td>{eft}</td>
                 <td>{ueiEntityName}</td>

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -139,14 +139,14 @@ router.get("/rebate-form-submissions", ensureAuthenticated, (req, res) => {
           project,
           created,
           // --- form fields ---
-          formType: "rebate-application", // TODO: hard-coded for now. where does this come from?
+          formType: "Rebate",
           uei: data.applicantUEI,
-          eft: "#########", // TODO: this needs to be in the form
+          eft: "####", // TODO: this needs to be in the form
           ueiEntityName: data.applicantOrganizationName,
           schoolDistrictName: data.ncesName,
           lastUpdatedBy: data.sam_hidden_name,
           lastUpdatedDate: modified,
-          status: state, // TODO: get full list of predefined set of states: "submitted" | "draft" ?
+          status: state,
         };
       });
     })


### PR DESCRIPTION
Update API to return `formtype` as it'll be displayed in the table in the AllRebateForms component