### PR TITLE
Feature/update modified datetime field from bap

### DIFF
--- a/app/client/src/contexts/user.tsx
+++ b/app/client/src/contexts/user.tsx
@@ -55,7 +55,7 @@ export type SamEntityData = {
 
 type BapSubmissionData = {
   CSB_Form_ID__c: string; // MongoDB ObjectId string
-  CSB_Form_Modified__c: string; // ISO 8601 date string
+  CSB_Modified_Full_String__c: string; // ISO 8601 date string
   UEI_EFTI_Combo_Key__c: string;
   Parent_Rebate_ID__c: string; // CSB Rebate ID
   Parent_CSB_Rebate__r: {

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -78,7 +78,7 @@ export default function AllRebates() {
       ...formioSubmission,
       bap: {
         lastModified: matchedSubmission
-          ? matchedSubmission?.CSB_Form_Modified__c
+          ? matchedSubmission?.CSB_Modified_Full_String__c
           : null,
         rebateId: matchedSubmission
           ? matchedSubmission?.Parent_Rebate_ID__c

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -195,7 +195,7 @@ function queryForRebateFormSubmissions(comboKeys, req) {
       `
         SELECT
           CSB_Form_ID__c,
-          CSB_Form_Modified__c,
+          CSB_Modified_Full_String__c,
           UEI_EFTI_Combo_Key__c,
           Parent_Rebate_ID__c,
           Parent_CSB_Rebate__r.CSB_Rebate_Status__c


### PR DESCRIPTION
This fixes an issue with the previous "modified" field (column) we were provided from the BAP. The BAP team indicated they're dropping some precision in the datetime from Forms.gov (removing the milliseconds) before storing that ISO 8601 datetime string as a date object in Salesforce, which caused the "wrapper" app's logic in determining if a submission was re-submitted to fail. To resolve this, they've created a new column/field where they store the exact string they get from Formio/Forms.gov.