### PR TITLE
Bugfix/handle on next for draft only

### DIFF
--- a/app/client/src/routes/existingRebateForm.tsx
+++ b/app/client/src/routes/existingRebateForm.tsx
@@ -207,6 +207,8 @@ export default function ExistingRebateForm() {
             });
         }}
         onNextPage={({ page, submission }: FormioOnNextParams) => {
+          if (submissionData.state !== "draft") return;
+
           const id = submissionData._id;
 
           fetchData(`${serverUrl}/api/v1/rebate-form-submission/${id}`, {


### PR DESCRIPTION
Update ExistingRebateForm's onNextPage event to only submit if the form is still in draft state