### PR TITLE
Feature/account for empty sam gov efti

### DIFF
--- a/app/client/src/contexts/forms.tsx
+++ b/app/client/src/contexts/forms.tsx
@@ -23,7 +23,7 @@ type RebateFormSubmission = {
   modified: string;
   data: {
     applicantUEI: string;
-    applicantEfti: string;
+    applicantEfti_display: string;
     applicantOrganizationName: string;
     schoolDistrictName: string;
     last_updated_by: string;

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -125,7 +125,7 @@ export default function AllRebates() {
                   const { _id, state, modified, data } = submission;
                   const {
                     applicantUEI,
-                    applicantEfti,
+                    applicantEfti_display,
                     applicantOrganizationName,
                     schoolDistrictName,
                     last_updated_by,
@@ -176,8 +176,34 @@ export default function AllRebates() {
                         )}
                       </td>
                       <td>
-                        {applicantEfti ? (
-                          applicantEfti
+                        {/*
+                        NOTE: In the initial version of the app, the rebate form
+                        (GSA) only set the `applicantEfti` field, based on the
+                        value we provide the `sam_hidden_applicant_efti` field.
+                        That value comes from the BAP/SAM.gov data, which could
+                        be an empty string. In those cases, '0000' should be
+                        used instead, so GSA updated the form definition to
+                        include a new `applicantEfti_display` field that will
+                        conditionally set its value to '0000' if the
+                        `sam_hidden_applicant_efti` field is an empty string.
+                        We still need to handle this situation for existing
+                        submissions (before GSA updated the form definition).
+                        */}
+                        {applicantEfti_display ? (
+                          applicantEfti_display
+                        ) : /*
+                        NOTE: Here's where we conditionally set "0000" for forms
+                        that have already been created before the rebate form's
+                        form definition was updated. We can't check the
+                        `applicantEfti` field, as it could be an empty string
+                        (falsy in JavaScript), so we'll check the `applicantUEI`
+                        field instead, as it should exist for existing form
+                        submissions that have advanced past the first screen (we
+                        could have also checked the `applicantOrganizationName`
+                        field for the same result).
+                        */
+                        applicantUEI ? (
+                          "0000"
                         ) : (
                           <TextWithTooltip
                             text=" "

--- a/app/client/src/routes/newRebate.tsx
+++ b/app/client/src/routes/newRebate.tsx
@@ -186,7 +186,7 @@ export default function NewRebate() {
                               {record.UNIQUE_ENTITY_ID__c}
                             </td>
                             <td className="font-sans-2xs">
-                              {record.ENTITY_EFT_INDICATOR__c}
+                              {record.ENTITY_EFT_INDICATOR__c || "0000"}
                             </td>
                             <td className="font-sans-2xs">
                               {record.LEGAL_BUSINESS_NAME__c}


### PR DESCRIPTION
Update app to account for when SAM.gov's EFTI field is an empty string (handled within the updated Forms.gov rebate form definition for all new submissions, but we need to account for 1) existing rebate form submissions and 2) the table that shows SAM.gov data for starting a new form submission).