### PR TITLE
Feature/update helpdesk to reflect enrollment period

### DIFF
--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -62,7 +62,7 @@ export default function Helpdesk() {
   const [formDisplayed, setFormDisplayed] = useState(false);
 
   const { content } = useContentState();
-  const { epaUserData } = useUserState();
+  const { csbData, epaUserData } = useUserState();
   const dispatch = useDialogDispatch();
   const helpdeskAccess = useHelpdeskAccess();
 
@@ -76,6 +76,7 @@ export default function Helpdesk() {
     });
 
   if (
+    csbData.status !== "success" ||
     epaUserData.status !== "success" ||
     helpdeskAccess === "idle" ||
     helpdeskAccess === "pending"
@@ -86,6 +87,8 @@ export default function Helpdesk() {
   if (helpdeskAccess === "failure") {
     navigate("/", { replace: true });
   }
+
+  const { enrollmentClosed } = csbData.data;
 
   const { formSchema, submissionData } = rebateFormSubmission.data;
 
@@ -252,7 +255,9 @@ export default function Helpdesk() {
                     <td>
                       <button
                         className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
-                        disabled={submissionData.state === "draft"}
+                        disabled={
+                          enrollmentClosed || submissionData.state === "draft"
+                        }
                         onClick={(ev) => {
                           dispatch({
                             type: "DISPLAY_DIALOG",

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -319,7 +319,7 @@ router.post("/:id/:comboKey/storage/s3", storeBapComboKeys, (req, res) => {
 
 // --- download s3 file metadata from Forms.gov
 router.get("/:id/:comboKey/storage/s3", storeBapComboKeys, (req, res) => {
-  const { id, comboKey } = req.params;
+  const { comboKey } = req.params;
 
   if (!req.bapComboKeys.includes(comboKey)) {
     const message = `User with email ${req.user.mail} attempted to download file without a matching BAP combo key`;

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -13,6 +13,8 @@ const {
 } = require("../middleware");
 const log = require("../utilities/logger");
 
+const enrollmentClosed = process.env.CSB_ENROLLMENT_PERIOD !== "open";
+
 const router = express.Router();
 
 // Confirm user is both authenticated and authorized with valid helpdesk roles
@@ -52,6 +54,11 @@ router.post("/rebate-form-submission/:id", verifyMongoObjectId, (req, res) => {
   const id = req.params.id;
   const userEmail = req.user.mail;
   const formioSubmissionUrl = `${formioProjectUrl}/${formioFormName}/submission/${id}`;
+
+  if (enrollmentClosed) {
+    const message = "CSB enrollment period is closed";
+    return res.status(400).json({ message });
+  }
 
   axiosFormio(req)
     .get(formioSubmissionUrl)

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -17,13 +17,13 @@ const enrollmentClosed = process.env.CSB_ENROLLMENT_PERIOD !== "open";
 
 const router = express.Router();
 
-// Confirm user is both authenticated and authorized with valid helpdesk roles
+// confirm user is both authenticated and authorized with valid helpdesk roles
 router.use(ensureAuthenticated);
 router.use(ensureHelpdesk);
 
 // --- get an existing rebate form's submission data from Forms.gov
 router.get("/rebate-form-submission/:id", verifyMongoObjectId, (req, res) => {
-  const id = req.params.id;
+  const { id } = req.params;
 
   axiosFormio(req)
     .get(`${formioProjectUrl}/${formioFormName}/submission/${id}`)
@@ -43,40 +43,37 @@ router.get("/rebate-form-submission/:id", verifyMongoObjectId, (req, res) => {
         });
     })
     .catch((error) => {
-      res.status(error?.response?.status || 500).json({
-        message: `Error getting Forms.gov rebate form submission ${id}`,
-      });
+      const message = `Error getting Forms.gov rebate form submission ${id}`;
+      return res.status(error?.response?.status || 500).json({ message });
     });
 });
 
 // --- change a submitted Forms.gov rebate form's submission back to 'draft'
 router.post("/rebate-form-submission/:id", verifyMongoObjectId, (req, res) => {
-  const id = req.params.id;
-  const userEmail = req.user.mail;
-  const formioSubmissionUrl = `${formioProjectUrl}/${formioFormName}/submission/${id}`;
+  const { id } = req.params;
+  const { mail } = req.user;
 
   if (enrollmentClosed) {
     const message = "CSB enrollment period is closed";
     return res.status(400).json({ message });
   }
 
+  const existingSubmissionUrl = `${formioProjectUrl}/${formioFormName}/submission/${id}`;
+
   axiosFormio(req)
-    .get(formioSubmissionUrl)
+    .get(existingSubmissionUrl)
     .then((axiosRes) => axiosRes.data)
     .then((existingSubmission) => {
       axiosFormio(req)
-        .put(formioSubmissionUrl, {
+        .put(existingSubmissionUrl, {
           state: "draft",
-          data: { ...existingSubmission.data, last_updated_by: userEmail },
+          data: { ...existingSubmission.data, last_updated_by: mail },
           metadata: { ...existingSubmission.metadata, ...formioCsbMetadata },
         })
         .then((axiosRes) => axiosRes.data)
         .then((updatedSubmission) => {
-          log({
-            level: "info",
-            message: `User with email ${userEmail} updated rebate form submission ${id} from submitted to draft.`,
-            req,
-          });
+          const message = `User with email ${mail} updated rebate form submission ${id} from submitted to draft.`;
+          log({ level: "info", message, req });
 
           axiosFormio(req)
             .get(`${formioProjectUrl}/form/${updatedSubmission.form}`)
@@ -93,9 +90,8 @@ router.post("/rebate-form-submission/:id", verifyMongoObjectId, (req, res) => {
         });
     })
     .catch((error) => {
-      res.status(error?.response?.status || 500).json({
-        message: `Error updating Forms.gov rebate form submission ${id}`,
-      });
+      const message = `Error updating Forms.gov rebate form submission ${id}`;
+      return res.status(error?.response?.status || 500).json({ message });
     });
 });
 


### PR DESCRIPTION
Locks down helpdesk functionality (both the server API, and the client app's UI) that changes a submitted application back to draft state if the enrollment period is closed.