### PR TITLE
Feature/update efti dashboard logic

### DIFF
--- a/app/client/src/contexts/forms.tsx
+++ b/app/client/src/contexts/forms.tsx
@@ -23,6 +23,7 @@ type RebateFormSubmission = {
   modified: string;
   data: {
     applicantUEI: string;
+    applicantEfti: string;
     applicantEfti_display: string;
     applicantOrganizationName: string;
     schoolDistrictName: string;


### PR DESCRIPTION
Update comments around displaying EFTI value on all rebates table, and logic to only fallback to '0000' if the `applicantEfti` field is an empty string (for old submissions before the rebate form update that included the new `applicantEfti_display` field)