### PR TITLE
Feature/update disclaimer dialog

### DIFF
--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -167,9 +167,11 @@ export default function Dashboard() {
               href="/"
               className="margin-bottom-1 usa-button font-sans-2xs"
               onClick={(ev) => {
-                ev.preventDefault();
-                const action = createDialogNavAction("/");
-                dispatch(action);
+                if (pathname.startsWith("/rebate")) {
+                  ev.preventDefault();
+                  const action = createDialogNavAction("/");
+                  dispatch(action);
+                }
               }}
             >
               <IconText
@@ -215,12 +217,14 @@ export default function Dashboard() {
                 </button>
               ) : (
                 <a
-                  href="/"
+                  href="/helpdesk"
                   className="margin-bottom-1 usa-button font-sans-2xs"
                   onClick={(ev) => {
-                    ev.preventDefault();
-                    const action = createDialogNavAction("/helpdesk");
-                    dispatch(action);
+                    if (pathname.startsWith("/rebate")) {
+                      ev.preventDefault();
+                      const action = createDialogNavAction("/helpdesk");
+                      dispatch(action);
+                    }
                   }}
                 >
                   <IconText order="icon-text" icon="people" text="Helpdesk" />


### PR DESCRIPTION
Update disclaimer dialog to only show when user is on a rebate form (e.g. no need to show when on the all rebate forms or helpdesk pages)