### PR TITLE
Feature/apply dashboard updates

### DIFF
--- a/app/client/src/contexts/user.tsx
+++ b/app/client/src/contexts/user.tsx
@@ -56,8 +56,8 @@ export type SamEntityData = {
 type BapSubmissionData = {
   CSB_Form_ID__c: string; // MongoDB ObjectId string
   CSB_Form_Modified__c: string; // ISO 8601 date string
-  CSB_Review_Item_ID__c: string;
   UEI_EFTI_Combo_Key__c: string;
+  Parent_Rebate_ID__c: string; // CSB Rebate ID
   Parent_CSB_Rebate__r: {
     CSB_Rebate_Status__c: "Draft" | "Submitted" | "Edits Requested";
     attributes: { type: string; url: string };

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -81,7 +81,7 @@ export default function AllRebates() {
           ? matchedSubmission?.CSB_Form_Modified__c
           : null,
         rebateId: matchedSubmission
-          ? matchedSubmission?.CSB_Review_Item_ID__c
+          ? matchedSubmission?.Parent_Rebate_ID__c
           : null,
         rebateStatus: matchedSubmission
           ? matchedSubmission?.Parent_CSB_Rebate__r?.CSB_Rebate_Status__c

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -77,11 +77,11 @@ export default function AllRebates() {
     return {
       ...formioSubmission,
       bap: {
-        applicationId: matchedSubmission
-          ? matchedSubmission?.CSB_Review_Item_ID__c
-          : null,
         lastModified: matchedSubmission
           ? matchedSubmission?.CSB_Form_Modified__c
+          : null,
+        rebateId: matchedSubmission
+          ? matchedSubmission?.CSB_Review_Item_ID__c
           : null,
         rebateStatus: matchedSubmission
           ? matchedSubmission?.Parent_CSB_Rebate__r?.CSB_Rebate_Status__c
@@ -125,8 +125,8 @@ export default function AllRebates() {
 
                   <th scope="col">
                     <TextWithTooltip
-                      text="Application ID"
-                      tooltip="Unique Clean School Bus Application ID"
+                      text="Rebate ID"
+                      tooltip="Unique Clean School Bus Rebate ID"
                     />
                   </th>
 
@@ -258,7 +258,7 @@ form for the fields to be displayed. */
                                     setMessage({
                                       displayed: true,
                                       type: "error",
-                                      text: `Error updating Application ${bap.applicationId}. Please try again.`,
+                                      text: `Error updating Rebate ${bap.rebateId}. Please try again.`,
                                     });
                                   });
                               }}
@@ -313,14 +313,14 @@ form for the fields to be displayed. */
                         </th>
 
                         <td className={statusClassNames}>
-                          {bap.applicationId ? (
+                          {bap.rebateId ? (
                             <span title={`Form ID: ${_id}`}>
-                              {bap.applicationId}
+                              {bap.rebateId}
                             </span>
                           ) : (
                             <TextWithTooltip
                               text=" "
-                              tooltip="Application ID will be displayed within 24hrs. after starting a new rebate form application"
+                              tooltip="Rebate ID will be displayed within 24hrs. after starting a new rebate form application"
                             />
                           )}
                         </td>

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -320,7 +320,7 @@ form for the fields to be displayed. */
                           ) : (
                             <TextWithTooltip
                               text=" "
-                              tooltip="Rebate ID will be displayed within 24hrs. after starting a new rebate form application"
+                              tooltip="Please edit and save the form and the Rebate ID will be displayed"
                             />
                           )}
                         </td>

--- a/app/server/app/content/all-rebates-intro.md
+++ b/app/server/app/content/all-rebates-intro.md
@@ -1,3 +1,3 @@
 ## Your Rebate Forms
 
-Select the pencil icon to open an existing rebate form.
+Select a button below to _Edit_ or _View_ an existing rebate form.

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -196,8 +196,8 @@ function queryForRebateFormSubmissions(comboKeys, req) {
         SELECT
           CSB_Form_ID__c,
           CSB_Form_Modified__c,
-          CSB_Review_Item_ID__c,
           UEI_EFTI_Combo_Key__c,
+          Parent_Rebate_ID__c,
           Parent_CSB_Rebate__r.CSB_Rebate_Status__c
         FROM
           ${BAP_FORMS_TABLE}


### PR DESCRIPTION
Various dashboard (all rebates table) updates:
- Renames "Application ID" column to "Rebate ID" and gets the value from the BAP from a different field/column
- Updates text displayed above the table to reflect lates UI changes w/ the "Edit" and "View" buttons
- Updates the tooltip displayed when a "Rebate ID" doesn't yet exist for a submission (still may be a 24 hour delay before the data is pulled into the BAP's ETL process, so we may consider including that info in the tooltip...or maybe just helpdesk documentation).