### PR TITLE
Feature/update helpdesk table rendering

### DIFF
--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -174,7 +174,7 @@ export default function Dashboard() {
         <nav className="desktop:order-last mobile-lg:display-flex flex-align-center flex-justify-end">
           <p className="margin-bottom-1 margin-right-1">
             <span>
-              {epaUserData.status === "success" && epaUserData.data.mail}
+              {epaUserData.status === "success" && epaUserData.data?.mail}
             </span>
           </p>
 

--- a/app/client/src/routes/allRebateForms.tsx
+++ b/app/client/src/routes/allRebateForms.tsx
@@ -61,7 +61,7 @@ export default function AllRebateForms() {
           {content.status === "success" && (
             <MarkdownContent
               className="margin-top-4"
-              children={content.data.allRebateFormsIntro}
+              children={content.data?.allRebateFormsIntro || ""}
             />
           )}
 
@@ -184,7 +184,7 @@ export default function AllRebateForms() {
 
       {content.status === "success" && (
         <div className="margin-top-4 padding-2 padding-bottom-0 border-1px border-base-lighter bg-base-lightest">
-          <MarkdownContent children={content.data.allRebateFormsOutro} />
+          <MarkdownContent children={content.data?.allRebateFormsOutro || ""} />
         </div>
       )}
     </>

--- a/app/client/src/routes/existingRebateForm.tsx
+++ b/app/client/src/routes/existingRebateForm.tsx
@@ -162,9 +162,9 @@ export default function ExistingRebateForm() {
           className="margin-top-4"
           children={
             submissionData.state === "draft"
-              ? content.data.existingDraftRebateFormIntro
+              ? content.data?.existingDraftRebateFormIntro || ""
               : submissionData.state === "submitted"
-              ? content.data.existingSubmittedRebateFormIntro
+              ? content.data?.existingSubmittedRebateFormIntro || ""
               : ""
           }
         />

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -77,7 +77,7 @@ export default function Helpdesk() {
       {content.status === "success" && (
         <MarkdownContent
           className="margin-top-4"
-          children={content.data.helpdeskIntro}
+          children={content.data?.helpdeskIntro || ""}
         />
       )}
 

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -139,7 +139,20 @@ export default function Helpdesk() {
         />
       )}
 
-      {rebateFormSubmission.status === "success" && (
+      {/*
+        NOTE: when the rebate form submission data is succesfully fetched, the
+        response should contain the submission data, but since it's coming from
+        an external server, we should check that it exists first before using it
+      */}
+      {rebateFormSubmission.status === "success" &&
+        !rebateFormSubmission.data && (
+          <Message
+            type="error"
+            text="Error loading rebate form submission. Please confirm the form ID is correct and search again."
+          />
+        )}
+
+      {rebateFormSubmission.status === "success" && rebateFormSubmission.data && (
         <div className="usa-table-container--scrollable" tabIndex={0}>
           <table className="usa-table usa-table--stacked usa-table--borderless usa-table--striped width-full">
             <thead>

--- a/app/client/src/routes/newRebateForm.tsx
+++ b/app/client/src/routes/newRebateForm.tsx
@@ -149,7 +149,7 @@ function FormioForm({ samData, epaData }: FormioFormProps) {
       {content.status === "success" && (
         <MarkdownContent
           className="margin-top-4"
-          children={content.data.newRebateFormIntro}
+          children={content.data?.newRebateFormIntro || ""}
         />
       )}
 
@@ -257,8 +257,8 @@ export default function NewRebateForm() {
 
   const activeSamData =
     samUserData.status === "success" &&
-    samUserData.data.results &&
-    samUserData.data.records.filter((entity) => {
+    samUserData.data?.results &&
+    samUserData.data?.records.filter((entity) => {
       return entity.ENTITY_STATUS__c === "Active";
     });
 
@@ -281,7 +281,7 @@ export default function NewRebateForm() {
               {content.status === "success" && (
                 <MarkdownContent
                   className="margin-top-4"
-                  children={content.data.newRebateFormDialog}
+                  children={content.data?.newRebateFormDialog || ""}
                   components={{
                     h2: (props) => (
                       <h2


### PR DESCRIPTION
Primarily fixes an issue with the GSA submission server returning a 200 response but no actual submission data (data fetched and used in the `<Helpdesk />` route component), but also updates all other situations where we're assuming the shape of fetched data is what we've defined it to be in the app's Typescript types. This is probably overkill with the other fetches, as we're in control of what data is returned to the client in the server app's route controllers, but still probably smart to do to play it safe.