### PR TITLE
Feature/account for withdrawn bap status

### DIFF
--- a/app/client/src/contexts/user.tsx
+++ b/app/client/src/contexts/user.tsx
@@ -59,7 +59,11 @@ type BapSubmissionData = {
   UEI_EFTI_Combo_Key__c: string;
   Parent_Rebate_ID__c: string; // CSB Rebate ID
   Parent_CSB_Rebate__r: {
-    CSB_Rebate_Status__c: "Draft" | "Submitted" | "Edits Requested";
+    CSB_Rebate_Status__c:
+      | "Draft"
+      | "Submitted"
+      | "Edits Requested"
+      | "Withdrawn";
     attributes: { type: string; url: string };
   };
   attributes: { type: string; url: string };

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -204,10 +204,8 @@ export default function AllRebates() {
                     (state === "draft" ||
                       (state === "submitted" && !submissionHasBeenUpdated));
 
-                  const submissionHasBeenResubmitted =
-                    bap.rebateStatus === "Edits Requested" &&
-                    state === "submitted" &&
-                    submissionHasBeenUpdated;
+                  const submissionHasBeenWithdrawn =
+                    bap.rebateStatus === "Withdrawn";
 
                   const statusClassNames = submissionNeedsEdits
                     ? "csb-needs-edits"
@@ -335,8 +333,9 @@ form for the fields to be displayed. */
                                 href={
                                   submissionNeedsEdits
                                     ? `${icons}#priority_high`
-                                    : submissionHasBeenResubmitted ||
-                                      state === "submitted"
+                                    : submissionHasBeenWithdrawn
+                                    ? `${icons}#close`
+                                    : state === "submitted"
                                     ? `${icons}#check`
                                     : state === "draft"
                                     ? `${icons}#more_horiz`
@@ -345,9 +344,8 @@ form for the fields to be displayed. */
                               />
                             </svg>
                             <span className="margin-left-05">
-                              {submissionHasBeenResubmitted
-                                ? "resubmitted"
-                                : submissionNeedsEdits
+                              {submissionNeedsEdits ||
+                              submissionHasBeenWithdrawn
                                 ? bap.rebateStatus
                                 : state}
                             </span>


### PR DESCRIPTION
Update all rebates table to account for 'Withdrawn' BAP status, and remove 'resubmitted' status in place of simpler/more consistent 'submitted' (for submissions after edits have been made and the form has been resubmitted, as the BAP team communicated they don't intent to expose a status called "resubmitted", and EPA agreed with the simpler approach of removing it from the wrapper).