### PR TITLE
Feature/update local dev proxy

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -45,6 +45,7 @@
     "uswds": "2.13.1",
     "web-vitals": "2.1.4"
   },
+  "proxy": "http://localhost:3001",
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -7,6 +7,7 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import {
   serverUrl,
+  serverUrlForLinks,
   formioBaseUrl,
   formioProjectUrl,
   fetchData,
@@ -150,7 +151,7 @@ export default function Dashboard() {
 
           <a
             className="margin-bottom-1 usa-button font-sans-2xs margin-right-0"
-            href={`${serverUrl}/logout`}
+            href={`${serverUrlForLinks}/logout`}
           >
             <IconText order="text-icon" icon="logout" text="Sign out" />
           </a>

--- a/app/client/src/components/welcome.tsx
+++ b/app/client/src/components/welcome.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import icons from "uswds/img/sprite.svg";
 // ---
-import { serverUrl, messages } from "../config";
+import { serverUrlForLinks, messages } from "../config";
 import Message from "components/message";
 
 export default function Welcome() {
@@ -84,7 +84,7 @@ export default function Welcome() {
 
         <a
           className="usa-button margin-top-1 margin-right-0 font-sans-2xs"
-          href={`${serverUrl}/login`}
+          href={`${serverUrlForLinks}/login`}
         >
           <span className="display-flex flex-align-center">
             <span className="margin-right-1">Sign in</span>

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -18,13 +18,29 @@ if (!REACT_APP_FORMIO_PROJECT_URL) {
   );
 }
 
+// allows the app to be accessed from a sub directory of a server (e.g. /csb)
 export const serverBasePath =
   NODE_ENV === "development" ? "" : REACT_APP_SERVER_BASE_PATH || "";
 
-export const serverUrl =
-  NODE_ENV === "development"
-    ? "http://localhost:3001"
-    : window.location.origin + serverBasePath;
+// NOTE: This app is configured to use [Create React App's proxy setup]
+// (https://create-react-app.dev/docs/proxying-api-requests-in-development/)
+//
+// For local development, the React app development server runs on port 3000,
+// and the Express app server runs on port 3001, so we've added a proxy field to
+// the client app's package.json file to proxy unknown requests from the React
+// app to the Express app (for local dev only – only works with `npm start`).
+//
+// When deployed to Cloud.gov, the React app is built and served as static files
+// from the Express app, so it's one app running from a single port so no proxy
+// is needed for production.
+export const serverUrl = window.location.origin + serverBasePath;
+
+// NOTE: This local development setup unfortunately doesn't proxy GET requests
+// from links though because they set an "Accept" request header to "text/html",
+// so we need to use a different environment variable for when the serverUrl is
+// used in the href of anchor tags (e.g. login and logout links).
+export const serverUrlForLinks =
+  NODE_ENV === "development" ? "http://localhost:3001" : serverUrl;
 
 export const cloudSpace =
   NODE_ENV === "development" ? "dev" : REACT_APP_CLOUD_SPACE || "";


### PR DESCRIPTION
Configure react app to [proxy requests to express app in local development](https://create-react-app.dev/docs/proxying-api-requests-in-development/) (resolves an issue that prevented file uploads in a form, which is an issue since uploading a vehicle title and registration document is a required field).