### PR TITLE
Feature/disable formio builtin alerts on submit

### DIFF
--- a/app/client/src/routes/existingRebateForm.tsx
+++ b/app/client/src/routes/existingRebateForm.tsx
@@ -178,6 +178,7 @@ export default function ExistingRebateForm() {
         }}
         options={{
           readOnly: submissionData.state === "submitted" ? true : false,
+          noAlerts: true,
         }}
         onSubmit={(submission: FormioSubmission) => {
           setSavedSubmission(submission);

--- a/app/client/src/routes/newRebateForm.tsx
+++ b/app/client/src/routes/newRebateForm.tsx
@@ -172,6 +172,7 @@ function FormioForm({ samData, epaData }: FormioFormProps) {
             ...savedSubmission.data,
           },
         }}
+        options={{ noAlerts: true }}
         onSubmit={(submission: FormioSubmission) => {
           setSavedSubmission(submission);
           fetchData(`${serverUrl}/api/rebate-form-submission/`, {


### PR DESCRIPTION
Update Formio Form options to disable form's automatic alert message displayed upon submission attempt, as we're handling that in the wrapper app