### PR TITLE
Feature/update rebate id tooltip

### DIFF
--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -314,7 +314,7 @@ form for the fields to be displayed. */
                           ) : (
                             <TextWithTooltip
                               text=" "
-                              tooltip="Please edit and save the form and the Rebate ID will be displayed"
+                              tooltip="Rebate ID should be displayed within 24hrs. after starting a new rebate form application"
                             />
                           )}
                         </td>


### PR DESCRIPTION
Update tooltip displayed when rebate ID does not exist for a submission (should only be brand new submissions that have not yet gone through the BAP's ETL process)