### PR TITLE
Feature/remove client app redirect logic

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -266,9 +266,7 @@ function ProtectedRoute({ children }: { children: JSX.Element }) {
   }
 
   if (!isAuthenticated) {
-    return (
-      <Navigate to="/welcome" state={{ redirectedFrom: pathname }} replace />
-    );
+    return <Navigate to="/welcome" replace />;
   }
 
   return (

--- a/app/client/src/components/welcome.tsx
+++ b/app/client/src/components/welcome.tsx
@@ -1,16 +1,11 @@
 import { useEffect } from "react";
-import { useLocation, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import icons from "uswds/img/sprite.svg";
 // ---
 import { serverUrl } from "../config";
 import Message, { useMessageState } from "components/message";
 
-type LocationState = {
-  redirectedFrom: string;
-};
-
 export default function Welcome() {
-  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const {
@@ -67,14 +62,6 @@ export default function Welcome() {
     displaySuccessMessage,
     displayErrorMessage,
   ]);
-
-  // page user was previously on before they were redirected to "/welcome"
-  const destination = (location.state as LocationState)?.redirectedFrom || "/";
-
-  // TODO: append the destination url to the login link's href as a query string
-  // param, so it could be used in the server app's /login controller
-  // (change the `successRedirect` value of '/' to the destination url)
-  console.log("previous url", destination);
 
   return (
     <>


### PR DESCRIPTION
Remove react-router navigate state from client app, as server app is setup to handle redirecting an unauthenticated user to the page they attempted to navigate to after they've been logged in