### PR TITLE
Feature/log helpdesk access for api calls only

### DIFF
--- a/app/server/app/middleware.js
+++ b/app/server/app/middleware.js
@@ -58,12 +58,17 @@ const ensureAuthenticated = (
  */
 const ensureHelpdesk = (req, res, next) => {
   const userRoles = req.user.memberof ? req.user.memberof.split(",") : [];
+
   if (!userRoles.includes("csb_admin") && !userRoles.includes("csb_helpdesk")) {
-    log.error(
-      `User with email ${req.user.mail} attempted to perform an admin/helpdesk action without correct privileges.`
-    );
+    if (!req.originalUrl.includes("/helpdesk-access")) {
+      log.error(
+        `User with email ${req.user.mail} attempted to perform an admin/helpdesk action without correct privileges.`
+      );
+    }
+
     return res.status(401).json({ message: "Unauthorized" });
   }
+
   next();
 };
 


### PR DESCRIPTION
Update `ensureHelpdesk` middleware to only be called when a 'help' API route is called (no need to log the 'helpdesk-access' API route)