### PR TITLE
Feature/update dependencies

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -78,7 +78,7 @@ jobs:
         working-directory: app/client
 
       - name: Install front-end dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
         working-directory: app/client
 
       - name: Build front-end files and move to server

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -77,7 +77,7 @@ jobs:
         working-directory: app/client
 
       - name: Install front-end dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
         working-directory: app/client
 
       - name: Build front-end files and move to server

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -78,7 +78,7 @@ jobs:
         working-directory: app/client
 
       - name: Install front-end dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
         working-directory: app/client
 
       - name: Build front-end files and move to server


### PR DESCRIPTION
Update GitHub workflows to install npm packages w/ `legacy-peer-deps` flag passed to get around React 18 conflicts w/ specific packages (tested in dev, so works fine – should consider removing this flag though when certain packages update and it's no longer needed)