### PR TITLE
Feature/inject current user fields

### DIFF
--- a/app/client/src/components/errorBoundary.tsx
+++ b/app/client/src/components/errorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from "react";
 // ---
+import { messages } from "../config";
 import Message from "components/message";
 
 type Props = {
@@ -28,7 +29,7 @@ export default class ErrorBoundary extends Component<Props, State> {
     const { hasError } = this.state;
 
     if (hasError) {
-      return <Message type="error" text="Something went wrong." />;
+      return <Message type="error" text={messages.genericError} />;
     }
 
     return children;

--- a/app/client/src/components/welcome.tsx
+++ b/app/client/src/components/welcome.tsx
@@ -23,7 +23,7 @@ export default function Welcome() {
       setMessage({
         displayed: true,
         type: "error",
-        text: messages.auth,
+        text: messages.authError,
       });
     }
 
@@ -31,7 +31,7 @@ export default function Welcome() {
       setMessage({
         displayed: true,
         type: "error",
-        text: messages.saml,
+        text: messages.samlError,
       });
     }
 
@@ -39,7 +39,7 @@ export default function Welcome() {
       setMessage({
         displayed: true,
         type: "error",
-        text: messages.samFetch,
+        text: messages.samFetchError,
       });
     }
 
@@ -47,7 +47,7 @@ export default function Welcome() {
       setMessage({
         displayed: true,
         type: "info",
-        text: messages.samResults,
+        text: messages.samNoResults,
       });
     }
 

--- a/app/client/src/components/welcome.tsx
+++ b/app/client/src/components/welcome.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import icons from "uswds/img/sprite.svg";
 // ---
-import { serverUrl } from "../config";
+import { serverUrl, messages } from "../config";
 import Message from "components/message";
 
 export default function Welcome() {
@@ -23,7 +23,7 @@ export default function Welcome() {
       setMessage({
         displayed: true,
         type: "error",
-        text: "Authentication error. Please log in again or contact support.",
+        text: messages.auth,
       });
     }
 
@@ -31,7 +31,7 @@ export default function Welcome() {
       setMessage({
         displayed: true,
         type: "error",
-        text: "Error logging in. Please try again or contact support.",
+        text: messages.saml,
       });
     }
 
@@ -39,7 +39,7 @@ export default function Welcome() {
       setMessage({
         displayed: true,
         type: "error",
-        text: "Error retrieving SAM.gov data. Please contact support.",
+        text: messages.samFetch,
       });
     }
 
@@ -47,7 +47,7 @@ export default function Welcome() {
       setMessage({
         displayed: true,
         type: "info",
-        text: "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
+        text: messages.samResults,
       });
     }
 
@@ -55,7 +55,7 @@ export default function Welcome() {
       setMessage({
         displayed: true,
         type: "info",
-        text: "For security reasons, you have been logged out due to 15 minutes of inactivity.",
+        text: messages.timeout,
       });
     }
 
@@ -63,7 +63,7 @@ export default function Welcome() {
       setMessage({
         displayed: true,
         type: "success",
-        text: "You have successfully logged out.",
+        text: messages.logout,
       });
     }
 

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -33,6 +33,17 @@ export const formioBaseUrl = REACT_APP_FORMIO_BASE_URL;
 
 export const formioProjectUrl = REACT_APP_FORMIO_PROJECT_URL;
 
+export const messages = {
+  auth: "Authentication error. Please log in again or contact support.",
+  saml: "Error logging in. Please try again or contact support.",
+  samFetch: "Error retrieving SAM.gov data. Please contact support.",
+  samResults:
+    "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
+  timeout:
+    "For security reasons, you have been logged out due to 15 minutes of inactivity.",
+  logout: "You have successfully logged out.",
+};
+
 /**
  * Returns a promise containing JSON fetched from a provided web service URL
  * or handles any other OK response returned from the server

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -34,11 +34,17 @@ export const formioBaseUrl = REACT_APP_FORMIO_BASE_URL;
 export const formioProjectUrl = REACT_APP_FORMIO_PROJECT_URL;
 
 export const messages = {
-  auth: "Authentication error. Please log in again or contact support.",
-  saml: "Error logging in. Please try again or contact support.",
-  samFetch: "Error retrieving SAM.gov data. Please contact support.",
-  samResults:
+  genericError: "Something went wrong.",
+  authError: "Authentication error. Please log in again or contact support.",
+  samlError: "Error logging in. Please try again or contact support.",
+  samFetchError: "Error retrieving SAM.gov data. Please contact support.",
+  samNoResults:
     "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
+  rebateSubmissionsError: "Error loading rebate form submissions.",
+  newRebateApplication:
+    "Please select the “New Application” button above to create your first rebate application.",
+  helpdeskRebateFormError:
+    "Error loading rebate form submission. Please confirm the form ID is correct and search again.",
   timeout:
     "For security reasons, you have been logged out due to 15 minutes of inactivity.",
   logout: "You have successfully logged out.",

--- a/app/client/src/contexts/user.tsx
+++ b/app/client/src/contexts/user.tsx
@@ -10,13 +10,13 @@ type Props = {
   children: ReactNode;
 };
 
-export type EPAUserData = {
+type EpaUserData = {
   mail: string;
   memberof: string;
   exp: number;
 };
 
-export type SAMUserData = {
+export type SamEntityData = {
   ENTITY_COMBO_KEY__c: string;
   UNIQUE_ENTITY_ID__c: string;
   ENTITY_EFT_INDICATOR__c: string;
@@ -55,7 +55,7 @@ type State = {
   epaUserData:
     | { status: "idle"; data: {} }
     | { status: "pending"; data: {} }
-    | { status: "success"; data: EPAUserData }
+    | { status: "success"; data: EpaUserData }
     | { status: "failure"; data: {} };
   samUserData:
     | { status: "idle"; data: {} }
@@ -63,7 +63,7 @@ type State = {
     | {
         status: "success";
         data:
-          | { results: true; records: SAMUserData[] }
+          | { results: true; records: SamEntityData[] }
           | { results: false; records: [] };
       }
     | { status: "failure"; data: {} };
@@ -76,7 +76,7 @@ type Action =
   | {
       type: "FETCH_EPA_USER_DATA_SUCCESS";
       payload: {
-        epaUserData: EPAUserData;
+        epaUserData: EpaUserData;
       };
     }
   | { type: "FETCH_EPA_USER_DATA_FAILURE" }
@@ -85,7 +85,7 @@ type Action =
       type: "FETCH_SAM_USER_DATA_SUCCESS";
       payload: {
         samUserData:
-          | { results: true; records: SAMUserData[] }
+          | { results: true; records: SamEntityData[] }
           | { results: false; records: [] };
       };
     }

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import icons from "uswds/img/sprite.svg";
 // ---
-import { serverUrl, fetchData } from "../config";
+import { serverUrl, fetchData, messages } from "../config";
 import Loading from "components/loading";
 import Message from "components/message";
 import MarkdownContent from "components/markdownContent";
@@ -42,19 +42,14 @@ export default function AllRebates() {
   }
 
   if (rebateFormSubmissions.status === "failure") {
-    return (
-      <Message type="error" text="Error loading rebate form submissions." />
-    );
+    return <Message type="error" text={messages.rebateSubmissionsError} />;
   }
 
   return (
     <>
       {rebateFormSubmissions.data.length === 0 ? (
         <div className="margin-top-4">
-          <Message
-            type="info"
-            text="Please select the “New Application” button above to create your first rebate application."
-          />
+          <Message type="info" text={messages.newRebateApplication} />
         </div>
       ) : (
         <>
@@ -66,7 +61,7 @@ export default function AllRebates() {
           )}
 
           <div className="usa-table-container--scrollable" tabIndex={0}>
-            <table 
+            <table
               aria-label="Your Rebate Forms"
               className="usa-table usa-table--stacked usa-table--borderless usa-table--striped width-full"
             >

--- a/app/client/src/routes/existingRebate.tsx
+++ b/app/client/src/routes/existingRebate.tsx
@@ -338,14 +338,17 @@ function ExistingRebateContent() {
   }
 
   const entityComboKey = storedSubmissionData.bap_hidden_entity_combo_key;
-  const samData = samUserData.data.records.find((record) => {
-    return record.ENTITY_COMBO_KEY__c === entityComboKey;
+  const record = samUserData.data.records.find((record) => {
+    return (
+      record.ENTITY_STATUS__c === "Active" &&
+      record.ENTITY_COMBO_KEY__c === entityComboKey
+    );
   });
 
-  if (!samData) return null;
+  if (!record) return null;
 
   const email = epaUserData.data.mail;
-  const { title, name } = getUserInfo(email, samData);
+  const { title, name } = getUserInfo(email, record);
 
   return (
     <div className="margin-top-2">

--- a/app/client/src/routes/existingRebate.tsx
+++ b/app/client/src/routes/existingRebate.tsx
@@ -13,6 +13,7 @@ import { Formio, Form } from "@formio/react";
 import { cloneDeep, isEqual } from "lodash";
 // ---
 import { serverUrl, fetchData } from "../config";
+import { getUserInfo } from "../utilities";
 import Loading from "components/loading";
 import Message from "components/message";
 import MarkdownContent from "components/markdownContent";
@@ -170,6 +171,7 @@ export default function ExistingRebate() {
 type FormioSubmissionData = {
   // NOTE: more fields are in a form.io submission,
   // but we're only concerned with the fields below
+  bap_hidden_entity_combo_key?: string;
   ncesDataSource?: string;
   // (other fields...)
 };
@@ -231,7 +233,7 @@ function ExistingRebateContent() {
   const navigate = useNavigate();
   const { id } = useParams<"id">();
   const { content } = useContentState();
-  const { epaUserData } = useUserState();
+  const { epaUserData, samUserData } = useUserState();
   const dispatch = useExistingRebateDispatch();
 
   const [rebateFormSubmission, setRebateFormSubmission] =
@@ -331,9 +333,19 @@ function ExistingRebateContent() {
     );
   }
 
-  if (epaUserData.status !== "success") {
+  if (epaUserData.status !== "success" || samUserData.status !== "success") {
     return <Loading />;
   }
+
+  const entityComboKey = storedSubmissionData.bap_hidden_entity_combo_key;
+  const samData = samUserData.data.records.find((record) => {
+    return record.ENTITY_COMBO_KEY__c === entityComboKey;
+  });
+
+  if (!samData) return null;
+
+  const email = epaUserData.data.mail;
+  const { title, name } = getUserInfo(email, samData);
 
   return (
     <div className="margin-top-2">
@@ -361,7 +373,10 @@ function ExistingRebateContent() {
           submission={{
             data: {
               ...storedSubmissionData,
-              last_updated_by: epaUserData.data.mail,
+              last_updated_by: email,
+              hidden_current_user_email: email,
+              hidden_current_user_title: title,
+              hidden_current_user_name: name,
               ...pendingSubmissionData,
             },
           }}

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -4,7 +4,7 @@ import { Form } from "@formio/react";
 import icon from "uswds/img/usa-icons-bg/search--white.svg";
 import icons from "uswds/img/sprite.svg";
 // ---
-import { serverUrl, fetchData } from "../config";
+import { serverUrl, messages, fetchData } from "../config";
 import { useHelpdeskAccess } from "components/app";
 import Loading from "components/loading";
 import Message from "components/message";
@@ -159,10 +159,7 @@ export default function Helpdesk() {
       {rebateFormSubmission.status === "pending" && <Loading />}
 
       {rebateFormSubmission.status === "failure" && (
-        <Message
-          type="error"
-          text="Error loading rebate form submission. Please confirm the form ID is correct and search again."
-        />
+        <Message type="error" text={messages.helpdeskRebateFormError} />
       )}
 
       {/*
@@ -172,10 +169,7 @@ export default function Helpdesk() {
       */}
       {rebateFormSubmission.status === "success" &&
         !rebateFormSubmission.data && (
-          <Message
-            type="error"
-            text="Error loading rebate form submission. Please confirm the form ID is correct and search again."
-          />
+          <Message type="error" text={messages.helpdeskRebateFormError} />
         )}
 
       {rebateFormSubmission.status === "success" &&
@@ -183,7 +177,7 @@ export default function Helpdesk() {
         submissionData && (
           <>
             <div className="usa-table-container--scrollable" tabIndex={0}>
-              <table 
+              <table
                 aria-label="Rebate Form Search Results"
                 className="usa-table usa-table--stacked usa-table--borderless usa-table--striped width-full"
               >

--- a/app/client/src/routes/newRebate.tsx
+++ b/app/client/src/routes/newRebate.tsx
@@ -4,52 +4,25 @@ import { DialogOverlay, DialogContent } from "@reach/dialog";
 import icons from "uswds/img/sprite.svg";
 // ---
 import { serverUrl, fetchData } from "../config";
+import { getUserInfo } from "../utilities";
 import Loading from "components/loading";
 import Message from "components/message";
 import MarkdownContent from "components/markdownContent";
 import { TextWithTooltip } from "components/infoTooltip";
 import { useContentState } from "contexts/content";
-import { EPAUserData, SAMUserData, useUserState } from "contexts/user";
+import { SamEntityData, useUserState } from "contexts/user";
 
-function getMatchedContactInfo(samData: SAMUserData, epaData: EPAUserData) {
-  const samEmailFields = [
-    "ELEC_BUS_POC_EMAIL__c",
-    "ALT_ELEC_BUS_POC_EMAIL__c",
-    "GOVT_BUS_POC_EMAIL__c",
-    "ALT_GOVT_BUS_POC_EMAIL__c",
-  ];
-
-  let matchedEmailField;
-
-  for (const [field, value] of Object.entries(samData)) {
-    if (!samEmailFields.includes(field)) continue;
-    // NOTE: take the first match only – there shouldn't be a case where the
-    // currently logged in user would be listed as multiple POCs for a single record
-    if (
-      typeof value === "string" &&
-      value.toLowerCase() === epaData.mail.toLowerCase()
-    ) {
-      matchedEmailField = field;
-      break;
-    }
-  }
-
-  const fieldPrefix = matchedEmailField?.split("_EMAIL__c").shift();
-
-  return {
-    title: samData[`${fieldPrefix}_TITLE__c` as keyof SAMUserData] as string,
-    name: samData[`${fieldPrefix}_NAME__c` as keyof SAMUserData] as string,
-  };
-}
-
-function createNewRebate(samData: SAMUserData, epaData: EPAUserData) {
-  const { title, name } = getMatchedContactInfo(samData, epaData);
+function createNewRebate(email: string, samData: SamEntityData) {
+  const { title, name } = getUserInfo(email, samData);
 
   return fetchData(`${serverUrl}/api/rebate-form-submission/`, {
     data: {
-      last_updated_by: epaData.mail,
+      last_updated_by: email,
+      hidden_current_user_email: email,
+      hidden_current_user_title: title,
+      hidden_current_user_name: name,
       bap_hidden_entity_combo_key: samData.ENTITY_COMBO_KEY__c,
-      sam_hidden_applicant_email: epaData.mail,
+      sam_hidden_applicant_email: email,
       sam_hidden_applicant_title: title,
       sam_hidden_applicant_name: name,
       sam_hidden_applicant_efti: samData.ENTITY_EFT_INDICATOR__c,
@@ -80,14 +53,15 @@ export default function NewRebate() {
     text: "",
   });
 
-  const activeSamData =
-    samUserData.status === "success" &&
-    samUserData.data?.results &&
-    samUserData.data?.records.filter((e) => e.ENTITY_STATUS__c === "Active");
-
-  if (epaUserData.status !== "success") {
-    return null;
+  if (epaUserData.status !== "success" || samUserData.status !== "success") {
+    return <Loading />;
   }
+
+  const email = epaUserData.data.mail;
+
+  const activeSamRecords = samUserData.data.records.filter((record) => {
+    return record.ENTITY_STATUS__c === "Active";
+  });
 
   return (
     <div className="margin-top-2">
@@ -99,135 +73,134 @@ export default function NewRebate() {
         >
           <div className="usa-modal__content">
             <div className="usa-modal__main">
-              {content.status === "success" && (
-                <MarkdownContent
-                  className="margin-top-4"
-                  children={content.data?.newRebateDialog || ""}
-                  components={{
-                    h2: (props) => (
-                      <h2
-                        id="csb-new-rebate-modal-heading"
-                        className="usa-modal__heading text-center"
-                      >
-                        {props.children}
-                      </h2>
-                    ),
-                    p: (props) => (
-                      <p
-                        id="csb-new-rebate-modal-description"
-                        className="text-center"
-                      >
-                        {props.children}
-                      </p>
-                    ),
-                  }}
+              {activeSamRecords.length <= 0 ? (
+                <Message
+                  type="info"
+                  text="No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms."
                 />
-              )}
+              ) : (
+                <>
+                  {content.status === "success" && (
+                    <MarkdownContent
+                      className="margin-top-4"
+                      children={content.data?.newRebateDialog || ""}
+                      components={{
+                        h2: (props) => (
+                          <h2
+                            id="csb-new-rebate-modal-heading"
+                            className="usa-modal__heading text-center"
+                          >
+                            {props.children}
+                          </h2>
+                        ),
+                        p: (props) => (
+                          <p
+                            id="csb-new-rebate-modal-description"
+                            className="text-center"
+                          >
+                            {props.children}
+                          </p>
+                        ),
+                      }}
+                    />
+                  )}
 
-              {message.displayed && (
-                <Message type={message.type} text={message.text} />
-              )}
+                  {message.displayed && (
+                    <Message type={message.type} text={message.text} />
+                  )}
 
-              <div className="usa-table-container--scrollable" tabIndex={0}>
-                <table 
-                  aria-label="SAM.gov Entities"
-                  className="usa-table usa-table--stacked usa-table--borderless usa-table--striped width-full"
-                >
-                  <thead>
-                    <tr className="font-sans-2xs text-no-wrap">
-                      <th scope="col">
-                        <span className="usa-sr-only">Create</span>
-                      </th>
-                      <th scope="col">
-                        <TextWithTooltip
-                          text="UEI"
-                          tooltip="Unique Entity ID from SAM.gov"
-                        />
-                      </th>
-                      <th scope="col">
-                        <TextWithTooltip
-                          text="EFT Indicator"
-                          tooltip="Electronic Funds Transfer Indicator listing the associated bank account from SAM.gov"
-                        />
-                      </th>
-                      <th scope="col">
-                        <TextWithTooltip
-                          text="Applicant"
-                          tooltip="Legal Business Name from SAM.gov for this UEI"
-                        />
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {!activeSamData ? (
-                      <tr>
-                        <td colSpan={4}>
-                          <div className="margin-bottom-2">
-                            <Loading />
-                          </div>
-                        </td>
-                      </tr>
-                    ) : (
-                      activeSamData.map((samData, index) => (
-                        <tr key={index}>
-                          <th scope="row" className="font-sans-2xs">
-                            <button
-                              className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
-                              onClick={(ev) => {
-                                setMessage({
-                                  displayed: true,
-                                  type: "info",
-                                  text: "Creating new rebate form application...",
-                                });
-
-                                createNewRebate(samData, epaUserData.data)
-                                  .then((res) => {
-                                    navigate(`/rebate/${res._id}`);
-                                  })
-                                  .catch((err) => {
-                                    setMessage({
-                                      displayed: true,
-                                      type: "error",
-                                      text: "Error creating new rebate form application.",
-                                    });
-                                  });
-                              }}
-                            >
-                              <span className="usa-sr-only">
-                                Create Form with UEI:{" "}
-                                {samData.UNIQUE_ENTITY_ID__c} and EFTI:{" "}
-                                {samData.ENTITY_EFT_INDICATOR__c}
-                              </span>
-                              <span className="display-flex flex-align-center">
-                                <svg
-                                  className="usa-icon"
-                                  aria-hidden="true"
-                                  focusable="false"
-                                  role="img"
-                                >
-                                  <use href={`${icons}#arrow_forward`} />
-                                </svg>
-                                <span className="mobile-lg:display-none margin-left-1">
-                                  New Form
-                                </span>
-                              </span>
-                            </button>
+                  <div className="usa-table-container--scrollable" tabIndex={0}>
+                    <table
+                      aria-label="SAM.gov Entities"
+                      className="usa-table usa-table--stacked usa-table--borderless usa-table--striped width-full"
+                    >
+                      <thead>
+                        <tr className="font-sans-2xs text-no-wrap">
+                          <th scope="col">
+                            <span className="usa-sr-only">Create</span>
                           </th>
-                          <td className="font-sans-2xs">
-                            {samData.UNIQUE_ENTITY_ID__c}
-                          </td>
-                          <td className="font-sans-2xs">
-                            {samData.ENTITY_EFT_INDICATOR__c}
-                          </td>
-                          <td className="font-sans-2xs">
-                            {samData.LEGAL_BUSINESS_NAME__c}
-                          </td>
+                          <th scope="col">
+                            <TextWithTooltip
+                              text="UEI"
+                              tooltip="Unique Entity ID from SAM.gov"
+                            />
+                          </th>
+                          <th scope="col">
+                            <TextWithTooltip
+                              text="EFT Indicator"
+                              tooltip="Electronic Funds Transfer Indicator listing the associated bank account from SAM.gov"
+                            />
+                          </th>
+                          <th scope="col">
+                            <TextWithTooltip
+                              text="Applicant"
+                              tooltip="Legal Business Name from SAM.gov for this UEI"
+                            />
+                          </th>
                         </tr>
-                      ))
-                    )}
-                  </tbody>
-                </table>
-              </div>
+                      </thead>
+                      <tbody>
+                        {activeSamRecords.map((samData, index) => (
+                          <tr key={index}>
+                            <th scope="row" className="font-sans-2xs">
+                              <button
+                                className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+                                onClick={(ev) => {
+                                  setMessage({
+                                    displayed: true,
+                                    type: "info",
+                                    text: "Creating new rebate form application...",
+                                  });
+
+                                  createNewRebate(email, samData)
+                                    .then((res) => {
+                                      navigate(`/rebate/${res._id}`);
+                                    })
+                                    .catch((err) => {
+                                      setMessage({
+                                        displayed: true,
+                                        type: "error",
+                                        text: "Error creating new rebate form application.",
+                                      });
+                                    });
+                                }}
+                              >
+                                <span className="usa-sr-only">
+                                  Create Form with UEI:{" "}
+                                  {samData.UNIQUE_ENTITY_ID__c} and EFTI:{" "}
+                                  {samData.ENTITY_EFT_INDICATOR__c}
+                                </span>
+                                <span className="display-flex flex-align-center">
+                                  <svg
+                                    className="usa-icon"
+                                    aria-hidden="true"
+                                    focusable="false"
+                                    role="img"
+                                  >
+                                    <use href={`${icons}#arrow_forward`} />
+                                  </svg>
+                                  <span className="mobile-lg:display-none margin-left-1">
+                                    New Form
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <td className="font-sans-2xs">
+                              {samData.UNIQUE_ENTITY_ID__c}
+                            </td>
+                            <td className="font-sans-2xs">
+                              {samData.ENTITY_EFT_INDICATOR__c}
+                            </td>
+                            <td className="font-sans-2xs">
+                              {samData.LEGAL_BUSINESS_NAME__c}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </>
+              )}
             </div>
 
             <button

--- a/app/client/src/routes/newRebate.tsx
+++ b/app/client/src/routes/newRebate.tsx
@@ -12,8 +12,8 @@ import { TextWithTooltip } from "components/infoTooltip";
 import { useContentState } from "contexts/content";
 import { SamEntityData, useUserState } from "contexts/user";
 
-function createNewRebate(email: string, samData: SamEntityData) {
-  const { title, name } = getUserInfo(email, samData);
+function createNewRebate(email: string, record: SamEntityData) {
+  const { title, name } = getUserInfo(email, record);
 
   return fetchData(`${serverUrl}/api/rebate-form-submission/`, {
     data: {
@@ -21,18 +21,18 @@ function createNewRebate(email: string, samData: SamEntityData) {
       hidden_current_user_email: email,
       hidden_current_user_title: title,
       hidden_current_user_name: name,
-      bap_hidden_entity_combo_key: samData.ENTITY_COMBO_KEY__c,
+      bap_hidden_entity_combo_key: record.ENTITY_COMBO_KEY__c,
       sam_hidden_applicant_email: email,
       sam_hidden_applicant_title: title,
       sam_hidden_applicant_name: name,
-      sam_hidden_applicant_efti: samData.ENTITY_EFT_INDICATOR__c,
-      sam_hidden_applicant_uei: samData.UNIQUE_ENTITY_ID__c,
-      sam_hidden_applicant_organization_name: samData.LEGAL_BUSINESS_NAME__c,
-      sam_hidden_applicant_street_address_1: samData.PHYSICAL_ADDRESS_LINE_1__c,
-      sam_hidden_applicant_street_address_2: samData.PHYSICAL_ADDRESS_LINE_2__c,
-      sam_hidden_applicant_city: samData.PHYSICAL_ADDRESS_CITY__c,
-      sam_hidden_applicant_state: samData.PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c,
-      sam_hidden_applicant_zip_code: samData.PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c,
+      sam_hidden_applicant_efti: record.ENTITY_EFT_INDICATOR__c,
+      sam_hidden_applicant_uei: record.UNIQUE_ENTITY_ID__c,
+      sam_hidden_applicant_organization_name: record.LEGAL_BUSINESS_NAME__c,
+      sam_hidden_applicant_street_address_1: record.PHYSICAL_ADDRESS_LINE_1__c,
+      sam_hidden_applicant_street_address_2: record.PHYSICAL_ADDRESS_LINE_2__c,
+      sam_hidden_applicant_city: record.PHYSICAL_ADDRESS_CITY__c,
+      sam_hidden_applicant_state: record.PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c,
+      sam_hidden_applicant_zip_code: record.PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c,
     },
     state: "draft",
   });
@@ -137,7 +137,7 @@ export default function NewRebate() {
                         </tr>
                       </thead>
                       <tbody>
-                        {activeSamRecords.map((samData, index) => (
+                        {activeSamRecords.map((record, index) => (
                           <tr key={index}>
                             <th scope="row" className="font-sans-2xs">
                               <button
@@ -149,7 +149,7 @@ export default function NewRebate() {
                                     text: "Creating new rebate form application...",
                                   });
 
-                                  createNewRebate(email, samData)
+                                  createNewRebate(email, record)
                                     .then((res) => {
                                       navigate(`/rebate/${res._id}`);
                                     })
@@ -164,8 +164,8 @@ export default function NewRebate() {
                               >
                                 <span className="usa-sr-only">
                                   Create Form with UEI:{" "}
-                                  {samData.UNIQUE_ENTITY_ID__c} and EFTI:{" "}
-                                  {samData.ENTITY_EFT_INDICATOR__c}
+                                  {record.UNIQUE_ENTITY_ID__c} and EFTI:{" "}
+                                  {record.ENTITY_EFT_INDICATOR__c}
                                 </span>
                                 <span className="display-flex flex-align-center">
                                   <svg
@@ -183,13 +183,13 @@ export default function NewRebate() {
                               </button>
                             </th>
                             <td className="font-sans-2xs">
-                              {samData.UNIQUE_ENTITY_ID__c}
+                              {record.UNIQUE_ENTITY_ID__c}
                             </td>
                             <td className="font-sans-2xs">
-                              {samData.ENTITY_EFT_INDICATOR__c}
+                              {record.ENTITY_EFT_INDICATOR__c}
                             </td>
                             <td className="font-sans-2xs">
-                              {samData.LEGAL_BUSINESS_NAME__c}
+                              {record.LEGAL_BUSINESS_NAME__c}
                             </td>
                           </tr>
                         ))}

--- a/app/client/src/routes/newRebate.tsx
+++ b/app/client/src/routes/newRebate.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { DialogOverlay, DialogContent } from "@reach/dialog";
 import icons from "uswds/img/sprite.svg";
 // ---
-import { serverUrl, fetchData } from "../config";
+import { serverUrl, messages, fetchData } from "../config";
 import { getUserInfo } from "../utilities";
 import Loading from "components/loading";
 import Message from "components/message";
@@ -74,10 +74,7 @@ export default function NewRebate() {
           <div className="usa-modal__content">
             <div className="usa-modal__main">
               {activeSamRecords.length <= 0 ? (
-                <Message
-                  type="info"
-                  text="No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms."
-                />
+                <Message type="info" text={messages.samResults} />
               ) : (
                 <>
                   {content.status === "success" && (

--- a/app/client/src/routes/newRebate.tsx
+++ b/app/client/src/routes/newRebate.tsx
@@ -74,7 +74,7 @@ export default function NewRebate() {
           <div className="usa-modal__content">
             <div className="usa-modal__main">
               {activeSamRecords.length <= 0 ? (
-                <Message type="info" text={messages.samResults} />
+                <Message type="info" text={messages.samNoResults} />
               ) : (
                 <>
                   {content.status === "success" && (

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -1,0 +1,36 @@
+import { SamEntityData } from "contexts/user";
+
+/**
+ * Returns a user’s title and name when provided an email address and a SAM.gov
+ * entity/record.
+ */
+export function getUserInfo(email: string, samData: SamEntityData) {
+  const samEmailFields = [
+    "ELEC_BUS_POC_EMAIL__c",
+    "ALT_ELEC_BUS_POC_EMAIL__c",
+    "GOVT_BUS_POC_EMAIL__c",
+    "ALT_GOVT_BUS_POC_EMAIL__c",
+  ];
+
+  let matchedEmailField;
+
+  for (const [field, value] of Object.entries(samData)) {
+    if (!samEmailFields.includes(field)) continue;
+    // NOTE: take the first match only (the assumption is if a user is listed
+    // as multiple POCs, their title and name will be the same for all POCs)
+    if (
+      typeof value === "string" &&
+      value.toLowerCase() === email.toLowerCase()
+    ) {
+      matchedEmailField = field;
+      break;
+    }
+  }
+
+  const fieldPrefix = matchedEmailField?.split("_EMAIL__c").shift();
+
+  return {
+    title: samData[`${fieldPrefix}_TITLE__c` as keyof SamEntityData] as string,
+    name: samData[`${fieldPrefix}_NAME__c` as keyof SamEntityData] as string,
+  };
+}

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -4,7 +4,7 @@ import { SamEntityData } from "contexts/user";
  * Returns a user’s title and name when provided an email address and a SAM.gov
  * entity/record.
  */
-export function getUserInfo(email: string, samData: SamEntityData) {
+export function getUserInfo(email: string, record: SamEntityData) {
   const samEmailFields = [
     "ELEC_BUS_POC_EMAIL__c",
     "ALT_ELEC_BUS_POC_EMAIL__c",
@@ -14,7 +14,7 @@ export function getUserInfo(email: string, samData: SamEntityData) {
 
   let matchedEmailField;
 
-  for (const [field, value] of Object.entries(samData)) {
+  for (const [field, value] of Object.entries(record)) {
     if (!samEmailFields.includes(field)) continue;
     // NOTE: take the first match only (the assumption is if a user is listed
     // as multiple POCs, their title and name will be the same for all POCs)
@@ -30,7 +30,7 @@ export function getUserInfo(email: string, samData: SamEntityData) {
   const fieldPrefix = matchedEmailField?.split("_EMAIL__c").shift();
 
   return {
-    title: samData[`${fieldPrefix}_TITLE__c` as keyof SamEntityData] as string,
-    name: samData[`${fieldPrefix}_NAME__c` as keyof SamEntityData] as string,
+    title: record[`${fieldPrefix}_TITLE__c` as keyof SamEntityData] as string,
+    name: record[`${fieldPrefix}_NAME__c` as keyof SamEntityData] as string,
   };
 }


### PR DESCRIPTION
Inject three new fields into new and existing rebate forms:
- `hidden_current_user_email`
- `hidden_current_user_title`
- `hidden_current_user_name`
...with info from currently logged in user.

Also centralizes message text used across components (as some of it was shared in this change).