### PR TITLE
Feature/fix verify user check

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -220,22 +220,22 @@ function ProtectedRoute({ children }: { children: JSX.Element }) {
 
   // Check if user is already logged in or needs to be redirected to /welcome route
   const verifyUser = useCallback(() => {
-    fetchData(`${serverUrl}/api/csb-data`)
+    fetchData(`${serverUrl}/api/epa-data`)
       .then((res) => {
         dispatch({
-          type: "FETCH_CSB_DATA_SUCCESS",
-          payload: { csbData: res },
+          type: "FETCH_EPA_USER_DATA_SUCCESS",
+          payload: { epaUserData: res },
         });
         dispatch({ type: "USER_SIGN_IN" });
       })
       .catch((err) => {
-        dispatch({ type: "FETCH_CSB_DATA_FAILURE" });
+        dispatch({ type: "FETCH_EPA_USER_DATA_FAILURE" });
         dispatch({ type: "USER_SIGN_OUT" });
       });
   }, [dispatch]);
 
   useEffect(() => {
-    dispatch({ type: "FETCH_CSB_DATA_REQUEST" });
+    dispatch({ type: "FETCH_EPA_USER_DATA_REQUEST" });
     verifyUser();
   }, [verifyUser, dispatch, pathname]);
 

--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -22,21 +22,21 @@ Formio.setProjectUrl(formioProjectUrl);
 Formio.use(premium);
 Formio.use(uswds);
 
-// Custom hook to fetch EPA data
-function useFetchedEpaData() {
+// Custom hook to fetch CSP app specific data
+function useFetchedCsbData() {
   const dispatch = useUserDispatch();
 
   useEffect(() => {
-    dispatch({ type: "FETCH_EPA_USER_DATA_REQUEST" });
-    fetchData(`${serverUrl}/api/epa-data`)
+    dispatch({ type: "FETCH_CSB_DATA_REQUEST" });
+    fetchData(`${serverUrl}/api/csb-data`)
       .then((res) => {
         dispatch({
-          type: "FETCH_EPA_USER_DATA_SUCCESS",
-          payload: { epaUserData: res },
+          type: "FETCH_CSB_DATA_SUCCESS",
+          payload: { csbData: res },
         });
       })
       .catch((err) => {
-        dispatch({ type: "FETCH_EPA_USER_DATA_FAILURE" });
+        dispatch({ type: "FETCH_CSB_DATA_FAILURE" });
       });
   }, [dispatch]);
 }
@@ -108,7 +108,7 @@ export default function Dashboard() {
   const dispatch = useDialogDispatch();
   const helpdeskAccess = useHelpdeskAccess();
 
-  useFetchedEpaData();
+  useFetchedCsbData();
   useFetchedBapData();
 
   /**


### PR DESCRIPTION
Update verifyUser callback to fetch data from /epa-data again, so the stored user's exp number is updated every time the token is refreshed on the server.

This really just reverts a change introduced recently where the new "/csb-data" server endpoint was used instead of the "/epa-data" server endpoint to attempt user verification. The issue was the "/csb-data" endpoint doesn't return the JWT's expiration time, only the "/epa-data" endpoint does. We store that value in the client (in React context state) every time the "/epa-data" endpoint it hit, which I changed to be **once** in a previous commit (whoops!).

Since the "/csb-data" server endpoint **doesn't** return the updated JWT's expiration time from the server (which is refreshed on the server every request), and the `useIdleTimer`'s onAction function used the stored JWT expiration value in the client (which was stored once and never updated every request), it would cause issues after 12 minutes, and kick the user out after 15 minutes.

cc: @coobr01 