### PR TITLE
Feature/update existing rebate form dirty check

### DIFF
--- a/app/client/src/contexts/forms.tsx
+++ b/app/client/src/contexts/forms.tsx
@@ -10,27 +10,20 @@ type Props = {
   children: ReactNode;
 };
 
-/**
- * Minimum fields required to display the user's forms on their dashboard, and
- * have the metadata needed to make an API call to the forms.gov web service to
- * retreive the form's JSON schema in order to display and edit the form.
- */
 type RebateFormSubmission = {
-  // NOTE: more fields are in a form.io submission,
-  // but we're only concerned with the fields below
-  _id: string;
+  [field: string]: unknown;
+  _id: string; // MongoDB ObjectId string
   state: "submitted" | "draft";
-  modified: string;
+  modified: string; // ISO 8601 date string
   data: {
+    [field: string]: unknown;
     applicantUEI: string;
     applicantEfti: string;
     applicantEfti_display: string;
     applicantOrganizationName: string;
     schoolDistrictName: string;
     last_updated_by: string;
-    // (other fields...)
   };
-  // (other fields...)
 };
 
 type State = {

--- a/app/client/src/routes/existingRebate.tsx
+++ b/app/client/src/routes/existingRebate.tsx
@@ -399,6 +399,40 @@ function ExistingRebateContent() {
                 : false,
             noAlerts: true,
           }}
+          onChange={(submission: {
+            changed: {
+              component: {
+                [field: string]: unknown;
+                key: string;
+              };
+              flags: unknown;
+              instance: unknown;
+              value: unknown;
+            };
+            data: FormioSubmissionData;
+            isValid: boolean;
+            metadata: unknown;
+          }) => {
+            // NOTE: For some unknown reason, whenever the bus info's "Save"
+            // button (the component w/ the key "busInformation") is clicked
+            // the `storedSubmissionDataRef` value is mutated, which invalidates
+            // the isEqual() early return "dirty check" used in the onNextPage
+            // event callback below (as the two object being compared are now
+            // equal). That means if the user changed any of the bus info fields
+            // (which are displayed via a Formio "Edit Grid" component, which
+            // includes its own "Save" button that must be clicked) and clicked
+            // the form's "Next" button without making any other form field
+            // changes, the "dirty check" incorrectly fails, and the updated
+            // form data was not posted. The fix below should resolve that issue
+            // as now we're intentionally mutating the `storedSubmissionDataRef`
+            // to an empty object whenever the Edit Grid's "Save" button is
+            // clicked (which must be clicked to close the bus info fields) to
+            // guarantee the "dirty check" succeeds the next time the form's
+            // "Next" button is clicked.
+            if (submission?.changed?.component?.key === "busInformation") {
+              storedSubmissionDataRef.current = {};
+            }
+          }}
           onSubmit={(submission: {
             state: "submitted" | "draft";
             data: FormioSubmissionData;

--- a/app/client/src/routes/existingRebate.tsx
+++ b/app/client/src/routes/existingRebate.tsx
@@ -169,15 +169,13 @@ export default function ExistingRebate() {
 // -----------------------------------------------------------------------------
 
 type FormioSubmissionData = {
-  // NOTE: more fields are in a form.io submission,
-  // but we're only concerned with the fields below
+  [field: string]: unknown;
   hidden_current_user_email?: string;
   hidden_current_user_title?: string;
   hidden_current_user_name?: string;
   bap_hidden_entity_combo_key?: string;
   ncesDataSource?: string;
   ncesDataLookup?: string[];
-  // (other fields...)
 };
 
 type SubmissionState =
@@ -204,12 +202,10 @@ type SubmissionState =
             userAccess: true;
             formSchema: { url: string; json: object };
             submissionData: {
-              // NOTE: more fields are in a form.io submission,
-              // but we're only concerned with the fields below
-              _id: string;
+              [field: string]: unknown;
+              _id: string; // MongoDB ObjectId string
               data: object;
               state: "submitted" | "draft";
-              // (other fields...)
             };
           }
         | {
@@ -436,7 +432,7 @@ function ExistingRebateContent() {
           onSubmit={(submission: {
             state: "submitted" | "draft";
             data: FormioSubmissionData;
-            metadata: object;
+            metadata: unknown;
           }) => {
             // remove `ncesDataSource` and `ncesDataLookup` fields
             const data = { ...submission.data };
@@ -513,7 +509,7 @@ function ExistingRebateContent() {
             page: number;
             submission: {
               data: FormioSubmissionData;
-              metadata: object;
+              metadata: unknown;
             };
           }) => {
             // remove `ncesDataSource` and `ncesDataLookup` fields

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -34,17 +34,15 @@ type SubmissionState =
       data: {
         formSchema: { url: string; json: object };
         submissionData: {
-          // NOTE: more fields are in a form.io submission,
-          // but we're only concerned with the fields below
-          _id: string;
+          [field: string]: unknown;
+          _id: string; // MongoDB ObjectId string
           state: "submitted" | "draft";
-          modified: string;
+          modified: string; // ISO 8601 date string
           data: {
+            [field: string]: unknown;
             applicantOrganizationName: string;
             last_updated_by: string;
-            // (other fields...)
           };
-          // (other fields...)
         };
       };
     }


### PR DESCRIPTION
Resolves issue of Formio "Edit Grid" component's "Save" button click incorrectly invalidating the data we use in the "dirty check" we do whenever the form's "Next" button is clicked to determine if any changes were made to the form, which would warrant posting that updated data to forms.gov.