### PR TITLE
Feature/disable enrollment period middleware

### DIFF
--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -193,7 +193,7 @@ router.get(
 router.post(
   "/rebate-form-submission/:id",
   verifyMongoObjectId,
-  checkCsbEnrollmentPeriod,
+  // checkCsbEnrollmentPeriod,
   storeBapComboKeys,
   (req, res) => {
     const { id } = req.params;


### PR DESCRIPTION
Temporarily disable checkCsbEnrollmentPeriod middleware so BAP team integration testing can continue until bug can be fixed.