### PR TITLE
Feature/simplify all rebate form data shape

### DIFF
--- a/app/client/src/contexts/forms.tsx
+++ b/app/client/src/contexts/forms.tsx
@@ -16,22 +16,20 @@ type Props = {
  * retreive the form's JSON schema in order to display and edit the form.
  */
 type RebateFormSubmission = {
-  // --- metadata fields ---
-  _id: string; // unique ID of form submission
-  _fvid: number; // version number of form
-  form: string; // unique ID of form
-  project: string; // unique ID of project
-  created: string; // datetime string created
-  modified: string; // datetime string modified
-  // --- form fields ---
-  formType: "Application" | "Payment Request" | "Close-Out";
-  uei: string;
-  eft: string;
-  applicant: string;
-  schoolDistrict: string;
-  lastUpdatedBy: string;
-  lastUpdatedDatetime: string;
-  status: "submitted" | "draft";
+  // NOTE: more fields are in a form.io submission,
+  // but we're only concerned with the fields below
+  _id: string;
+  state: "submitted" | "draft";
+  modified: string;
+  data: {
+    applicantUEI: string;
+    applicantEfti: string;
+    applicantOrganizationName: string;
+    schoolDistrictName: string;
+    last_updated_by: string;
+    // (other fields...)
+  };
+  // (other fields...)
 };
 
 type State = {

--- a/app/client/src/routes/allRebateForms.tsx
+++ b/app/client/src/routes/allRebateForms.tsx
@@ -124,23 +124,20 @@ export default function AllRebateForms() {
               </thead>
               <tbody>
                 {rebateFormSubmissions.data.map((submission) => {
+                  const { _id, state, modified, data } = submission;
                   const {
-                    _id,
-                    formType,
-                    uei,
-                    eft,
-                    applicant,
-                    schoolDistrict,
-                    lastUpdatedBy,
-                    lastUpdatedDatetime,
-                    status,
-                  } = submission;
+                    applicantUEI,
+                    applicantEfti,
+                    applicantOrganizationName,
+                    schoolDistrictName,
+                    last_updated_by,
+                  } = data;
 
                   return (
                     <tr
                       key={_id}
                       className={
-                        status === "submitted"
+                        state === "submitted"
                           ? "text-italic text-base-dark"
                           : ""
                       }
@@ -166,16 +163,14 @@ export default function AllRebateForms() {
                           </span>
                         </Link>
                       </th>
-                      <td>{formType}</td>
-                      <td>{uei}</td>
-                      <td>{eft}</td>
-                      <td>{applicant}</td>
-                      <td>{schoolDistrict}</td>
-                      <td>{lastUpdatedBy}</td>
-                      <td>
-                        {new Date(lastUpdatedDatetime).toLocaleDateString()}
-                      </td>
-                      <td>{status}</td>
+                      <td>Application</td>
+                      <td>{applicantUEI}</td>
+                      <td>{applicantEfti}</td>
+                      <td>{applicantOrganizationName}</td>
+                      <td>{schoolDistrictName}</td>
+                      <td>{last_updated_by}</td>
+                      <td>{new Date(modified).toLocaleDateString()}</td>
+                      <td>{state}</td>
                     </tr>
                   );
                 })}

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -289,28 +289,6 @@ router.get("/rebate-form-submissions", checkBapComboKeys, (req, res) => {
   axios
     .get(formioUserSubmissionsUrl, formioHeaders)
     .then((axiosRes) => axiosRes.data)
-    .then((submissions) => {
-      return submissions.map((submission) => {
-        const { _id, _fid, form, project, state, created, modified, data } =
-          submission;
-
-        return {
-          _id,
-          _fid,
-          form,
-          project,
-          created,
-          formType: "Application",
-          uei: data.applicantUEI,
-          eft: data.applicantEfti,
-          applicant: data.applicantOrganizationName,
-          schoolDistrict: data.schoolDistrictName,
-          lastUpdatedBy: data.last_updated_by,
-          lastUpdatedDatetime: modified,
-          status: state,
-        };
-      });
-    })
     .then((submissions) => res.json(submissions))
     .catch((error) => {
       if (typeof error.toJSON === "function") {


### PR DESCRIPTION
Update `/rebate-form-submissions` API to return submission data in the exact shape returned from Forms.gov, and update client app to use those exact field names (no need to rename fields for client app)