### PR TITLE
Feature/support external links in static markdown

### DIFF
--- a/app/client/src/components/markdownContent.tsx
+++ b/app/client/src/components/markdownContent.tsx
@@ -1,0 +1,56 @@
+import ReactMarkdown, { Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+type Props = {
+  className?: string;
+  children: string;
+  components?: Components;
+};
+
+// NOTE: This is just a wrapper around the <ReactMarkdown /> component to
+// automatically use the GitHub Flavored Markdown (GFM) remark plugin to support
+// GFM in the static content files, and set some default attributes for
+// rendering anchor links consistently (and support allowing markdown authors
+// to determine if an anchor link should open in a new tab – see note below).
+// Any additional elements beyond anchor links can be passed when to explicitly
+// set how those components should be rendered.
+export default function MarkdownContent({
+  className,
+  children,
+  components,
+}: Props) {
+  return (
+    <ReactMarkdown
+      className={className || ""}
+      children={children}
+      remarkPlugins={[remarkGfm]}
+      components={{
+        ...components,
+        a: ({ node, ...props }) => {
+          // NOTE: The only attribute GFM allows you to set on hyperlinks is
+          // title attributes, so authors of the markdown content will need to
+          // set the title attribute to "external" for any links that should
+          // open in a new tab. For example:
+          // [contact EPA](https://www.epa.gov/aboutepa/forms/contact-epa "external")
+          //
+          // If a different title attribute is set in the markdown (unlikely)
+          // the code below will use the title set in the markdown as the
+          // rendered anchor link's title attribute.
+          const title = node?.properties?.title;
+          const externalLink = title === "external";
+          return (
+            <a
+              {...props}
+              className="usa-link"
+              title={title ? (externalLink ? "" : title.toString()) : ""}
+              target={externalLink ? "_blank" : ""}
+              rel={externalLink ? "noopener noreferrer" : ""}
+            >
+              {props.children}
+            </a>
+          );
+        },
+      }}
+    />
+  );
+}

--- a/app/client/src/routes/allRebateForms.tsx
+++ b/app/client/src/routes/allRebateForms.tsx
@@ -1,12 +1,11 @@
 import { useEffect } from "react";
 import { Link } from "react-router-dom";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import icons from "uswds/img/sprite.svg";
 // ---
 import { serverUrl, fetchData } from "../config";
 import Loading from "components/loading";
 import Message from "components/message";
+import MarkdownContent from "components/markdownContent";
 import { TextWithTooltip } from "components/infoTooltip";
 import { useContentState } from "contexts/content";
 import { useFormsState, useFormsDispatch } from "contexts/forms";
@@ -48,10 +47,9 @@ export default function AllRebateForms() {
   return (
     <>
       {content.status === "success" && (
-        <ReactMarkdown
+        <MarkdownContent
           className="margin-top-4"
           children={content.data.allRebateFormsIntro}
-          remarkPlugins={[remarkGfm]}
         />
       )}
 
@@ -144,10 +142,7 @@ export default function AllRebateForms() {
 
       {content.status === "success" && (
         <div className="margin-top-4 padding-2 border-1px border-base-lighter bg-base-lightest">
-          <ReactMarkdown
-            children={content.data.allRebateFormsOutro}
-            remarkPlugins={[remarkGfm]}
-          />
+          <MarkdownContent children={content.data.allRebateFormsOutro} />
         </div>
       )}
     </>

--- a/app/client/src/routes/existingRebateForm.tsx
+++ b/app/client/src/routes/existingRebateForm.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { Form } from "@formio/react";
 // ---
 import { serverUrl, fetchData } from "../config";
 import Loading from "components/loading";
 import Message from "components/message";
+import MarkdownContent from "components/markdownContent";
 import { useContentState } from "contexts/content";
 
 type SubmissionsState =
@@ -45,12 +44,12 @@ export default function ExistingRebateForm() {
 
   const [rebateFormSubmission, setRebateFormSubmission] =
     useState<SubmissionsState>({
-    status: "idle",
-    data: {
+      status: "idle",
+      data: {
         formSchema: null,
-      submissionData: null,
-    },
-  });
+        submissionData: null,
+      },
+    });
 
   useEffect(() => {
     setRebateFormSubmission({
@@ -96,7 +95,7 @@ export default function ExistingRebateForm() {
   return (
     <div className="margin-top-2">
       {content.status === "success" && (
-        <ReactMarkdown
+        <MarkdownContent
           className="margin-top-4"
           children={
             submissionData.state === "draft"
@@ -105,7 +104,6 @@ export default function ExistingRebateForm() {
               ? content.data.existingSubmittedRebateFormIntro
               : ""
           }
-          remarkPlugins={[remarkGfm]}
         />
       )}
 

--- a/app/client/src/routes/newRebateForm.tsx
+++ b/app/client/src/routes/newRebateForm.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { DialogOverlay, DialogContent } from "@reach/dialog";
 import { Form } from "@formio/react";
 import icons from "uswds/img/sprite.svg";
@@ -9,6 +7,7 @@ import icons from "uswds/img/sprite.svg";
 import { serverUrl, fetchData } from "../config";
 import Loading from "components/loading";
 import Message from "components/message";
+import MarkdownContent from "components/markdownContent";
 import { TextWithTooltip } from "components/infoTooltip";
 import { useContentState } from "contexts/content";
 import { EPAUserData, SAMUserData, useUserState } from "contexts/user";
@@ -75,10 +74,9 @@ function FormioForm({ samData, epaData }: FormioFormProps) {
   return (
     <>
       {content.status === "success" && (
-        <ReactMarkdown
+        <MarkdownContent
           className="margin-top-4"
           children={content.data.newRebateFormIntro}
-          remarkPlugins={[remarkGfm]}
         />
       )}
 
@@ -143,10 +141,9 @@ export default function NewRebateForm() {
           <div className="usa-modal__content">
             <div className="usa-modal__main">
               {content.status === "success" && (
-                <ReactMarkdown
+                <MarkdownContent
                   className="margin-top-4"
                   children={content.data.newRebateFormDialog}
-                  remarkPlugins={[remarkGfm]}
                   components={{
                     h2: (props) => (
                       <h2

--- a/app/server/app/content/existing-submitted-rebate-form-intro.md
+++ b/app/server/app/content/existing-submitted-rebate-form-intro.md
@@ -1,3 +1,3 @@
 ## View Your Rebate Application
 
-Your submission is under review and not editable at this time. If you wish to change your submission, [contact the helpdesk](https://www.epa.gov/cleanschoolbus/forms/contact-us-about-clean-school-bus-program-funding).
+Your submission is under review and not editable at this time. If you wish to change your submission, [contact the helpdesk](https://www.epa.gov/cleanschoolbus/forms/contact-us-about-clean-school-bus-program-funding "external").


### PR DESCRIPTION
Markdown content authors should add the "external" title attribute to hyperlinks if they want them to open in a new tab. For example:

```md
[contact EPA](https://www.epa.gov/aboutepa/forms/contact-epa "external")
```