### PR TITLE
Feature/update all rebates table

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -220,24 +220,24 @@ function ProtectedRoute({ children }: { children: JSX.Element }) {
 
   // Check if user is already logged in or needs to be redirected to /welcome route
   const verifyUser = useCallback(() => {
-    fetchData(`${serverUrl}/api/epa-data`)
+    dispatch({ type: "FETCH_CSB_DATA_REQUEST" });
+    fetchData(`${serverUrl}/api/csb-data`)
       .then((res) => {
         dispatch({
-          type: "FETCH_EPA_USER_DATA_SUCCESS",
-          payload: { epaUserData: res },
+          type: "FETCH_CSB_DATA_SUCCESS",
+          payload: { csbData: res },
         });
         dispatch({ type: "USER_SIGN_IN" });
       })
       .catch((err) => {
-        dispatch({ type: "FETCH_EPA_USER_DATA_FAILURE" });
+        dispatch({ type: "FETCH_CSB_DATA_FAILURE" });
         dispatch({ type: "USER_SIGN_OUT" });
       });
   }, [dispatch]);
 
   useEffect(() => {
-    dispatch({ type: "FETCH_EPA_USER_DATA_REQUEST" });
     verifyUser();
-  }, [verifyUser, dispatch, pathname]);
+  }, [verifyUser, pathname]);
 
   useInactivityDialog(verifyUser);
 

--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -7,7 +7,7 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import {
   serverUrl,
-  serverUrlForLinks,
+  serverUrlForHrefs,
   formioBaseUrl,
   formioProjectUrl,
   fetchData,
@@ -55,12 +55,12 @@ function useFetchedBapData() {
             payload: { bapUserData: res },
           });
         } else {
-          window.location.href = `${serverUrl}/logout?RelayState=/welcome?info=sam-results`;
+          window.location.href = `${serverUrlForHrefs}/logout?RelayState=/welcome?info=sam-results`;
         }
       })
       .catch((err) => {
         dispatch({ type: "FETCH_BAP_USER_DATA_FAILURE" });
-        window.location.href = `${serverUrl}/logout?RelayState=/welcome?error=sam-fetch`;
+        window.location.href = `${serverUrlForHrefs}/logout?RelayState=/welcome?error=bap-fetch`;
       });
   }, [dispatch]);
 }
