### PR TITLE
Feature/override ncesdatasource in formio submission

### DIFF
--- a/app/client/src/routes/existingRebateForm.tsx
+++ b/app/client/src/routes/existingRebateForm.tsx
@@ -183,7 +183,10 @@ export default function ExistingRebateForm() {
           setSavedSubmission(submission);
           fetchData(
             `${serverUrl}/api/rebate-form-submission/${submissionData._id}`,
-            submission
+            {
+              ...submission,
+              data: { ...submission.data, ncesDataSource: "" },
+            }
           )
             .then((res) => {
               if (submission.state === "submitted") {
@@ -206,7 +209,11 @@ export default function ExistingRebateForm() {
           setSavedSubmission(submission);
           fetchData(
             `${serverUrl}/api/rebate-form-submission/${submissionData._id}`,
-            { ...submission, state: "draft" }
+            {
+              ...submission,
+              data: { ...submission.data, ncesDataSource: "" },
+              state: "draft",
+            }
           )
             .then((res) => {
               displaySuccessMessage("Draft succesfully saved.");

--- a/app/client/src/routes/newRebateForm.tsx
+++ b/app/client/src/routes/newRebateForm.tsx
@@ -174,7 +174,10 @@ function FormioForm({ samData, epaData }: FormioFormProps) {
         }}
         onSubmit={(submission: FormioSubmission) => {
           setSavedSubmission(submission);
-          fetchData(`${serverUrl}/api/rebate-form-submission/`, submission)
+          fetchData(`${serverUrl}/api/rebate-form-submission/`, {
+            ...submission,
+            data: { ...submission.data, ncesDataSource: "" },
+          })
             .then((res) => {
               if (submission.state === "submitted") {
                 displaySuccessMessage("Form succesfully submitted.");
@@ -199,6 +202,7 @@ function FormioForm({ samData, epaData }: FormioFormProps) {
           setSavedSubmission(submission);
           fetchData(`${serverUrl}/api/rebate-form-submission/`, {
             ...submission,
+            data: { ...submission.data, ncesDataSource: "" },
             state: "draft",
           })
             .then((res) => {


### PR DESCRIPTION
Override `NewRebateForm` and `ExistingRebateForm`'s `ncesDataSource` to be an empty string on form submission.

The Form.io rebate form configuration still tries to send the full `ncesDataSource` data (~13MB string) on form submission with is too large for the Form.io server to accept. As a workaround we're overriding that field to be an empty string on submission and marking it as a backlog item to follow up with GSA to see if they can configure anything on their end to prevent us having to do this. This works fine as a workaround, but if they ever change the API field name from `ncesDataSource` to something else, we'd need to update our code to make that same change.