### PR TITLE
Feature/fix links in epa template

### DIFF
--- a/app/client/public/404.html
+++ b/app/client/public/404.html
@@ -27,7 +27,7 @@
     <meta property="DC.type" content="Data and Tools" />
     <meta property="og:site_name" content="US EPA" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://eforms.epa.gov/csb" />
+    <meta property="og:url" content="%PUBLIC_URL%" />
     <meta
       property="og:title"
       content="Clean School Bus Data Collection System | US EPA"
@@ -49,13 +49,13 @@
       name="twitter:title"
       content="Clean School Bus Data Collection System | US EPA"
     />
-    <meta name="twitter:url" content="https://eforms.epa.gov/csb" />
+    <meta name="twitter:url" content="%PUBLIC_URL%" />
     <meta name="twitter:image:height" content="600" />
     <meta name="twitter:image:width" content="1200" />
     <meta name="msapplication-TileColor" content="#005ea2" />
     <meta name="theme-color" content="#005ea2" />
     <link rel="manifest" href="./manifest.json" />
-    <link rel="canonical" href="https://eforms.epa.gov/csb" />
+    <link rel="canonical" href="%PUBLIC_URL%" />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="196x196"

--- a/app/client/public/404.html
+++ b/app/client/public/404.html
@@ -27,7 +27,7 @@
     <meta property="DC.type" content="Data and Tools" />
     <meta property="og:site_name" content="US EPA" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="%PUBLIC_URL%" />
+    <meta property="og:url" content="%PUBLIC_URL%/" />
     <meta
       property="og:title"
       content="Clean School Bus Data Collection System | US EPA"
@@ -49,13 +49,13 @@
       name="twitter:title"
       content="Clean School Bus Data Collection System | US EPA"
     />
-    <meta name="twitter:url" content="%PUBLIC_URL%" />
+    <meta name="twitter:url" content="%PUBLIC_URL%/" />
     <meta name="twitter:image:height" content="600" />
     <meta name="twitter:image:width" content="1200" />
     <meta name="msapplication-TileColor" content="#005ea2" />
     <meta name="theme-color" content="#005ea2" />
     <link rel="manifest" href="./manifest.json" />
-    <link rel="canonical" href="%PUBLIC_URL%" />
+    <link rel="canonical" href="%PUBLIC_URL%/" />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="196x196"

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -27,7 +27,7 @@
     <meta property="DC.type" content="Data and Tools" />
     <meta property="og:site_name" content="US EPA" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://eforms.epa.gov/csb" />
+    <meta property="og:url" content="%PUBLIC_URL%" />
     <meta
       property="og:title"
       content="Clean School Bus Data Collection System | US EPA"
@@ -49,13 +49,13 @@
       name="twitter:title"
       content="Clean School Bus Data Collection System | US EPA"
     />
-    <meta name="twitter:url" content="https://eforms.epa.gov/csb" />
+    <meta name="twitter:url" content="%PUBLIC_URL%" />
     <meta name="twitter:image:height" content="600" />
     <meta name="twitter:image:width" content="1200" />
     <meta name="msapplication-TileColor" content="#005ea2" />
     <meta name="theme-color" content="#005ea2" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link rel="canonical" href="https://eforms.epa.gov/csb" />
+    <link rel="canonical" href="%PUBLIC_URL%" />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="196x196"

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -27,7 +27,7 @@
     <meta property="DC.type" content="Data and Tools" />
     <meta property="og:site_name" content="US EPA" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="%PUBLIC_URL%" />
+    <meta property="og:url" content="%PUBLIC_URL%/" />
     <meta
       property="og:title"
       content="Clean School Bus Data Collection System | US EPA"
@@ -49,13 +49,13 @@
       name="twitter:title"
       content="Clean School Bus Data Collection System | US EPA"
     />
-    <meta name="twitter:url" content="%PUBLIC_URL%" />
+    <meta name="twitter:url" content="%PUBLIC_URL%/" />
     <meta name="twitter:image:height" content="600" />
     <meta name="twitter:image:width" content="1200" />
     <meta name="msapplication-TileColor" content="#005ea2" />
     <meta name="theme-color" content="#005ea2" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link rel="canonical" href="%PUBLIC_URL%" />
+    <link rel="canonical" href="%PUBLIC_URL%/" />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="196x196"


### PR DESCRIPTION
Replace 'eforms.epa.gov/csb' in public html file with the built public url