@@ -171,7 +171,7 @@ export default function Dashboard() {
 
           <a
             className="margin-bottom-1 usa-button font-sans-2xs margin-right-0"
-            href={`${serverUrlForLinks}/logout`}
+            href={`${serverUrlForHrefs}/logout`}
           >
             <IconText order="text-icon" icon="logout" text="Sign out" />
           </a>

--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -22,6 +22,25 @@ Formio.setProjectUrl(formioProjectUrl);
 Formio.use(premium);
 Formio.use(uswds);
 
+// Custom hook to fetch EPA data
+function useFetchedEpaData() {
+  const dispatch = useUserDispatch();
+
+  useEffect(() => {
+    dispatch({ type: "FETCH_EPA_USER_DATA_REQUEST" });
+    fetchData(`${serverUrl}/api/epa-data`)
+      .then((res) => {
+        dispatch({
+          type: "FETCH_EPA_USER_DATA_SUCCESS",
+          payload: { epaUserData: res },
+        });
+      })
+      .catch((err) => {
+        dispatch({ type: "FETCH_EPA_USER_DATA_FAILURE" });
+      });
+  }, [dispatch]);
+}
+
 // Custom hook to fetch BAP data
 function useFetchedBapData() {
   const dispatch = useUserDispatch();
@@ -85,10 +104,11 @@ export default function Dashboard() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
 
-  const { epaUserData, bapUserData } = useUserState();
+  const { csbData, epaUserData, bapUserData } = useUserState();
   const dispatch = useDialogDispatch();
   const helpdeskAccess = useHelpdeskAccess();
 
+  useFetchedEpaData();
   useFetchedBapData();
 
   /**
@@ -145,7 +165,7 @@ export default function Dashboard() {
         <nav className="desktop:order-last mobile-lg:display-flex flex-align-center flex-justify-end">
           <p className="margin-bottom-1 margin-right-1">
             <span>
-              {epaUserData.status === "success" && epaUserData.data?.mail}
+              {epaUserData.status === "success" && epaUserData.data.mail}
             </span>
           </p>
 
@@ -190,8 +210,7 @@ export default function Dashboard() {
           )}
 
           {pathname.startsWith("/rebate") ||
-          (epaUserData.status === "success" &&
-            epaUserData.data?.enrollmentClosed) ? (
+          (csbData.status === "success" && csbData.data.enrollmentClosed) ? (
             <button
               className="margin-bottom-1 usa-button font-sans-2xs"
               disabled

--- a/app/client/src/components/infoTooltip.tsx
+++ b/app/client/src/components/infoTooltip.tsx
@@ -31,7 +31,7 @@ type TextWithTooltipProps = {
 
 export function TextWithTooltip({ text, tooltip }: TextWithTooltipProps) {
   return (
-    <span className="display-flex flex-align-center text-no-wrap">
+    <span className="display-inline-flex flex-align-center text-no-wrap">
       <InfoTooltip label={tooltip} />
       {text}
     </span>

--- a/app/client/src/components/infoTooltip.tsx
+++ b/app/client/src/components/infoTooltip.tsx
@@ -13,7 +13,7 @@ export function InfoTooltip({ label }: InfoTooltipProps) {
       style={{ backgroundColor: "rgba(0, 0, 0, 0.875)" }}
     >
       <svg
-        className="usa-icon margin-left-05 text-base"
+        className="usa-icon margin-right-05 text-base"
         aria-hidden="true"
         focusable="false"
         role="img"
@@ -32,8 +32,8 @@ type TextWithTooltipProps = {
 export function TextWithTooltip({ text, tooltip }: TextWithTooltipProps) {
   return (
     <span className="display-flex flex-align-center text-no-wrap">
-      {text}
       <InfoTooltip label={tooltip} />
+      {text}
     </span>
   );
 }

--- a/app/client/src/components/welcome.tsx
+++ b/app/client/src/components/welcome.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import icons from "uswds/img/sprite.svg";
 // ---
-import { serverUrlForLinks, messages } from "../config";
+import { serverUrlForHrefs, messages } from "../config";
 import Message from "components/message";
 
 export default function Welcome() {
@@ -84,7 +84,7 @@ export default function Welcome() {
 
         <a
           className="usa-button margin-top-1 margin-right-0 font-sans-2xs"
-          href={`${serverUrlForLinks}/login`}
+          href={`${serverUrlForHrefs}/login`}
         >
           <span className="display-flex flex-align-center">
             <span className="margin-right-1">Sign in</span>

--- a/app/client/src/components/welcome.tsx
+++ b/app/client/src/components/welcome.tsx
@@ -35,11 +35,11 @@ export default function Welcome() {
       });
     }
 
-    if (searchParams.get("error") === "sam-fetch") {
+    if (searchParams.get("error") === "bap-fetch") {
       setMessage({
         displayed: true,
         type: "error",
-        text: messages.samFetchError,
+        text: messages.bapFetchError,
       });
     }
 
@@ -47,7 +47,7 @@ export default function Welcome() {
       setMessage({
         displayed: true,
         type: "info",
-        text: messages.samNoResults,
+        text: messages.noSamResults,
       });
     }
 

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -55,7 +55,7 @@ export const messages = {
   authError: "Authentication error. Please log in again or contact support.",
   samlError: "Error logging in. Please try again or contact support.",
   bapFetchError:
-    "Error retrieving SAM.gov or rebate submission data. Please contact support.",
+    "Error loading SAM.gov or rebate submission data. Please contact support.",
   noSamResults:
     "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
   rebateSubmissionsError: "Error loading rebate form submissions.",

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -54,7 +54,8 @@ export const messages = {
   genericError: "Something went wrong.",
   authError: "Authentication error. Please log in again or contact support.",
   samlError: "Error logging in. Please try again or contact support.",
-  bapFetchError: "Error retrieving SAM.gov data. Please contact support.",
+  bapFetchError:
+    "Error retrieving SAM.gov or rebate submission data. Please contact support.",
   noSamResults:
     "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
   rebateSubmissionsError: "Error loading rebate form submissions.",

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -55,8 +55,8 @@ export const messages = {
   genericError: "Something went wrong.",
   authError: "Authentication error. Please log in again or contact support.",
   samlError: "Error logging in. Please try again or contact support.",
-  samFetchError: "Error retrieving SAM.gov data. Please contact support.",
-  samNoResults:
+  bapFetchError: "Error retrieving SAM.gov data. Please contact support.",
+  noSamResults:
     "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
   rebateSubmissionsError: "Error loading rebate form submissions.",
   newRebateApplication:

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -35,11 +35,10 @@ export const serverBasePath =
 // is needed for production.
 export const serverUrl = window.location.origin + serverBasePath;
 
-// NOTE: This local development setup unfortunately doesn't proxy GET requests
-// from links though because they set an "Accept" request header to "text/html",
-// so we need to use a different environment variable for when the serverUrl is
-// used in the href of anchor tags (e.g. login and logout links).
-export const serverUrlForLinks =
+// NOTE: Create React App's local development proxy setup doesn't proxy requests
+// that set an "Accept" request header to "text/html", so in those cases we need
+// to explicitly use the server app's URL/port (localhost:3001)
+export const serverUrlForHrefs =
   NODE_ENV === "development" ? "http://localhost:3001" : serverUrl;
 
 export const cloudSpace =

--- a/app/client/src/contexts/user.tsx
+++ b/app/client/src/contexts/user.tsx
@@ -53,6 +53,17 @@ export type SamEntityData = {
   attributes: { type: string; url: string };
 };
 
+type BapSubmissionData = {
+  CSB_Form_ID__c: string; // MongoDB ObjectId string
+  CSB_Review_Item_ID__c: string;
+  UEI_EFTI_Combo_Key__c: string;
+  Parent_CSB_Rebate__r: {
+    CSB_Rebate_Status__c: "Draft" | "Submitted" | "Edits Requested";
+    attributes: { type: string; url: string };
+  };
+  attributes: { type: string; url: string };
+};
+
 type State = {
   isAuthenticating: boolean;
   isAuthenticated: boolean;
@@ -72,8 +83,16 @@ type State = {
     | {
         status: "success";
         data:
-          | { samResults: true; samEntities: SamEntityData[] }
-          | { samResults: false; samEntities: [] };
+          | {
+              samResults: false;
+              samEntities: [];
+              rebateSubmissions: [];
+            }
+          | {
+              samResults: true;
+              samEntities: SamEntityData[];
+              rebateSubmissions: BapSubmissionData[];
+            };
       }
     | { status: "failure"; data: {} };
 };
@@ -98,8 +117,16 @@ type Action =
       type: "FETCH_BAP_USER_DATA_SUCCESS";
       payload: {
         bapUserData:
-          | { samResults: true; samEntities: SamEntityData[] }
-          | { samResults: false; samEntities: [] };
+          | {
+              samResults: false;
+              samEntities: [];
+              rebateSubmissions: [];
+            }
+          | {
+              samResults: true;
+              samEntities: SamEntityData[];
+              rebateSubmissions: BapSubmissionData[];
+            };
       };
     }
   | { type: "FETCH_BAP_USER_DATA_FAILURE" };

--- a/app/client/src/contexts/user.tsx
+++ b/app/client/src/contexts/user.tsx
@@ -55,6 +55,7 @@ export type SamEntityData = {
 
 type BapSubmissionData = {
   CSB_Form_ID__c: string; // MongoDB ObjectId string
+  CSB_Form_Modified__c: string; // ISO 8601 date string
   CSB_Review_Item_ID__c: string;
   UEI_EFTI_Combo_Key__c: string;
   Parent_CSB_Rebate__r: {

--- a/app/client/src/contexts/user.tsx
+++ b/app/client/src/contexts/user.tsx
@@ -10,8 +10,11 @@ type Props = {
   children: ReactNode;
 };
 
-type EpaUserData = {
+type CsbData = {
   enrollmentClosed: boolean;
+};
+
+type EpaUserData = {
   mail: string;
   memberof: string;
   exp: number;
@@ -53,6 +56,11 @@ export type SamEntityData = {
 type State = {
   isAuthenticating: boolean;
   isAuthenticated: boolean;
+  csbData:
+    | { status: "idle"; data: {} }
+    | { status: "pending"; data: {} }
+    | { status: "success"; data: CsbData }
+    | { status: "failure"; data: {} };
   epaUserData:
     | { status: "idle"; data: {} }
     | { status: "pending"; data: {} }
@@ -73,12 +81,16 @@ type State = {
 type Action =
   | { type: "USER_SIGN_IN" }
   | { type: "USER_SIGN_OUT" }
+  | { type: "FETCH_CSB_DATA_REQUEST" }
+  | {
+      type: "FETCH_CSB_DATA_SUCCESS";
+      payload: { csbData: CsbData };
+    }
+  | { type: "FETCH_CSB_DATA_FAILURE" }
   | { type: "FETCH_EPA_USER_DATA_REQUEST" }
   | {
       type: "FETCH_EPA_USER_DATA_SUCCESS";
-      payload: {
-        epaUserData: EpaUserData;
-      };
+      payload: { epaUserData: EpaUserData };
     }
   | { type: "FETCH_EPA_USER_DATA_FAILURE" }
   | { type: "FETCH_BAP_USER_DATA_REQUEST" }
@@ -110,12 +122,47 @@ function reducer(state: State, action: Action): State {
         ...state,
         isAuthenticating: false,
         isAuthenticated: false,
+        csbData: {
+          status: "idle",
+          data: {},
+        },
         epaUserData: {
           status: "idle",
           data: {},
         },
         bapUserData: {
           status: "idle",
+          data: {},
+        },
+      };
+    }
+
+    case "FETCH_CSB_DATA_REQUEST": {
+      return {
+        ...state,
+        csbData: {
+          status: "pending",
+          data: {},
+        },
+      };
+    }
+
+    case "FETCH_CSB_DATA_SUCCESS": {
+      const { csbData } = action.payload;
+      return {
+        ...state,
+        csbData: {
+          status: "success",
+          data: csbData,
+        },
+      };
+    }
+
+    case "FETCH_CSB_DATA_FAILURE": {
+      return {
+        ...state,
+        csbData: {
+          status: "failure",
           data: {},
         },
       };
@@ -193,6 +240,10 @@ export function UserProvider({ children }: Props) {
   const initialState: State = {
     isAuthenticating: true,
     isAuthenticated: false,
+    csbData: {
+      status: "idle",
+      data: {},
+    },
     epaUserData: {
       status: "idle",
       data: {},

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -54,9 +54,8 @@ export default function AllRebates() {
   }
 
   /**
-   * Formio submissions, merged with the CSB rebate status returned from the
-   * submission data returned from the BAP: currently only used to handle
-   * submitted submissions that require edits (via the "Edits Requested" status)
+   * Formio submissions, merged with rebate submissions returned from the BAP,
+   * so we can include CSB rebate status and CSB review item ID
    */
   const submissions = rebateFormSubmissions.data.map((formioSubmission) => {
     const matchedSubmission = bapUserData.data.rebateSubmissions.find(
@@ -66,8 +65,11 @@ export default function AllRebates() {
     return {
       ...formioSubmission,
       bap: {
+        applicationId: matchedSubmission
+          ? matchedSubmission?.CSB_Review_Item_ID__c
+          : null,
         rebateStatus: matchedSubmission
-          ? matchedSubmission.Parent_CSB_Rebate__r.CSB_Rebate_Status__c
+          ? matchedSubmission?.Parent_CSB_Rebate__r?.CSB_Rebate_Status__c
           : null,
       },
     };
@@ -254,10 +256,14 @@ form for the fields to be displayed. */
                         </th>
 
                         <td className={statusStyles}>
-                          <TextWithTooltip
-                            text=" "
-                            tooltip="Application ID will be displayed within 24hrs. after starting a new rebate form application"
-                          />
+                          {bap.applicationId ? (
+                            bap.applicationId
+                          ) : (
+                            <TextWithTooltip
+                              text=" "
+                              tooltip="Application ID will be displayed within 24hrs. after starting a new rebate form application"
+                            />
+                          )}
                         </td>
 
                         <td className={statusStyles}>

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -181,10 +181,11 @@ export default function AllRebates() {
                     state === "submitted" &&
                     bap.rebateStatus === "Edits Requested";
 
-                  const statusStyles =
-                    enrollmentClosed || state === "submitted"
-                      ? "text-italic text-base-dark"
-                      : "";
+                  const statusClassNames = submissionNeedsEdits
+                    ? "csb-needs-edits"
+                    : enrollmentClosed || state === "submitted"
+                    ? "text-italic text-base-dark"
+                    : "";
 
                   /* NOTE: when a form is first initially created, and the user
 has not yet clicked the "Next" or "Save" buttons, any fields that the formio
@@ -200,7 +201,7 @@ form for the fields to be displayed. */
                   return (
                     <Fragment key={_id}>
                       <tr>
-                        <th scope="row">
+                        <th scope="row" className={statusClassNames}>
                           {submissionNeedsEdits ? (
                             <button
                               className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
@@ -268,7 +269,7 @@ form for the fields to be displayed. */
                           ) : null}
                         </th>
 
-                        <td className={statusStyles}>
+                        <td className={statusClassNames}>
                           {bap.applicationId ? (
                             bap.applicationId
                           ) : (
@@ -279,7 +280,7 @@ form for the fields to be displayed. */
                           )}
                         </td>
 
-                        <td className={statusStyles}>
+                        <td className={statusClassNames}>
                           <span title={_id}>Application</span>
                           <br />
                           <span className="display-flex flex-align-center font-sans-2xs">
@@ -307,7 +308,7 @@ form for the fields to be displayed. */
                           </span>
                         </td>
 
-                        <td className={statusStyles}>
+                        <td className={statusClassNames}>
                           <>
                             {Boolean(applicantUEI) ? (
                               applicantUEI
@@ -370,7 +371,7 @@ save the form for the EFT indicator to be displayed. */
                           </>
                         </td>
 
-                        <td className={statusStyles}>
+                        <td className={statusClassNames}>
                           <>
                             {Boolean(applicantOrganizationName) ? (
                               applicantOrganizationName
@@ -392,7 +393,7 @@ save the form for the EFT indicator to be displayed. */
                           </>
                         </td>
 
-                        <td className={statusStyles}>
+                        <td className={statusClassNames}>
                           {last_updated_by}
                           <br />
                           <span title={`${date} ${time}`}>{date}</span>

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -56,7 +56,8 @@ export default function AllRebates() {
 
   /**
    * Formio submissions, merged with rebate submissions returned from the BAP,
-   * so we can include CSB rebate status and CSB review item ID
+   * so we can include CSB rebate status, CSB review item ID, and last updated
+   * datetime.
    */
   const submissions = rebateFormSubmissions.data.map((formioSubmission) => {
     const matchedSubmission = bapUserData.data.rebateSubmissions.find(
@@ -180,14 +181,18 @@ export default function AllRebates() {
                   const date = new Date(modified).toLocaleDateString();
                   const time = new Date(modified).toLocaleTimeString();
 
-                  /** the submission has been updated since the last time the
-                   * BAP's submissions ETL process has succesfully run */
+                  /**
+                   * The submission has been updated since the last time the
+                   * BAP's submissions ETL process has succesfully run.
+                   */
                   const submissionHasBeenUpdated = bap.lastModified
                     ? new Date(modified) > new Date(bap.lastModified)
                     : false;
 
-                  /** the previously submitted submission has been flagged by
-                   * EPA as needing edits, and it has not yet been updated */
+                  /**
+                   * The previously submitted submission has been flagged by
+                   * EPA as needing edits, and it has not yet been updated.
+                   */
                   const submissionNeedsEdits =
                     state === "submitted" &&
                     bap.rebateStatus === "Edits Requested" &&

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -13,7 +13,7 @@ import { useFormsState, useFormsDispatch } from "contexts/forms";
 
 export default function AllRebates() {
   const { content } = useContentState();
-  const { epaUserData, bapUserData } = useUserState();
+  const { csbData, bapUserData } = useUserState();
   const { rebateFormSubmissions } = useFormsState();
   const dispatch = useFormsDispatch();
 
@@ -147,8 +147,8 @@ export default function AllRebates() {
 
                   const statusStyles =
                     state === "submitted" ||
-                    (epaUserData.status === "success" &&
-                      epaUserData.data?.enrollmentClosed)
+                    (csbData.status === "success" &&
+                      csbData.data.enrollmentClosed)
                       ? "text-italic text-base-dark"
                       : "";
 

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { Fragment, useEffect } from "react";
 import { Link } from "react-router-dom";
 import icons from "uswds/img/sprite.svg";
 // ---
@@ -72,12 +72,22 @@ export default function AllRebates() {
                   <th scope="col">
                     <span className="usa-sr-only">Open</span>
                   </th>
+
+                  <th scope="col">
+                    <TextWithTooltip text="Application ID" tooltip="..." />
+                  </th>
+
                   <th scope="col">
                     <TextWithTooltip
-                      text="Form Type &nbsp;•&nbsp; Form Status"
-                      tooltip="Application, Payment Request, or Close-Out &nbsp;•&nbsp; submitted or draft"
+                      text="Form Type"
+                      tooltip="Application, Payment Request, or Close-Out"
+                    />
+                    <TextWithTooltip
+                      text="Form Status"
+                      tooltip="submitted or draft"
                     />
                   </th>
+
                   <th scope="col">
                     <TextWithTooltip
                       text="UEI"
@@ -88,6 +98,7 @@ export default function AllRebates() {
                       tooltip="Electronic Funds Transfer Indicator listing the associated bank account from SAM.gov"
                     />
                   </th>
+
                   <th scope="col">
                     <TextWithTooltip
                       text="Applicant"
@@ -98,6 +109,7 @@ export default function AllRebates() {
                       tooltip="School district represented by applicant"
                     />
                   </th>
+
                   <th scope="col">
                     <TextWithTooltip
                       text="Updated By"
@@ -110,6 +122,7 @@ export default function AllRebates() {
                   </th>
                 </tr>
               </thead>
+
               <tbody>
                 {rebateFormSubmissions.data.map((submission) => {
                   const { _id, state, modified, data } = submission;
@@ -144,15 +157,44 @@ believe is a bit of an edge case, as most users will likely do that after
 starting a new application), indicate to the user they need to first save the
 form for the fields to be displayed. */
                   return (
-                    <tr key={_id}>
-                      <th scope="row">
-                        <Link
-                          to={`/rebate/${_id}`}
-                          className={`usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1 ${
-                            state === "submitted" && "usa-button--base"
-                          }`}
-                        >
-                          <span className="display-flex flex-align-center">
+                    <Fragment key={_id}>
+                      <tr>
+                        <th scope="row">
+                          <Link
+                            to={`/rebate/${_id}`}
+                            className={`usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1 ${
+                              state === "submitted" && "usa-button--base"
+                            }`}
+                          >
+                            <span className="display-flex flex-align-center">
+                              <svg
+                                className="usa-icon"
+                                aria-hidden="true"
+                                focusable="false"
+                                role="img"
+                              >
+                                <use
+                                  href={
+                                    state === "draft"
+                                      ? `${icons}#edit`
+                                      : `${icons}#visibility`
+                                  }
+                                />
+                              </svg>
+                              <span className="margin-left-1">
+                                {state === "draft" && <>Edit</>}
+                                {state === "submitted" && <>View</>}
+                              </span>
+                            </span>
+                          </Link>
+                        </th>
+
+                        <td className={statusStyles}>&nbsp;</td>
+
+                        <td className={statusStyles}>
+                          <span title={_id}>Application</span>
+                          <br />
+                          <span className="display-flex flex-align-center font-sans-2xs">
                             <svg
                               className="usa-icon"
                               aria-hidden="true"
@@ -162,37 +204,28 @@ form for the fields to be displayed. */
                               <use
                                 href={
                                   state === "draft"
-                                    ? `${icons}#edit`
-                                    : `${icons}#visibility`
+                                    ? `${icons}#remove`
+                                    : `${icons}#check`
                                 }
                               />
                             </svg>
-                            <span className="margin-left-1">
-                              {state === "draft" && <>Edit</>}
-                              {state === "submitted" && <>View</>}
-                            </span>
+                            <span className="margin-left-05">{state}</span>
                           </span>
-                        </Link>
-                      </th>
+                        </td>
 
-                      <td className={statusStyles}>
-                        <span title={_id}>
-                          Application &nbsp;•&nbsp; {state}
-                        </span>
-                      </td>
-                      <td className={statusStyles}>
-                        <>
-                          {Boolean(applicantUEI) ? (
-                            applicantUEI
-                          ) : (
-                            <TextWithTooltip
-                              text=" "
-                              tooltip="Please edit and save the form and the UEI will be displayed"
-                            />
-                          )}
-                          <br />
-                          {
-                            /* NOTE:
+                        <td className={statusStyles}>
+                          <>
+                            {Boolean(applicantUEI) ? (
+                              applicantUEI
+                            ) : (
+                              <TextWithTooltip
+                                text=" "
+                                tooltip="Please edit and save the form and the UEI will be displayed"
+                              />
+                            )}
+                            <br />
+                            {
+                              /* NOTE:
 The initial version of the rebate form definition included the `applicantEfti`
 field, which is configured via the form definition (in formio/forms.gov) to set
 its value based on the value of the `sam_hidden_applicant_efti` field, which we
@@ -205,9 +238,9 @@ definition to set it's value to the string '0000' if the `applicantEfti` field's
 value is an empty string. This logic (again, built into the form definition)
 works great for new form submissions that have taken place after the form
 definition has been updated to include this `applicantEfti_display` field... */
-                            Boolean(applicantEfti_display) ? (
-                              applicantEfti_display
-                            ) : /* NOTE:
+                              Boolean(applicantEfti_display) ? (
+                                applicantEfti_display
+                              ) : /* NOTE:
 ...but we need to handle old/existing submissions that were submitted before the
 form definition was updated to include the new `applicantEfti_display` field,
 and where the user has already advanced past the first screen (e.g. they've hit
@@ -222,53 +255,56 @@ truthy. We'll check the `applicantUEI` field's value, as it's value will always
 be set for users that have advanced past the first screen (we could have just as
 easily used another field, like the `applicantOrganizationName` field for the
 same result). */
-                            Boolean(applicantUEI) ? (
-                              /* NOTE:
+                              Boolean(applicantUEI) ? (
+                                /* NOTE:
 If the `applicantUEI` field's value is truthy, we know the user has advanced
 past the first screen, so we'll render the value of the `applicantEfti` field,
 and fall back to "0000", which will be used in cases where the `applicantEfti`
 field's value is an empty string. */
-                              applicantEfti || "0000"
-                            ) : (
-                              /* NOTE:
+                                applicantEfti || "0000"
+                              ) : (
+                                /* NOTE:
 At this point in the conditional logic, we know the user has not advanced past
 the first screen, so we'll render the tooltip, indicating the user must edit and
 save the form for the EFT indicator to be displayed. */
+                                <TextWithTooltip
+                                  text=" "
+                                  tooltip="Please edit and save the form and the EFT Indicator will be displayed"
+                                />
+                              )
+                            }
+                          </>
+                        </td>
+
+                        <td className={statusStyles}>
+                          <>
+                            {Boolean(applicantOrganizationName) ? (
+                              applicantOrganizationName
+                            ) : (
                               <TextWithTooltip
                                 text=" "
-                                tooltip="Please edit and save the form and the EFT Indicator will be displayed"
+                                tooltip="Please edit and save the form and the Applicant will be displayed"
                               />
-                            )
-                          }
-                        </>
-                      </td>
-                      <td className={statusStyles}>
-                        <>
-                          {Boolean(applicantOrganizationName) ? (
-                            applicantOrganizationName
-                          ) : (
-                            <TextWithTooltip
-                              text=" "
-                              tooltip="Please edit and save the form and the Applicant will be displayed"
-                            />
-                          )}
+                            )}
+                            <br />
+                            {Boolean(schoolDistrictName) ? (
+                              schoolDistrictName
+                            ) : (
+                              <TextWithTooltip
+                                text=" "
+                                tooltip="School District will be displayed after that field has been entered in the form"
+                              />
+                            )}
+                          </>
+                        </td>
+
+                        <td className={statusStyles}>
+                          {last_updated_by}
                           <br />
-                          {Boolean(schoolDistrictName) ? (
-                            schoolDistrictName
-                          ) : (
-                            <TextWithTooltip
-                              text=" "
-                              tooltip="School District will be displayed after that field has been entered in the form"
-                            />
-                          )}
-                        </>
-                      </td>
-                      <td className={statusStyles}>
-                        {last_updated_by}
-                        <br />
-                        <span title={`${date} ${time}`}>{date}</span>
-                      </td>
-                    </tr>
+                          <span title={`${date} ${time}`}>{date}</span>
+                        </td>
+                      </tr>
+                    </Fragment>
                   );
                 })}
               </tbody>

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -74,7 +74,10 @@ export default function AllRebates() {
                   </th>
 
                   <th scope="col">
-                    <TextWithTooltip text="Application ID" tooltip="..." />
+                    <TextWithTooltip
+                      text="Application ID"
+                      tooltip="Unique Clean School Bus Application ID"
+                    />
                   </th>
 
                   <th scope="col">
@@ -82,6 +85,7 @@ export default function AllRebates() {
                       text="Form Type"
                       tooltip="Application, Payment Request, or Close-Out"
                     />
+                    <br />
                     <TextWithTooltip
                       text="Form Status"
                       tooltip="submitted or draft"
@@ -93,6 +97,7 @@ export default function AllRebates() {
                       text="UEI"
                       tooltip="Unique Entity ID from SAM.gov"
                     />
+                    <br />
                     <TextWithTooltip
                       text="EFT Indicator"
                       tooltip="Electronic Funds Transfer Indicator listing the associated bank account from SAM.gov"
@@ -104,6 +109,7 @@ export default function AllRebates() {
                       text="Applicant"
                       tooltip="Legal Business Name from SAM.gov for this UEI"
                     />
+                    <br />
                     <TextWithTooltip
                       text="School District"
                       tooltip="School district represented by applicant"
@@ -115,6 +121,7 @@ export default function AllRebates() {
                       text="Updated By"
                       tooltip="Last person that updated this form"
                     />
+                    <br />
                     <TextWithTooltip
                       text="Date Updated"
                       tooltip="Last date this form was updated"
@@ -189,7 +196,12 @@ form for the fields to be displayed. */
                           </Link>
                         </th>
 
-                        <td className={statusStyles}>&nbsp;</td>
+                        <td className={statusStyles}>
+                          <TextWithTooltip
+                            text=" "
+                            tooltip="Application ID will be displayed within 24hrs. after starting a new rebate form application"
+                          />
+                        </td>
 
                         <td className={statusStyles}>
                           <span title={_id}>Application</span>

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -119,7 +119,7 @@ export default function AllRebates() {
                   <th scope="col">
                     <TextWithTooltip
                       text="Form Type"
-                      tooltip="Application, Payment Request, or Close-Out"
+                      tooltip="Application, Payment Request, or Close-Out form"
                     />
                     <br />
                     <TextWithTooltip

--- a/app/client/src/routes/existingRebate.tsx
+++ b/app/client/src/routes/existingRebate.tsx
@@ -233,7 +233,7 @@ function ExistingRebateContent() {
   const navigate = useNavigate();
   const { id } = useParams<"id">();
   const { content } = useContentState();
-  const { epaUserData, bapUserData } = useUserState();
+  const { csbData, epaUserData, bapUserData } = useUserState();
   const dispatch = useExistingRebateDispatch();
 
   const [rebateFormSubmission, setRebateFormSubmission] =
@@ -337,7 +337,11 @@ function ExistingRebateContent() {
     );
   }
 
-  if (epaUserData.status !== "success" || bapUserData.status !== "success") {
+  if (
+    csbData.status !== "success" ||
+    epaUserData.status !== "success" ||
+    bapUserData.status !== "success"
+  ) {
     return <Loading />;
   }
 
@@ -390,7 +394,7 @@ function ExistingRebateContent() {
           options={{
             readOnly:
               submissionData.state === "submitted" ||
-              epaUserData.data.enrollmentClosed
+              csbData.data.enrollmentClosed
                 ? true
                 : false,
             noAlerts: true,

--- a/app/client/src/routes/newRebate.tsx
+++ b/app/client/src/routes/newRebate.tsx
@@ -41,7 +41,7 @@ function createNewRebate(email: string, entity: SamEntityData) {
 export default function NewRebate() {
   const navigate = useNavigate();
   const { content } = useContentState();
-  const { epaUserData, bapUserData } = useUserState();
+  const { csbData, epaUserData, bapUserData } = useUserState();
 
   const [message, setMessage] = useState<{
     displayed: boolean;
@@ -53,7 +53,11 @@ export default function NewRebate() {
     text: "",
   });
 
-  if (epaUserData.status !== "success" || bapUserData.status !== "success") {
+  if (
+    csbData.status !== "success" ||
+    epaUserData.status !== "success" ||
+    bapUserData.status !== "success"
+  ) {
     return <Loading />;
   }
 
@@ -73,7 +77,7 @@ export default function NewRebate() {
         >
           <div className="usa-modal__content">
             <div className="usa-modal__main">
-              {epaUserData.data.enrollmentClosed ? (
+              {csbData.data.enrollmentClosed ? (
                 <Message type="info" text={messages.enrollmentClosed} />
               ) : activeSamEntities.length <= 0 ? (
                 <Message type="info" text={messages.samNoResults} />

--- a/app/client/src/routes/newRebate.tsx
+++ b/app/client/src/routes/newRebate.tsx
@@ -80,7 +80,7 @@ export default function NewRebate() {
               {csbData.data.enrollmentClosed ? (
                 <Message type="info" text={messages.enrollmentClosed} />
               ) : activeSamEntities.length <= 0 ? (
-                <Message type="info" text={messages.samNoResults} />
+                <Message type="info" text={messages.noSamResults} />
               ) : (
                 <>
                   {content.status === "success" && (

--- a/app/client/src/styles.css
+++ b/app/client/src/styles.css
@@ -55,3 +55,8 @@
 [data-reach-tooltip] {
   z-index: 100000;
 }
+
+/* --- CSB --- */
+.csb-needs-edits {
+  background-color: #d9e8f6 !important; /* USWDS primary-lighter */
+}

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -93,15 +93,16 @@ router.get("/helpdesk-access", ensureHelpdesk, (req, res) => {
   res.sendStatus(200);
 });
 
-// --- get data from EPA Gateway/Login.gov
+// --- get CSB app specific data (open enrollment status, etc.)
+router.get("/csb-data", (req, res) => {
+  const enrollmentClosed = process.env.CSB_ENROLLMENT_PERIOD === "closed";
+  res.json({ enrollmentClosed });
+});
+
+// --- get user data from EPA Gateway/Login.gov
 router.get("/epa-data", (req, res) => {
-  // Explicitly return only required attributes from user info
-  res.json({
-    enrollmentClosed: process.env.CSB_ENROLLMENT_PERIOD === "closed",
-    mail: req.user.mail,
-    memberof: req.user.memberof,
-    exp: req.user.exp,
-  });
+  const { mail, memberof, exp } = req.user;
+  res.json({ mail, memberof, exp });
 });
 
 // --- get data from EPA's Business Automation Platform (BAP)

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -194,9 +194,9 @@ function queryForRebateFormSubmissions(comboKeys, req) {
     .query(
       `
         SELECT
-          id,
+          CSB_Form_ID__c,
           CSB_Review_Item_ID__c,
-          Parent_CSB_Rebate__r.id,
+          UEI_EFTI_Combo_Key__c,
           Parent_CSB_Rebate__r.CSB_Rebate_Status__c
         FROM
           ${BAP_FORMS_TABLE}

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -195,6 +195,7 @@ function queryForRebateFormSubmissions(comboKeys, req) {
       `
         SELECT
           CSB_Form_ID__c,
+          CSB_Form_Modified__c,
           CSB_Review_Item_ID__c,
           UEI_EFTI_Combo_Key__c,
           Parent_CSB_Rebate__r.CSB_Rebate_Status__c


### PR DESCRIPTION
Fetches data from the BAP team's web service to determine if a submission requires edits, and also to display the new CSB Application ID on the user's all submissions table.

Also improves the UX of the all submissions table by re-organizing the columns displayed in a more condensed manner.

Additionally, moves the client-side validation check that a user has access to the app into a new web service endpoint that returns whether the program's enrollment period is open or closed (as that was shoved into the "epa-data" web service in a previous commit, as a quick change – this improves it's functionality in a bit cleaner manner.