### PR TITLE
Feature/rework enrollment period api check

### DIFF
--- a/app/client/src/routes/existingRebate.tsx
+++ b/app/client/src/routes/existingRebate.tsx
@@ -279,7 +279,8 @@ function ExistingRebateContent() {
         const s3Provider = Formio.Providers.providers.storage.s3;
         Formio.Providers.providers.storage.s3 = function (formio: any) {
           const s3Formio = cloneDeep(formio);
-          s3Formio.formUrl = `${serverUrl}/api/${res.submissionData.data.bap_hidden_entity_combo_key}`;
+          const comboKey = res.submissionData.data.bap_hidden_entity_combo_key;
+          s3Formio.formUrl = `${serverUrl}/api/${id}/${comboKey}`;
           return s3Provider(s3Formio);
         };
 

--- a/app/server/app/middleware.js
+++ b/app/server/app/middleware.js
@@ -137,36 +137,6 @@ function protectClientRoutes(req, res, next) {
 }
 
 /**
- * Intercepting middleware that returns an error if the enrollment period is
- * closed (as set via the `CSB_ENROLLMENT_PERIOD` environment variable), and if
- * the form submission does not have the status "Edits Requested" (as stored in
- * and returned from the BAP).
- * @param {express.Request} req
- * @param {express.Response} res
- * @param {express.NextFunction} next
- */
-function checkCsbEnrollmentPeriod(req, res, next) {
-  if (process.env.CSB_ENROLLMENT_PERIOD !== "closed") next();
-
-  const id = req.params?.id;
-  const comboKey = req.body.data?.bap_hidden_entity_combo_key;
-  if (!id && !comboKey) next();
-
-  return getRebateSubmissionsData([comboKey], req)
-    .then((submissions) => {
-      const submission = submissions.find((s) => s.CSB_Form_ID__c === id);
-      const status = submission?.Parent_CSB_Rebate__r?.CSB_Rebate_Status__c;
-      if (status !== "Edits Requested") throw error;
-      next();
-    })
-    .catch((error) => {
-      return res
-        .status(400)
-        .json({ message: `CSB enrollment period is closed` });
-    });
-}
-
-/**
  * @param {express.Request} req
  * @param {express.Response} res
  * @param {express.NextFunction} next
@@ -236,7 +206,6 @@ module.exports = {
   ensureHelpdesk,
   appScan,
   protectClientRoutes,
-  checkCsbEnrollmentPeriod,
   checkClientRouteExists,
   storeBapComboKeys,
   verifyMongoObjectId,

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -35,7 +35,7 @@ function checkEnrollmentPeriodAndBapStatus({ id, comboKey, req }) {
   if (!enrollmentClosed) {
     return Promise.resolve();
   }
-  // else, enrollment isn't closed, so only continue if edits are requested
+  // else, enrollment is closed, so only continue if edits are requested
   return getRebateSubmissionsData([comboKey], req).then((submissions) => {
     const submission = submissions.find((s) => s.CSB_Form_ID__c === id);
     const status = submission?.Parent_CSB_Rebate__r?.CSB_Rebate_Status__c;

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -263,14 +263,14 @@ router.post("/rebate-form-submission", storeBapComboKeys, (req, res) => {
     return res.status(400).json({ message });
   }
 
-  // Verify post data includes one of user's BAP combo keys
+  // verify post data includes one of user's BAP combo keys
   if (!req.bapComboKeys.includes(comboKey)) {
     const message = `User with email ${req.user.mail} attempted to post new form without a matching BAP combo key`;
     log({ level: "error", message, req });
     return res.status(401).json({ message: "Unauthorized" });
   }
 
-  // Add custom metadata to track formio submissions from wrapper
+  // add custom metadata to track formio submissions from wrapper
   req.body.metadata = {
     ...req.body.metadata,
     ...formioCsbMetadata,


### PR DESCRIPTION
Replace `checkCsbEnrollmentPeriod` custom Express middleware with a function that takes the form `id`, `comboKey`, and Express `response` as parameters and returns a resolved or rejected promise, so it could be used in the S3 express endpoints to lock down those requests when the enrollment period is closed and the submission in question does not have the BAP status of "Edits Requested".