### PR TITLE
Feature/organize data fetching and storage

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -28,7 +28,7 @@ import { Helpdesk } from "routes/helpdesk";
 import { AllRebates } from "routes/allRebates";
 import { NewApplicationForm } from "routes/newApplicationForm";
 import { ApplicationForm } from "routes/applicationForm";
-import { PaymentForm } from "routes/paymentForm";
+import { PaymentRequestForm } from "routes/paymentRequestForm";
 import { useContentState, useContentDispatch } from "contexts/content";
 import { useUserState, useUserDispatch } from "contexts/user";
 import { useDialogDispatch, useDialogState } from "contexts/dialog";
@@ -291,7 +291,7 @@ export function App() {
           <Route path="helpdesk" element={<Helpdesk />} />
           <Route path="rebate/new" element={<NewApplicationForm />} />
           <Route path="rebate/:id" element={<ApplicationForm />} />
-          <Route path="payment-request/:id" element={<PaymentForm />} />
+          <Route path="payment-request/:id" element={<PaymentRequestForm />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>

--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -158,7 +158,7 @@ function useInactivityDialog(callback: () => void) {
 
       /**
        * If user makes action and the JWT is set to expire within 3 minutes,
-       * call the callback (hit the /epa-data endpoint) to refresh the JWT
+       * call the callback (hit the /epa-user-data endpoint) to refresh the JWT
        */
       if (epaUserData.status !== "success") return;
 
@@ -221,7 +221,7 @@ function ProtectedRoute({ children }: { children: JSX.Element }) {
 
   // Check if user is already logged in or needs to be redirected to /welcome route
   const verifyUser = useCallback(() => {
-    getData(`${serverUrl}/api/epa-data`)
+    getData(`${serverUrl}/api/epa-user-data`)
       .then((res) => {
         dispatch({
           type: "FETCH_EPA_USER_DATA_SUCCESS",

--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -14,7 +14,8 @@ import {
 } from "../config";
 import { useHelpdeskAccess } from "components/app";
 import { Loading } from "components/loading";
-import { useUserState, useUserDispatch } from "contexts/user";
+import { useUserState } from "contexts/user";
+import { useCsbState, useCsbDispatch } from "contexts/csb";
 import { useBapState, useBapDispatch } from "contexts/bap";
 import { Action, useDialogDispatch } from "contexts/dialog";
 
@@ -25,7 +26,7 @@ Formio.use(uswds);
 
 /** Custom hook to fetch CSP app specific data */
 function useFetchedCsbData() {
-  const dispatch = useUserDispatch();
+  const dispatch = useCsbDispatch();
 
   useEffect(() => {
     dispatch({ type: "FETCH_CSB_DATA_REQUEST" });
@@ -105,7 +106,8 @@ export function Dashboard() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
 
-  const { csbData, epaUserData } = useUserState();
+  const { epaUserData } = useUserState();
+  const { csbData } = useCsbState();
   const { samEntities } = useBapState();
   const dispatch = useDialogDispatch();
   const helpdeskAccess = useHelpdeskAccess();

--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -15,6 +15,7 @@ import {
 import { useHelpdeskAccess } from "components/app";
 import { Loading } from "components/loading";
 import { useUserState, useUserDispatch } from "contexts/user";
+import { useBapState, useBapDispatch } from "contexts/bap";
 import { Action, useDialogDispatch } from "contexts/dialog";
 
 Formio.setBaseUrl(formioBaseUrl);
@@ -41,26 +42,26 @@ function useFetchedCsbData() {
   }, [dispatch]);
 }
 
-/** Custom hook to fetch BAP data */
-function useFetchedBapData() {
-  const dispatch = useUserDispatch();
+/** Custom hook to fetch SAM.gov data */
+function useFetchedSamData() {
+  const dispatch = useBapDispatch();
 
   useEffect(() => {
-    dispatch({ type: "FETCH_BAP_USER_DATA_REQUEST" });
-    getData(`${serverUrl}/api/bap-data`)
+    dispatch({ type: "FETCH_BAP_SAM_DATA_REQUEST" });
+    getData(`${serverUrl}/api/bap-sam-data`)
       .then((res) => {
-        if (res.samResults) {
+        if (res.results) {
           dispatch({
-            type: "FETCH_BAP_USER_DATA_SUCCESS",
-            payload: { bapUserData: res },
+            type: "FETCH_BAP_SAM_DATA_SUCCESS",
+            payload: { samEntities: res },
           });
         } else {
-          window.location.href = `${serverUrlForHrefs}/logout?RelayState=/welcome?info=sam-results`;
+          window.location.href = `${serverUrlForHrefs}/logout?RelayState=/welcome?info=bap-sam-results`;
         }
       })
       .catch((err) => {
-        dispatch({ type: "FETCH_BAP_USER_DATA_FAILURE" });
-        window.location.href = `${serverUrlForHrefs}/logout?RelayState=/welcome?error=bap-fetch`;
+        dispatch({ type: "FETCH_BAP_SAM_DATA_FAILURE" });
+        window.location.href = `${serverUrlForHrefs}/logout?RelayState=/welcome?error=bap-sam-fetch`;
       });
   }, [dispatch]);
 }
@@ -104,12 +105,13 @@ export function Dashboard() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
 
-  const { csbData, epaUserData, bapUserData } = useUserState();
+  const { csbData, epaUserData } = useUserState();
+  const { samEntities } = useBapState();
   const dispatch = useDialogDispatch();
   const helpdeskAccess = useHelpdeskAccess();
 
   useFetchedCsbData();
-  useFetchedBapData();
+  useFetchedSamData();
 
   /**
    * When provided a destination location to navigate to, creates an action
@@ -132,7 +134,7 @@ export function Dashboard() {
     };
   }
 
-  if (bapUserData.status !== "success") {
+  if (samEntities.status !== "success") {
     return <Loading />;
   }
 

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -56,7 +56,8 @@ export const messages = {
   bapNoSamResults:
     "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
   applicationSubmissionsError: "Error loading Application form submissions.",
-  paymentSubmissionsError: "Error loading Payment Request form submissions.",
+  paymentRequestSubmissionsError:
+    "Error loading Payment Request form submissions.",
   newApplication:
     "Please select the “New Application” button above to create your first rebate application.",
   helpdeskApplicationSubmissionError:

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -52,9 +52,8 @@ export const messages = {
   genericError: "Something went wrong.",
   authError: "Authentication error. Please log in again or contact support.",
   samlError: "Error logging in. Please try again or contact support.",
-  bapFetchError:
-    "Error loading SAM.gov or rebate submission data. Please contact support.",
-  noSamResults:
+  bapSamFetchError: "Error loading SAM.gov data. Please contact support.",
+  bapNoSamResults:
     "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
   applicationSubmissionsError: "Error loading Application form submissions.",
   paymentSubmissionsError: "Error loading Payment Request form submissions.",

--- a/app/client/src/contexts/bap.tsx
+++ b/app/client/src/contexts/bap.tsx
@@ -10,7 +10,7 @@ type Props = {
   children: ReactNode;
 };
 
-export type SamEntity = {
+export type BapSamEntity = {
   ENTITY_COMBO_KEY__c: string;
   UNIQUE_ENTITY_ID__c: string;
   ENTITY_EFT_INDICATOR__c: string;
@@ -42,7 +42,7 @@ export type SamEntity = {
   attributes: { type: string; url: string };
 };
 
-type ApplicationFormSubmission = {
+type BapApplicationSubmission = {
   CSB_Form_ID__c: string; // MongoDB ObjectId string
   CSB_Modified_Full_String__c: string; // ISO 8601 date string
   UEI_EFTI_Combo_Key__c: string;
@@ -67,13 +67,13 @@ type State = {
         status: "success";
         data:
           | { results: false; entities: [] }
-          | { results: true; entities: SamEntity[] };
+          | { results: true; entities: BapSamEntity[] };
       }
     | { status: "failure"; data: {} };
   applicationSubmissions:
     | { status: "idle"; data: {} }
     | { status: "pending"; data: {} }
-    | { status: "success"; data: ApplicationFormSubmission[] }
+    | { status: "success"; data: BapApplicationSubmission[] }
     | { status: "failure"; data: {} };
 };
 
@@ -84,14 +84,14 @@ type Action =
       payload: {
         samEntities:
           | { results: false; entities: [] }
-          | { results: true; entities: SamEntity[] };
+          | { results: true; entities: BapSamEntity[] };
       };
     }
   | { type: "FETCH_BAP_SAM_DATA_FAILURE" }
   | { type: "FETCH_BAP_APPLICATION_SUBMISSIONS_REQUEST" }
   | {
       type: "FETCH_BAP_APPLICATION_SUBMISSIONS_SUCCESS";
-      payload: { applicationSubmissions: ApplicationFormSubmission[] };
+      payload: { applicationSubmissions: BapApplicationSubmission[] };
     }
   | { type: "FETCH_BAP_APPLICATION_SUBMISSIONS_FAILURE" };
 

--- a/app/client/src/contexts/bap.tsx
+++ b/app/client/src/contexts/bap.tsx
@@ -1,0 +1,218 @@
+import {
+  Dispatch,
+  ReactNode,
+  createContext,
+  useContext,
+  useReducer,
+} from "react";
+
+type Props = {
+  children: ReactNode;
+};
+
+export type SamEntity = {
+  ENTITY_COMBO_KEY__c: string;
+  UNIQUE_ENTITY_ID__c: string;
+  ENTITY_EFT_INDICATOR__c: string;
+  ENTITY_STATUS__c: "Active" | string;
+  LEGAL_BUSINESS_NAME__c: string;
+  PHYSICAL_ADDRESS_LINE_1__c: string;
+  PHYSICAL_ADDRESS_LINE_2__c: string | null;
+  PHYSICAL_ADDRESS_CITY__c: string;
+  PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c: string;
+  PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c: string;
+  PHYSICAL_ADDRESS_ZIP_CODE_4__c: string;
+  // contacts
+  ELEC_BUS_POC_EMAIL__c: string | null;
+  ELEC_BUS_POC_NAME__c: string | null;
+  ELEC_BUS_POC_TITLE__c: string | null;
+  //
+  ALT_ELEC_BUS_POC_EMAIL__c: string | null;
+  ALT_ELEC_BUS_POC_NAME__c: string | null;
+  ALT_ELEC_BUS_POC_TITLE__c: string | null;
+  //
+  GOVT_BUS_POC_EMAIL__c: string | null;
+  GOVT_BUS_POC_NAME__c: string | null;
+  GOVT_BUS_POC_TITLE__c: string | null;
+  //
+  ALT_GOVT_BUS_POC_EMAIL__c: string | null;
+  ALT_GOVT_BUS_POC_NAME__c: string | null;
+  ALT_GOVT_BUS_POC_TITLE__c: string | null;
+  //
+  attributes: { type: string; url: string };
+};
+
+type ApplicationFormSubmission = {
+  CSB_Form_ID__c: string; // MongoDB ObjectId string
+  CSB_Modified_Full_String__c: string; // ISO 8601 date string
+  UEI_EFTI_Combo_Key__c: string;
+  Parent_Rebate_ID__c: string; // CSB Rebate ID
+  Parent_CSB_Rebate__r: {
+    CSB_Rebate_Status__c:
+      | "Draft"
+      | "Submitted"
+      | "Edits Requested"
+      | "Withdrawn"
+      | "Selected";
+    attributes: { type: string; url: string };
+  };
+  attributes: { type: string; url: string };
+};
+
+type State = {
+  samEntities:
+    | { status: "idle"; data: {} }
+    | { status: "pending"; data: {} }
+    | {
+        status: "success";
+        data:
+          | { results: false; entities: [] }
+          | { results: true; entities: SamEntity[] };
+      }
+    | { status: "failure"; data: {} };
+  applicationSubmissions:
+    | { status: "idle"; data: {} }
+    | { status: "pending"; data: {} }
+    | { status: "success"; data: ApplicationFormSubmission[] }
+    | { status: "failure"; data: {} };
+};
+
+type Action =
+  | { type: "FETCH_BAP_SAM_DATA_REQUEST" }
+  | {
+      type: "FETCH_BAP_SAM_DATA_SUCCESS";
+      payload: {
+        samEntities:
+          | { results: false; entities: [] }
+          | { results: true; entities: SamEntity[] };
+      };
+    }
+  | { type: "FETCH_BAP_SAM_DATA_FAILURE" }
+  | { type: "FETCH_BAP_APPLICATION_SUBMISSIONS_REQUEST" }
+  | {
+      type: "FETCH_BAP_APPLICATION_SUBMISSIONS_SUCCESS";
+      payload: { applicationSubmissions: ApplicationFormSubmission[] };
+    }
+  | { type: "FETCH_BAP_APPLICATION_SUBMISSIONS_FAILURE" };
+
+const StateContext = createContext<State | undefined>(undefined);
+const DispatchContext = createContext<Dispatch<Action> | undefined>(undefined);
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "FETCH_BAP_SAM_DATA_REQUEST": {
+      return {
+        ...state,
+        samEntities: {
+          status: "pending",
+          data: {},
+        },
+      };
+    }
+
+    case "FETCH_BAP_SAM_DATA_SUCCESS": {
+      const { samEntities } = action.payload;
+      return {
+        ...state,
+        samEntities: {
+          status: "success",
+          data: samEntities,
+        },
+      };
+    }
+
+    case "FETCH_BAP_SAM_DATA_FAILURE": {
+      return {
+        ...state,
+        samEntities: {
+          status: "failure",
+          data: {},
+        },
+      };
+    }
+
+    case "FETCH_BAP_APPLICATION_SUBMISSIONS_REQUEST": {
+      return {
+        ...state,
+        applicationSubmissions: {
+          status: "pending",
+          data: {},
+        },
+      };
+    }
+
+    case "FETCH_BAP_APPLICATION_SUBMISSIONS_SUCCESS": {
+      const { applicationSubmissions } = action.payload;
+      return {
+        ...state,
+        applicationSubmissions: {
+          status: "success",
+          data: applicationSubmissions,
+        },
+      };
+    }
+
+    case "FETCH_BAP_APPLICATION_SUBMISSIONS_FAILURE": {
+      return {
+        ...state,
+        applicationSubmissions: {
+          status: "failure",
+          data: {},
+        },
+      };
+    }
+
+    default: {
+      const message = `Unhandled action type: ${action}`;
+      throw new Error(message);
+    }
+  }
+}
+
+export function BapProvider({ children }: Props) {
+  const initialState: State = {
+    samEntities: {
+      status: "idle",
+      data: {},
+    },
+    applicationSubmissions: {
+      status: "idle",
+      data: {},
+    },
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <StateContext.Provider value={state}>
+      <DispatchContext.Provider value={dispatch}>
+        {children}
+      </DispatchContext.Provider>
+    </StateContext.Provider>
+  );
+}
+
+/**
+ * Returns state stored in `BapProvider` context component.
+ */
+export function useBapState() {
+  const context = useContext(StateContext);
+  if (context === undefined) {
+    const message = `useBapState must be called within a BapProvider`;
+    throw new Error(message);
+  }
+  return context;
+}
+
+/**
+ * Returns `dispatch` method for dispatching actions to update state stored in
+ * `BapProvider` context component.
+ */
+export function useBapDispatch() {
+  const context = useContext(DispatchContext);
+  if (context === undefined) {
+    const message = `useBapDispatch must be used within a BapProvider`;
+    throw new Error(message);
+  }
+  return context;
+}

--- a/app/client/src/contexts/csb.tsx
+++ b/app/client/src/contexts/csb.tsx
@@ -10,82 +10,56 @@ type Props = {
   children: ReactNode;
 };
 
-type EpaUserData = {
-  mail: string;
-  memberof: string;
-  exp: number;
+type CsbData = {
+  enrollmentClosed: boolean;
 };
 
 type State = {
-  isAuthenticating: boolean;
-  isAuthenticated: boolean;
-  epaUserData:
+  csbData:
     | { status: "idle"; data: {} }
     | { status: "pending"; data: {} }
-    | { status: "success"; data: EpaUserData }
+    | { status: "success"; data: CsbData }
     | { status: "failure"; data: {} };
 };
 
 type Action =
-  | { type: "USER_SIGN_IN" }
-  | { type: "USER_SIGN_OUT" }
-  | { type: "FETCH_EPA_USER_DATA_REQUEST" }
+  | { type: "FETCH_CSB_DATA_REQUEST" }
   | {
-      type: "FETCH_EPA_USER_DATA_SUCCESS";
-      payload: { epaUserData: EpaUserData };
+      type: "FETCH_CSB_DATA_SUCCESS";
+      payload: { csbData: CsbData };
     }
-  | { type: "FETCH_EPA_USER_DATA_FAILURE" };
+  | { type: "FETCH_CSB_DATA_FAILURE" };
 
 const StateContext = createContext<State | undefined>(undefined);
 const DispatchContext = createContext<Dispatch<Action> | undefined>(undefined);
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
-    case "USER_SIGN_IN": {
+    case "FETCH_CSB_DATA_REQUEST": {
       return {
         ...state,
-        isAuthenticating: false,
-        isAuthenticated: true,
-      };
-    }
-
-    case "USER_SIGN_OUT": {
-      return {
-        ...state,
-        isAuthenticating: false,
-        isAuthenticated: false,
-        epaUserData: {
-          status: "idle",
-          data: {},
-        },
-      };
-    }
-
-    case "FETCH_EPA_USER_DATA_REQUEST": {
-      return {
-        ...state,
-        epaUserData: {
+        csbData: {
           status: "pending",
           data: {},
         },
       };
     }
 
-    case "FETCH_EPA_USER_DATA_SUCCESS": {
-      const { epaUserData } = action.payload;
+    case "FETCH_CSB_DATA_SUCCESS": {
+      const { csbData } = action.payload;
       return {
         ...state,
-        epaUserData: {
+        csbData: {
           status: "success",
-          data: epaUserData,
+          data: csbData,
         },
       };
     }
 
-    case "FETCH_EPA_USER_DATA_FAILURE": {
+    case "FETCH_CSB_DATA_FAILURE": {
       return {
         ...state,
-        epaUserData: {
+        csbData: {
           status: "failure",
           data: {},
         },
@@ -99,11 +73,9 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-export function UserProvider({ children }: Props) {
+export function CsbProvider({ children }: Props) {
   const initialState: State = {
-    isAuthenticating: true,
-    isAuthenticated: false,
-    epaUserData: {
+    csbData: {
       status: "idle",
       data: {},
     },
@@ -121,12 +93,12 @@ export function UserProvider({ children }: Props) {
 }
 
 /**
- * Returns state stored in `UserProvider` context component.
+ * Returns state stored in `CsbProvider` context component.
  */
-export function useUserState() {
+export function useCsbState() {
   const context = useContext(StateContext);
   if (context === undefined) {
-    const message = `useUserState must be called within a UserProvider`;
+    const message = `useCsbState must be called within a CsbProvider`;
     throw new Error(message);
   }
   return context;
@@ -134,12 +106,12 @@ export function useUserState() {
 
 /**
  * Returns `dispatch` method for dispatching actions to update state stored in
- * `UserProvider` context component.
+ * `CsbProvider` context component.
  */
-export function useUserDispatch() {
+export function useCsbDispatch() {
   const context = useContext(DispatchContext);
   if (context === undefined) {
-    const message = `useUserDispatch must be used within a UserProvider`;
+    const message = `useCsbDispatch must be used within a CsbProvider`;
     throw new Error(message);
   }
   return context;

--- a/app/client/src/contexts/formio.tsx
+++ b/app/client/src/contexts/formio.tsx
@@ -159,7 +159,7 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-export function FormsProvider({ children }: Props) {
+export function FormioProvider({ children }: Props) {
   const initialState: State = {
     applicationSubmissions: {
       status: "idle",
@@ -183,12 +183,12 @@ export function FormsProvider({ children }: Props) {
 }
 
 /**
- * Returns state stored in `FormsProvider` context component.
+ * Returns state stored in `FormioProvider` context component.
  */
-export function useFormsState() {
+export function useFormioState() {
   const context = useContext(StateContext);
   if (context === undefined) {
-    const message = `useFormsState must be called within a FormsProvider`;
+    const message = `useFormioState must be called within a FormioProvider`;
     throw new Error(message);
   }
   return context;
@@ -196,12 +196,12 @@ export function useFormsState() {
 
 /**
  * Returns `dispatch` method for dispatching actions to update state stored in
- * `FormsProvider` context component.
+ * `FormioProvider` context component.
  */
-export function useFormsDispatch() {
+export function useFormioDispatch() {
   const context = useContext(DispatchContext);
   if (context === undefined) {
-    const message = `useFormsDispatch must be used within a FormsProvider`;
+    const message = `useFormioDispatch must be used within a FormioProvider`;
     throw new Error(message);
   }
   return context;

--- a/app/client/src/contexts/forms.tsx
+++ b/app/client/src/contexts/forms.tsx
@@ -10,7 +10,7 @@ type Props = {
   children: ReactNode;
 };
 
-export type ApplicationFormSubmission = {
+export type FormioApplicationSubmission = {
   [field: string]: unknown;
   _id: string; // MongoDB ObjectId string
   state: "submitted" | "draft";
@@ -43,7 +43,7 @@ export type ApplicationFormSubmission = {
   };
 };
 
-type PaymentFormSubmission = {
+type FormioPaymentRequestSubmission = {
   [field: string]: unknown;
   _id: string; // MongoDB ObjectId string
   state: "submitted" | "draft";
@@ -54,98 +54,98 @@ type PaymentFormSubmission = {
 };
 
 type State = {
-  applicationFormSubmissions:
+  applicationSubmissions:
     | { status: "idle"; data: [] }
     | { status: "pending"; data: [] }
-    | { status: "success"; data: ApplicationFormSubmission[] }
+    | { status: "success"; data: FormioApplicationSubmission[] }
     | { status: "failure"; data: [] };
-  paymentFormSubmissions:
+  paymentRequestSubmissions:
     | { status: "idle"; data: [] }
     | { status: "pending"; data: [] }
-    | { status: "success"; data: PaymentFormSubmission[] }
+    | { status: "success"; data: FormioPaymentRequestSubmission[] }
     | { status: "failure"; data: [] };
 };
 
 type Action =
-  | { type: "FETCH_APPLICATION_FORM_SUBMISSIONS_REQUEST" }
+  | { type: "FETCH_FORMIO_APPLICATION_SUBMISSIONS_REQUEST" }
   | {
-      type: "FETCH_APPLICATION_FORM_SUBMISSIONS_SUCCESS";
+      type: "FETCH_FORMIO_APPLICATION_SUBMISSIONS_SUCCESS";
       payload: {
-        applicationFormSubmissions: ApplicationFormSubmission[];
+        applicationSubmissions: FormioApplicationSubmission[];
       };
     }
-  | { type: "FETCH_APPLICATION_FORM_SUBMISSIONS_FAILURE" }
-  | { type: "FETCH_PAYMENT_FORM_SUBMISSIONS_REQUEST" }
-  | { type: "FETCH_PAYMENT_FORM_SUBMISSIONS_REQUEST" }
+  | { type: "FETCH_FORMIO_APPLICATION_SUBMISSIONS_FAILURE" }
+  | { type: "FETCH_FORMIO_PAYMENT_REQUEST_SUBMISSIONS_REQUEST" }
+  | { type: "FETCH_FORMIO_PAYMENT_REQUEST_SUBMISSIONS_REQUEST" }
   | {
-      type: "FETCH_PAYMENT_FORM_SUBMISSIONS_SUCCESS";
+      type: "FETCH_FORMIO_PAYMENT_REQUEST_SUBMISSIONS_SUCCESS";
       payload: {
-        paymentFormSubmissions: PaymentFormSubmission[];
+        paymentRequestSubmissions: FormioPaymentRequestSubmission[];
       };
     }
-  | { type: "FETCH_PAYMENT_FORM_SUBMISSIONS_FAILURE" };
+  | { type: "FETCH_FORMIO_PAYMENT_REQUEST_SUBMISSIONS_FAILURE" };
 
 const StateContext = createContext<State | undefined>(undefined);
 const DispatchContext = createContext<Dispatch<Action> | undefined>(undefined);
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
-    case "FETCH_APPLICATION_FORM_SUBMISSIONS_REQUEST": {
+    case "FETCH_FORMIO_APPLICATION_SUBMISSIONS_REQUEST": {
       return {
         ...state,
-        applicationFormSubmissions: {
+        applicationSubmissions: {
           status: "pending",
           data: [],
         },
       };
     }
 
-    case "FETCH_APPLICATION_FORM_SUBMISSIONS_SUCCESS": {
-      const { applicationFormSubmissions } = action.payload;
+    case "FETCH_FORMIO_APPLICATION_SUBMISSIONS_SUCCESS": {
+      const { applicationSubmissions } = action.payload;
       return {
         ...state,
-        applicationFormSubmissions: {
+        applicationSubmissions: {
           status: "success",
-          data: applicationFormSubmissions,
+          data: applicationSubmissions,
         },
       };
     }
 
-    case "FETCH_APPLICATION_FORM_SUBMISSIONS_FAILURE": {
+    case "FETCH_FORMIO_APPLICATION_SUBMISSIONS_FAILURE": {
       return {
         ...state,
-        applicationFormSubmissions: {
+        applicationSubmissions: {
           status: "failure",
           data: [],
         },
       };
     }
 
-    case "FETCH_PAYMENT_FORM_SUBMISSIONS_REQUEST": {
+    case "FETCH_FORMIO_PAYMENT_REQUEST_SUBMISSIONS_REQUEST": {
       return {
         ...state,
-        paymentFormSubmissions: {
+        paymentRequestSubmissions: {
           status: "pending",
           data: [],
         },
       };
     }
 
-    case "FETCH_PAYMENT_FORM_SUBMISSIONS_SUCCESS": {
-      const { paymentFormSubmissions } = action.payload;
+    case "FETCH_FORMIO_PAYMENT_REQUEST_SUBMISSIONS_SUCCESS": {
+      const { paymentRequestSubmissions } = action.payload;
       return {
         ...state,
-        paymentFormSubmissions: {
+        paymentRequestSubmissions: {
           status: "success",
-          data: paymentFormSubmissions,
+          data: paymentRequestSubmissions,
         },
       };
     }
 
-    case "FETCH_PAYMENT_FORM_SUBMISSIONS_FAILURE": {
+    case "FETCH_FORMIO_PAYMENT_REQUEST_SUBMISSIONS_FAILURE": {
       return {
         ...state,
-        paymentFormSubmissions: {
+        paymentRequestSubmissions: {
           status: "failure",
           data: [],
         },
@@ -161,11 +161,11 @@ function reducer(state: State, action: Action): State {
 
 export function FormsProvider({ children }: Props) {
   const initialState: State = {
-    applicationFormSubmissions: {
+    applicationSubmissions: {
       status: "idle",
       data: [],
     },
-    paymentFormSubmissions: {
+    paymentRequestSubmissions: {
       status: "idle",
       data: [],
     },

--- a/app/client/src/contexts/user.tsx
+++ b/app/client/src/contexts/user.tsx
@@ -20,55 +20,6 @@ type EpaUserData = {
   exp: number;
 };
 
-export type SamEntity = {
-  ENTITY_COMBO_KEY__c: string;
-  UNIQUE_ENTITY_ID__c: string;
-  ENTITY_EFT_INDICATOR__c: string;
-  ENTITY_STATUS__c: "Active" | string;
-  LEGAL_BUSINESS_NAME__c: string;
-  PHYSICAL_ADDRESS_LINE_1__c: string;
-  PHYSICAL_ADDRESS_LINE_2__c: string | null;
-  PHYSICAL_ADDRESS_CITY__c: string;
-  PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c: string;
-  PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c: string;
-  PHYSICAL_ADDRESS_ZIP_CODE_4__c: string;
-  // contacts
-  ELEC_BUS_POC_EMAIL__c: string | null;
-  ELEC_BUS_POC_NAME__c: string | null;
-  ELEC_BUS_POC_TITLE__c: string | null;
-  //
-  ALT_ELEC_BUS_POC_EMAIL__c: string | null;
-  ALT_ELEC_BUS_POC_NAME__c: string | null;
-  ALT_ELEC_BUS_POC_TITLE__c: string | null;
-  //
-  GOVT_BUS_POC_EMAIL__c: string | null;
-  GOVT_BUS_POC_NAME__c: string | null;
-  GOVT_BUS_POC_TITLE__c: string | null;
-  //
-  ALT_GOVT_BUS_POC_EMAIL__c: string | null;
-  ALT_GOVT_BUS_POC_NAME__c: string | null;
-  ALT_GOVT_BUS_POC_TITLE__c: string | null;
-  //
-  attributes: { type: string; url: string };
-};
-
-type ApplicationFormSubmissionMetadata = {
-  CSB_Form_ID__c: string; // MongoDB ObjectId string
-  CSB_Modified_Full_String__c: string; // ISO 8601 date string
-  UEI_EFTI_Combo_Key__c: string;
-  Parent_Rebate_ID__c: string; // CSB Rebate ID
-  Parent_CSB_Rebate__r: {
-    CSB_Rebate_Status__c:
-      | "Draft"
-      | "Submitted"
-      | "Edits Requested"
-      | "Withdrawn"
-      | "Selected";
-    attributes: { type: string; url: string };
-  };
-  attributes: { type: string; url: string };
-};
-
 type State = {
   isAuthenticating: boolean;
   isAuthenticated: boolean;
@@ -81,24 +32,6 @@ type State = {
     | { status: "idle"; data: {} }
     | { status: "pending"; data: {} }
     | { status: "success"; data: EpaUserData }
-    | { status: "failure"; data: {} };
-  bapUserData:
-    | { status: "idle"; data: {} }
-    | { status: "pending"; data: {} }
-    | {
-        status: "success";
-        data:
-          | {
-              samResults: false;
-              samEntities: [];
-              applicationSubmissions: [];
-            }
-          | {
-              samResults: true;
-              samEntities: SamEntity[];
-              applicationSubmissions: ApplicationFormSubmissionMetadata[];
-            };
-      }
     | { status: "failure"; data: {} };
 };
 
@@ -116,25 +49,7 @@ type Action =
       type: "FETCH_EPA_USER_DATA_SUCCESS";
       payload: { epaUserData: EpaUserData };
     }
-  | { type: "FETCH_EPA_USER_DATA_FAILURE" }
-  | { type: "FETCH_BAP_USER_DATA_REQUEST" }
-  | {
-      type: "FETCH_BAP_USER_DATA_SUCCESS";
-      payload: {
-        bapUserData:
-          | {
-              samResults: false;
-              samEntities: [];
-              applicationSubmissions: [];
-            }
-          | {
-              samResults: true;
-              samEntities: SamEntity[];
-              applicationSubmissions: ApplicationFormSubmissionMetadata[];
-            };
-      };
-    }
-  | { type: "FETCH_BAP_USER_DATA_FAILURE" };
+  | { type: "FETCH_EPA_USER_DATA_FAILURE" };
 
 const StateContext = createContext<State | undefined>(undefined);
 const DispatchContext = createContext<Dispatch<Action> | undefined>(undefined);
@@ -159,10 +74,6 @@ function reducer(state: State, action: Action): State {
           data: {},
         },
         epaUserData: {
-          status: "idle",
-          data: {},
-        },
-        bapUserData: {
           status: "idle",
           data: {},
         },
@@ -231,37 +142,6 @@ function reducer(state: State, action: Action): State {
       };
     }
 
-    case "FETCH_BAP_USER_DATA_REQUEST": {
-      return {
-        ...state,
-        bapUserData: {
-          status: "pending",
-          data: {},
-        },
-      };
-    }
-
-    case "FETCH_BAP_USER_DATA_SUCCESS": {
-      const { bapUserData } = action.payload;
-      return {
-        ...state,
-        bapUserData: {
-          status: "success",
-          data: bapUserData,
-        },
-      };
-    }
-
-    case "FETCH_BAP_USER_DATA_FAILURE": {
-      return {
-        ...state,
-        bapUserData: {
-          status: "failure",
-          data: {},
-        },
-      };
-    }
-
     default: {
       const message = `Unhandled action type: ${action}`;
       throw new Error(message);
@@ -278,10 +158,6 @@ export function UserProvider({ children }: Props) {
       data: {},
     },
     epaUserData: {
-      status: "idle",
-      data: {},
-    },
-    bapUserData: {
       status: "idle",
       data: {},
     },

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -5,7 +5,7 @@ import reportWebVitals from "./reportWebVitals";
 import { ContentProvider } from "contexts/content";
 import { UserProvider } from "contexts/user";
 import { BapProvider } from "contexts/bap";
-import { FormsProvider } from "contexts/forms";
+import { FormioProvider } from "contexts/formio";
 import { DialogProvider } from "contexts/dialog";
 import { ErrorBoundary } from "components/errorBoundary";
 import { App } from "components/app";
@@ -19,11 +19,11 @@ render(
       <ContentProvider>
         <UserProvider>
           <BapProvider>
-            <FormsProvider>
+            <FormioProvider>
               <DialogProvider>
                 <App />
               </DialogProvider>
-            </FormsProvider>
+            </FormioProvider>
           </BapProvider>
         </UserProvider>
       </ContentProvider>

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -4,6 +4,7 @@ import reportWebVitals from "./reportWebVitals";
 // ---
 import { ContentProvider } from "contexts/content";
 import { UserProvider } from "contexts/user";
+import { CsbProvider } from "contexts/csb";
 import { BapProvider } from "contexts/bap";
 import { FormioProvider } from "contexts/formio";
 import { DialogProvider } from "contexts/dialog";
@@ -18,13 +19,15 @@ render(
     <ErrorBoundary>
       <ContentProvider>
         <UserProvider>
-          <BapProvider>
-            <FormioProvider>
-              <DialogProvider>
-                <App />
-              </DialogProvider>
-            </FormioProvider>
-          </BapProvider>
+          <CsbProvider>
+            <BapProvider>
+              <FormioProvider>
+                <DialogProvider>
+                  <App />
+                </DialogProvider>
+              </FormioProvider>
+            </BapProvider>
+          </CsbProvider>
         </UserProvider>
       </ContentProvider>
     </ErrorBoundary>

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -4,6 +4,7 @@ import reportWebVitals from "./reportWebVitals";
 // ---
 import { ContentProvider } from "contexts/content";
 import { UserProvider } from "contexts/user";
+import { BapProvider } from "contexts/bap";
 import { FormsProvider } from "contexts/forms";
 import { DialogProvider } from "contexts/dialog";
 import { ErrorBoundary } from "components/errorBoundary";
@@ -17,11 +18,13 @@ render(
     <ErrorBoundary>
       <ContentProvider>
         <UserProvider>
-          <FormsProvider>
-            <DialogProvider>
-              <App />
-            </DialogProvider>
-          </FormsProvider>
+          <BapProvider>
+            <FormsProvider>
+              <DialogProvider>
+                <App />
+              </DialogProvider>
+            </FormsProvider>
+          </BapProvider>
         </UserProvider>
       </ContentProvider>
     </ErrorBoundary>

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -79,7 +79,7 @@ function useFetchedFormioPaymentRequestSubmissions() {
 
     dispatch({ type: "FETCH_PAYMENT_FORM_SUBMISSIONS_REQUEST" });
 
-    getData(`${serverUrl}/api/payment-form-submissions`)
+    getData(`${serverUrl}/api/formio-payment-request-submissions`)
       .then((res) => {
         dispatch({
           type: "FETCH_PAYMENT_FORM_SUBMISSIONS_SUCCESS",
@@ -117,7 +117,7 @@ function createNewPaymentRequest(
     schoolDistricPrioritized,
   } = applicationData;
 
-  return postData(`${serverUrl}/api/payment-form-submission/`, {
+  return postData(`${serverUrl}/api/formio-payment-request-submission/`, {
     data: {
       last_updated_by: email,
       hidden_current_user_email: email,

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -10,6 +10,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/infoTooltip";
 import { useContentState } from "contexts/content";
 import { useUserState } from "contexts/user";
+import { useCsbState } from "contexts/csb";
 import { BapSamEntity, useBapState, useBapDispatch } from "contexts/bap";
 import {
   FormioApplicationSubmission,
@@ -160,7 +161,8 @@ function createNewPaymentRequest(
 export function AllRebates() {
   const navigate = useNavigate();
   const { content } = useContentState();
-  const { csbData, epaUserData } = useUserState();
+  const { epaUserData } = useUserState();
+  const { csbData } = useCsbState();
   const { samEntities, applicationSubmissions: bapApplicationSubmissions } =
     useBapState();
   const {

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -410,7 +410,7 @@ form for the fields to be displayed. */
                                 // change the submission's state to draft, then
                                 // redirect to the form to allow user to edit
                                 postData(
-                                  `${serverUrl}/api/application-form-submission/${_id}`,
+                                  `${serverUrl}/api/formio-application-submission/${_id}`,
                                   { data, state: "draft" }
                                 )
                                   .then((res) => {

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -13,14 +13,14 @@ import { useUserState } from "contexts/user";
 import { BapSamEntity, useBapState, useBapDispatch } from "contexts/bap";
 import {
   FormioApplicationSubmission,
-  useFormsState,
-  useFormsDispatch,
-} from "contexts/forms";
+  useFormioState,
+  useFormioDispatch,
+} from "contexts/formio";
 
 /** Custom hook to fetch Application form submissions from Forms.gov */
 function useFetchedFormioApplicationSubmissions() {
   const { samEntities } = useBapState();
-  const dispatch = useFormsDispatch();
+  const dispatch = useFormioDispatch();
 
   useEffect(() => {
     if (samEntities.status !== "success" || !samEntities.data.results) {
@@ -70,7 +70,7 @@ function useFetchedBapApplicationSubmissions() {
 /** Custom hook to fetch Payment Request form submissions from Forms.gov */
 function useFetchedFormioPaymentRequestSubmissions() {
   const { samEntities } = useBapState();
-  const dispatch = useFormsDispatch();
+  const dispatch = useFormioDispatch();
 
   useEffect(() => {
     if (samEntities.status !== "success" || !samEntities.data.results) {
@@ -166,7 +166,7 @@ export function AllRebates() {
   const {
     applicationSubmissions: formioApplicationSubmissions,
     paymentRequestSubmissions: formioPaymentRequestSubmissions,
-  } = useFormsState();
+  } = useFormioState();
 
   const [message, setMessage] = useState<{
     displayed: boolean;

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -29,7 +29,7 @@ function useFetchedFormioApplicationSubmissions() {
 
     dispatch({ type: "FETCH_APPLICATION_FORM_SUBMISSIONS_REQUEST" });
 
-    getData(`${serverUrl}/api/application-form-submissions`)
+    getData(`${serverUrl}/api/formio-application-submissions`)
       .then((res) => {
         dispatch({
           type: "FETCH_APPLICATION_FORM_SUBMISSIONS_SUCCESS",

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -239,7 +239,7 @@ function ApplicationFormContent() {
     useBapState();
   const dispatch = useApplicationFormDispatch();
 
-  const [applicationFormSubmission, setApplicationFormSubmission] =
+  const [formioApplicationSubmission, setFormioApplicationSubmission] =
     useState<SubmissionState>({
       status: "idle",
       data: {
@@ -267,7 +267,7 @@ function ApplicationFormContent() {
     useState<FormioSubmissionData>({});
 
   useEffect(() => {
-    setApplicationFormSubmission({
+    setFormioApplicationSubmission({
       status: "pending",
       data: {
         userAccess: false,
@@ -301,13 +301,13 @@ function ApplicationFormContent() {
           return data;
         });
 
-        setApplicationFormSubmission({
+        setFormioApplicationSubmission({
           status: "success",
           data: res,
         });
       })
       .catch((err) => {
-        setApplicationFormSubmission({
+        setFormioApplicationSubmission({
           status: "failure",
           data: {
             userAccess: false,
@@ -318,19 +318,19 @@ function ApplicationFormContent() {
       });
   }, [id]);
 
-  if (applicationFormSubmission.status === "idle") {
+  if (formioApplicationSubmission.status === "idle") {
     return null;
   }
 
-  if (applicationFormSubmission.status === "pending") {
+  if (formioApplicationSubmission.status === "pending") {
     return <Loading />;
   }
 
   const { userAccess, formSchema, submissionData } =
-    applicationFormSubmission.data;
+    formioApplicationSubmission.data;
 
   if (
-    applicationFormSubmission.status === "failure" ||
+    formioApplicationSubmission.status === "failure" ||
     !userAccess ||
     !formSchema ||
     !submissionData

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -20,6 +20,7 @@ import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { useContentState } from "contexts/content";
 import { useUserState } from "contexts/user";
+import { useCsbState } from "contexts/csb";
 import { useBapState } from "contexts/bap";
 
 // -----------------------------------------------------------------------------
@@ -234,7 +235,8 @@ function ApplicationFormContent() {
   const navigate = useNavigate();
   const { id } = useParams<"id">();
   const { content } = useContentState();
-  const { csbData, epaUserData } = useUserState();
+  const { epaUserData } = useUserState();
+  const { csbData } = useCsbState();
   const { samEntities, applicationSubmissions: bapApplicationSubmissions } =
     useBapState();
   const dispatch = useApplicationFormDispatch();

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -276,7 +276,7 @@ function ApplicationFormContent() {
       },
     });
 
-    getData(`${serverUrl}/api/application-form-submission/${id}`)
+    getData(`${serverUrl}/api/formio-application-submission/${id}`)
       .then((res) => {
         // set up s3 re-route to wrapper app
         const s3Provider = Formio.Providers.providers.storage.s3;
@@ -509,7 +509,7 @@ function ApplicationFormContent() {
             setPendingSubmissionData(data);
 
             postData(
-              `${serverUrl}/api/application-form-submission/${submissionData._id}`,
+              `${serverUrl}/api/formio-application-submission/${submissionData._id}`,
               { ...submission, data }
             )
               .then((res) => {
@@ -594,7 +594,7 @@ function ApplicationFormContent() {
             setPendingSubmissionData(data);
 
             postData(
-              `${serverUrl}/api/application-form-submission/${submissionData._id}`,
+              `${serverUrl}/api/formio-application-submission/${submissionData._id}`,
               { ...submission, data, state: "draft" }
             )
               .then((res) => {

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -66,7 +66,7 @@ export function Helpdesk() {
   const dispatch = useDialogDispatch();
   const helpdeskAccess = useHelpdeskAccess();
 
-  const [applicationFormSubmission, setApplicationFormSubmission] =
+  const [formioApplicationSubmission, setFormioApplicationSubmission] =
     useState<SubmissionState>({
       status: "idle",
       data: {
@@ -90,7 +90,7 @@ export function Helpdesk() {
 
   const { enrollmentClosed } = csbData.data;
 
-  const { formSchema, submissionData } = applicationFormSubmission.data;
+  const { formSchema, submissionData } = formioApplicationSubmission.data;
 
   return (
     <>
@@ -111,7 +111,7 @@ export function Helpdesk() {
             setFormId("");
             setFormDisplayed(false);
 
-            setApplicationFormSubmission({
+            setFormioApplicationSubmission({
               status: "pending",
               data: {
                 formSchema: null,
@@ -124,14 +124,14 @@ export function Helpdesk() {
             )
               .then((res) => {
                 setFormId(res.submissionData._id);
-                setApplicationFormSubmission({
+                setFormioApplicationSubmission({
                   status: "success",
                   data: res,
                 });
               })
               .catch((err) => {
                 setFormId("");
-                setApplicationFormSubmission({
+                setFormioApplicationSubmission({
                   status: "failure",
                   data: {
                     formSchema: null,
@@ -159,9 +159,9 @@ export function Helpdesk() {
         </form>
       </div>
 
-      {applicationFormSubmission.status === "pending" && <Loading />}
+      {formioApplicationSubmission.status === "pending" && <Loading />}
 
-      {applicationFormSubmission.status === "failure" && (
+      {formioApplicationSubmission.status === "failure" && (
         <Message
           type="error"
           text={messages.helpdeskApplicationSubmissionError}
@@ -174,15 +174,15 @@ export function Helpdesk() {
         from an external server, we should check that it exists first before
         using it
       */}
-      {applicationFormSubmission.status === "success" &&
-        !applicationFormSubmission.data && (
+      {formioApplicationSubmission.status === "success" &&
+        !formioApplicationSubmission.data && (
           <Message
             type="error"
             text={messages.helpdeskApplicationSubmissionError}
           />
         )}
 
-      {applicationFormSubmission.status === "success" &&
+      {formioApplicationSubmission.status === "success" &&
         formSchema &&
         submissionData && (
           <>
@@ -281,7 +281,7 @@ export function Helpdesk() {
                               confirmedAction: () => {
                                 setFormDisplayed(false);
 
-                                setApplicationFormSubmission({
+                                setFormioApplicationSubmission({
                                   status: "pending",
                                   data: {
                                     formSchema: null,
@@ -294,13 +294,13 @@ export function Helpdesk() {
                                   {}
                                 )
                                   .then((res) => {
-                                    setApplicationFormSubmission({
+                                    setFormioApplicationSubmission({
                                       status: "success",
                                       data: res,
                                     });
                                   })
                                   .catch((err) => {
-                                    setApplicationFormSubmission({
+                                    setFormioApplicationSubmission({
                                       status: "failure",
                                       data: {
                                         formSchema: null,

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -12,6 +12,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/infoTooltip";
 import { useContentState } from "contexts/content";
 import { useUserState } from "contexts/user";
+import { useCsbState } from "contexts/csb";
 import { useDialogDispatch } from "contexts/dialog";
 
 type SubmissionState =
@@ -62,7 +63,8 @@ export function Helpdesk() {
   const [formDisplayed, setFormDisplayed] = useState(false);
 
   const { content } = useContentState();
-  const { csbData, epaUserData } = useUserState();
+  const { epaUserData } = useUserState();
+  const { csbData } = useCsbState();
   const dispatch = useDialogDispatch();
   const helpdeskAccess = useHelpdeskAccess();
 

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -120,7 +120,7 @@ export function Helpdesk() {
             });
 
             getData(
-              `${serverUrl}/help/application-form-submission/${searchText}`
+              `${serverUrl}/help/formio-application-submission/${searchText}`
             )
               .then((res) => {
                 setFormId(res.submissionData._id);
@@ -290,7 +290,7 @@ export function Helpdesk() {
                                 });
 
                                 postData(
-                                  `${serverUrl}/help/application-form-submission/${formId}`,
+                                  `${serverUrl}/help/formio-application-submission/${formId}`,
                                   {}
                                 )
                                   .then((res) => {

--- a/app/client/src/routes/newApplicationForm.tsx
+++ b/app/client/src/routes/newApplicationForm.tsx
@@ -16,7 +16,7 @@ import { SamEntity, useBapState } from "contexts/bap";
 function createNewApplication(email: string, entity: SamEntity) {
   const { title, name } = getUserInfo(email, entity);
 
-  return postData(`${serverUrl}/api/application-form-submission/`, {
+  return postData(`${serverUrl}/api/formio-application-submission/`, {
     data: {
       last_updated_by: email,
       hidden_current_user_email: email,

--- a/app/client/src/routes/newApplicationForm.tsx
+++ b/app/client/src/routes/newApplicationForm.tsx
@@ -11,9 +11,9 @@ import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/infoTooltip";
 import { useContentState } from "contexts/content";
 import { useUserState } from "contexts/user";
-import { SamEntity, useBapState } from "contexts/bap";
+import { BapSamEntity, useBapState } from "contexts/bap";
 
-function createNewApplication(email: string, entity: SamEntity) {
+function createNewApplication(email: string, entity: BapSamEntity) {
   const { title, name } = getUserInfo(email, entity);
 
   return postData(`${serverUrl}/api/formio-application-submission/`, {

--- a/app/client/src/routes/newApplicationForm.tsx
+++ b/app/client/src/routes/newApplicationForm.tsx
@@ -10,7 +10,8 @@ import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/infoTooltip";
 import { useContentState } from "contexts/content";
-import { SamEntity, useUserState } from "contexts/user";
+import { useUserState } from "contexts/user";
+import { SamEntity, useBapState } from "contexts/bap";
 
 function createNewApplication(email: string, entity: SamEntity) {
   const { title, name } = getUserInfo(email, entity);
@@ -41,7 +42,8 @@ function createNewApplication(email: string, entity: SamEntity) {
 export function NewApplicationForm() {
   const navigate = useNavigate();
   const { content } = useContentState();
-  const { csbData, epaUserData, bapUserData } = useUserState();
+  const { csbData, epaUserData } = useUserState();
+  const { samEntities } = useBapState();
 
   const [message, setMessage] = useState<{
     displayed: boolean;
@@ -56,14 +58,14 @@ export function NewApplicationForm() {
   if (
     csbData.status !== "success" ||
     epaUserData.status !== "success" ||
-    bapUserData.status !== "success"
+    samEntities.status !== "success"
   ) {
     return <Loading />;
   }
 
   const email = epaUserData.data.mail;
 
-  const activeSamEntities = bapUserData.data.samEntities.filter((entity) => {
+  const activeSamEntities = samEntities.data.entities.filter((entity) => {
     return entity.ENTITY_STATUS__c === "Active";
   });
 
@@ -80,7 +82,7 @@ export function NewApplicationForm() {
               {csbData.data.enrollmentClosed ? (
                 <Message type="info" text={messages.enrollmentClosed} />
               ) : activeSamEntities.length <= 0 ? (
-                <Message type="info" text={messages.noSamResults} />
+                <Message type="info" text={messages.bapNoSamResults} />
               ) : (
                 <>
                   {content.status === "success" && (

--- a/app/client/src/routes/newApplicationForm.tsx
+++ b/app/client/src/routes/newApplicationForm.tsx
@@ -11,6 +11,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/infoTooltip";
 import { useContentState } from "contexts/content";
 import { useUserState } from "contexts/user";
+import { useCsbState } from "contexts/csb";
 import { BapSamEntity, useBapState } from "contexts/bap";
 
 function createNewApplication(email: string, entity: BapSamEntity) {
@@ -42,7 +43,8 @@ function createNewApplication(email: string, entity: BapSamEntity) {
 export function NewApplicationForm() {
   const navigate = useNavigate();
   const { content } = useContentState();
-  const { csbData, epaUserData } = useUserState();
+  const { epaUserData } = useUserState();
+  const { csbData } = useCsbState();
   const { samEntities } = useBapState();
 
   const [message, setMessage] = useState<{

--- a/app/client/src/routes/paymentForm.tsx
+++ b/app/client/src/routes/paymentForm.tsx
@@ -22,7 +22,7 @@ export function PaymentForm() {
   });
 
   useEffect(() => {
-    getData(`${serverUrl}/api/payment-form-schema`)
+    getData(`${serverUrl}/api/formio-payment-request-schema`)
       .then((res) => setPaymentFormSchema({ status: "success", data: res }))
       .catch((err) => setPaymentFormSchema({ status: "failure", data: null }));
   }, []);

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -13,28 +13,32 @@ type FormSchema =
   | { status: "success"; data: object }
   | { status: "failure"; data: null };
 
-export function PaymentForm() {
+export function PaymentRequestForm() {
   const { id } = useParams<"id">();
 
-  const [paymentFormSchema, setPaymentFormSchema] = useState<FormSchema>({
+  const [paymentRequestSchema, setPaymentRequestSchema] = useState<FormSchema>({
     status: "idle",
     data: null,
   });
 
   useEffect(() => {
     getData(`${serverUrl}/api/formio-payment-request-schema`)
-      .then((res) => setPaymentFormSchema({ status: "success", data: res }))
-      .catch((err) => setPaymentFormSchema({ status: "failure", data: null }));
+      .then((res) => {
+        setPaymentRequestSchema({ status: "success", data: res });
+      })
+      .catch((err) => {
+        setPaymentRequestSchema({ status: "failure", data: null });
+      });
   }, []);
 
   if (
-    paymentFormSchema.status === "idle" ||
-    paymentFormSchema.status === "pending"
+    paymentRequestSchema.status === "idle" ||
+    paymentRequestSchema.status === "pending"
   ) {
     return <Loading />;
   }
 
-  if (paymentFormSchema.status === "failure") {
+  if (paymentRequestSchema.status === "failure") {
     return (
       <Message type="error" text="Error loading Payment Request form schema." />
     );
@@ -55,7 +59,7 @@ export function PaymentForm() {
         </li>
       </ul>
 
-      <Form form={paymentFormSchema.data} />
+      <Form form={paymentRequestSchema.data} />
     </div>
   );
 }

--- a/app/client/src/routes/welcome.tsx
+++ b/app/client/src/routes/welcome.tsx
@@ -35,19 +35,19 @@ export function Welcome() {
       });
     }
 
-    if (searchParams.get("error") === "bap-fetch") {
+    if (searchParams.get("error") === "bap-sam-fetch") {
       setMessage({
         displayed: true,
         type: "error",
-        text: messages.bapFetchError,
+        text: messages.bapSamFetchError,
       });
     }
 
-    if (searchParams.get("info") === "sam-results") {
+    if (searchParams.get("info") === "bap-sam-results") {
       setMessage({
         displayed: true,
         type: "info",
-        text: messages.noSamResults,
+        text: messages.bapNoSamResults,
       });
     }
 

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -1,10 +1,10 @@
-import { SamEntity } from "contexts/bap";
+import { BapSamEntity } from "contexts/bap";
 
 /**
  * Returns a user’s title and name when provided an email address and a SAM.gov
  * entity/record.
  */
-export function getUserInfo(email: string, entity: SamEntity) {
+export function getUserInfo(email: string, entity: BapSamEntity) {
   const samEmailFields = [
     "ELEC_BUS_POC_EMAIL__c",
     "ALT_ELEC_BUS_POC_EMAIL__c",
@@ -30,7 +30,7 @@ export function getUserInfo(email: string, entity: SamEntity) {
   const fieldPrefix = matchedEmailField?.split("_EMAIL__c").shift();
 
   return {
-    title: entity[`${fieldPrefix}_TITLE__c` as keyof SamEntity] as string,
-    name: entity[`${fieldPrefix}_NAME__c` as keyof SamEntity] as string,
+    title: entity[`${fieldPrefix}_TITLE__c` as keyof BapSamEntity] as string,
+    name: entity[`${fieldPrefix}_NAME__c` as keyof BapSamEntity] as string,
   };
 }

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -1,4 +1,4 @@
-import { SamEntity } from "contexts/user";
+import { SamEntity } from "contexts/bap";
 
 /**
  * Returns a user’s title and name when provided an email address and a SAM.gov

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -193,7 +193,7 @@ router.get("/formio-application-submissions", storeBapComboKeys, (req, res) => {
 });
 
 // --- post a new Application form submission to Forms.gov
-router.post("/application-form-submission", storeBapComboKeys, (req, res) => {
+router.post("/formio-application-submission", storeBapComboKeys, (req, res) => {
   const comboKey = req.body.data?.bap_hidden_entity_combo_key;
 
   if (enrollmentClosed) {
@@ -226,7 +226,7 @@ router.post("/application-form-submission", storeBapComboKeys, (req, res) => {
 
 // --- get an existing Application form's schema and submission data from Forms.gov
 router.get(
-  "/application-form-submission/:id",
+  "/formio-application-submission/:id",
   verifyMongoObjectId,
   storeBapComboKeys,
   async (req, res) => {
@@ -268,7 +268,7 @@ router.get(
 
 // --- post an update to an existing draft Application form submission to Forms.gov
 router.post(
-  "/application-form-submission/:id",
+  "/formio-application-submission/:id",
   verifyMongoObjectId,
   storeBapComboKeys,
   (req, res) => {
@@ -402,7 +402,7 @@ router.post("/payment-form-submission", storeBapComboKeys, (req, res) => {
     });
 });
 
-// --- TODO: WIP, as we'll eventually mirror `router.get("/application-form-submission/:id")`
+// --- TODO: WIP, as we'll eventually mirror `router.get("/formio-application-submission/:id")`
 router.get("/payment-form-schema", storeBapComboKeys, (req, res) => {
   axiosFormio(req)
     .get(paymentFormApiPath)

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -144,11 +144,11 @@ router.get("/bap-sam-data", (req, res) => {
         return res.json({ results: false, entities: [] });
       }
       return res.json({ results: true, entities });
-        })
-        .catch((error) => {
+    })
+    .catch((error) => {
       const message = `Error getting SAM.gov data from BAP`;
       return res.status(401).json({ message });
-        });
+    });
 });
 
 // --- get user's Application form submissions from EPA's BAP
@@ -164,7 +164,7 @@ router.get("/bap-application-submissions", storeBapComboKeys, (req, res) => {
 const applicationFormApiPath = `${formioProjectUrl}/${formioApplicationFormPath}`;
 
 // --- get user's Application form submissions from Forms.gov
-router.get("/application-form-submissions", storeBapComboKeys, (req, res) => {
+router.get("/formio-application-submissions", storeBapComboKeys, (req, res) => {
   // NOTE: Helpdesk users might not have any SAM.gov records associated with
   // their email address so we should not return any submissions to those users.
   // The only reason we explicitly need to do this is because there could be

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -23,9 +23,9 @@ router.use(ensureHelpdesk);
 
 const applicationFormApiPath = `${formioProjectUrl}/${formioApplicationFormPath}`;
 
-// --- get an existing application form's submission data from Forms.gov
+// --- get an existing Application form's submission data from Forms.gov
 router.get(
-  "/application-form-submission/:id",
+  "/formio-application-submission/:id",
   verifyMongoObjectId,
   (req, res) => {
     const { id } = req.params;
@@ -54,9 +54,9 @@ router.get(
   }
 );
 
-// --- change a submitted Forms.gov application form's submission state back to draft
+// --- change a submitted Forms.gov Application form's submission state back to draft
 router.post(
-  "/application-form-submission/:id",
+  "/formio-application-submission/:id",
   verifyMongoObjectId,
   (req, res) => {
     const { id } = req.params;

--- a/app/server/app/routes/status.js
+++ b/app/server/app/routes/status.js
@@ -13,7 +13,7 @@ router.get("/app", (req, res) => {
   res.json({ status: true });
 });
 
-router.get("/bap", (req, res) => {
+router.get("/bap-sam-data", (req, res) => {
   getSamData("CleanSchoolBus@erg.com", req)
     .then(() => {
       res.json({ status: true });
@@ -25,7 +25,7 @@ router.get("/bap", (req, res) => {
 
 const applicationFormApiPath = `${formioProjectUrl}/${formioApplicationFormPath}`;
 
-router.get("/application-form", (req, res) => {
+router.get("/formio-application-schema", (req, res) => {
   axiosFormio(req)
     .get(applicationFormApiPath)
     .then((axiosRes) => axiosRes.data)

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -7,7 +7,7 @@ const express = require("express");
 const log = require("../utilities/logger");
 
 /**
- * @typedef {Object} SamEntity
+ * @typedef {Object} BapSamEntity
  * @property {string} ENTITY_COMBO_KEY__c
  * @property {string} ENTITY_STATUS__c
  * @property {string} UNIQUE_ENTITY_ID__c
@@ -37,7 +37,7 @@ const log = require("../utilities/logger");
  */
 
 /**
- * @typedef {Object} ApplicationFormSubmission
+ * @typedef {Object} BapApplicationSubmission
  * @property {string} CSB_Form_ID__c
  * @property {string} CSB_Modified_Full_String__c
  * @property {string} UEI_EFTI_Combo_Key__c
@@ -91,7 +91,7 @@ function setupConnection(app) {
  * Uses cached JSforce connection to query the BAP for SAM.gov entities.
  * @param {string} email
  * @param {express.Request} req
- * @returns {Promise<SamEntity[]>} collection of SAM.gov entities
+ * @returns {Promise<BapSamEntity[]>} collection of SAM.gov entities
  */
 async function queryForSamEntities(email, req) {
   /** @type {jsforce.Connection} */
@@ -193,9 +193,9 @@ function getComboKeys(email, req) {
  * Uses cached JSforce connection to query the BAP for application form submissions.
  * @param {string[]} comboKeys
  * @param {express.Request} req
- * @returns {Promise<ApplicationFormSubmission[]>} collection of application form submissions
+ * @returns {Promise<BapApplicationSubmission[]>} collection of application form submissions
  */
-async function queryForApplicationFormSubmissions(comboKeys, req) {
+async function queryForApplicationSubmissions(comboKeys, req) {
   /** @type {jsforce.Connection} */
   const bapConnection = req.app.locals.bapConnection;
   return await bapConnection
@@ -227,7 +227,7 @@ function getApplicationSubmissionsData(comboKeys, req) {
     log({ level: "info", message });
 
     return setupConnection(req.app)
-      .then(() => queryForApplicationFormSubmissions(comboKeys, req))
+      .then(() => queryForApplicationSubmissions(comboKeys, req))
       .catch((err) => {
         const message = `BAP Error: ${err}`;
         log({ level: "error", message, req });
@@ -235,7 +235,7 @@ function getApplicationSubmissionsData(comboKeys, req) {
       });
   }
 
-  return queryForApplicationFormSubmissions(comboKeys, req).catch((err) => {
+  return queryForApplicationSubmissions(comboKeys, req).catch((err) => {
     if (err?.toString() === "invalid_grant: expired access/refresh token") {
       const message = `BAP access token expired`;
       log({ level: "info", message, req });
@@ -245,7 +245,7 @@ function getApplicationSubmissionsData(comboKeys, req) {
     }
 
     return setupConnection(req.app)
-      .then(() => queryForApplicationFormSubmissions(comboKeys, req))
+      .then(() => queryForApplicationSubmissions(comboKeys, req))
       .catch((retryErr) => {
         const message = `BAP Error: ${retryErr}`;
         log({ level: "error", message, req });

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -183,9 +183,7 @@ function getSamData(email, req) {
  */
 function getComboKeys(email, req) {
   return getSamData(email, req)
-    .then((samEntities) => {
-      return samEntities.map((samEntity) => samEntity.ENTITY_COMBO_KEY__c);
-    })
+    .then((entities) => entities.map((entity) => entity.ENTITY_COMBO_KEY__c))
     .catch((err) => {
       throw err;
     });

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -21,9 +21,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/bap": {
+    "/status/bap-sam-data": {
       "get": {
-        "summary": "/status/bap",
+        "summary": "/status/bap-sam-data",
         "responses": {
           "200": {
             "description": "OK"
@@ -33,9 +33,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/application-form": {
+    "/status/formio-application-schema": {
       "get": {
-        "summary": "/status/application-form",
+        "summary": "/status/formio-application-schema",
         "responses": {
           "200": {
             "description": "OK"
@@ -142,9 +142,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/help/application-form-submission/{id}": {
+    "/help/formio-application-submission/{id}": {
       "get": {
-        "summary": "/help/application-form-submission/{id}",
+        "summary": "/help/formio-application-submission/{id}",
         "parameters": [
           {
             "name": "id",
@@ -192,7 +192,7 @@
         "tags": []
       },
       "post": {
-        "summary": "/help/application-form-submission/{id}",
+        "summary": "/help/formio-application-submission/{id}",
         "parameters": [
           {
             "name": "id",
@@ -495,9 +495,9 @@
         ]
       }
     },
-    "/api/application-form-submission": {
+    "/api/formio-application-submission": {
       "post": {
-        "summary": "/api/application-form-submission",
+        "summary": "/api/formio-application-submission",
         "responses": {
           "200": {
             "description": "OK",
@@ -539,9 +539,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/api/application-form-submission/{id}": {
+    "/api/formio-application-submission/{id}": {
       "get": {
-        "summary": "/api/application-form-submission/{id}",
+        "summary": "/api/formio-application-submission/{id}",
         "parameters": [
           {
             "name": "id",
@@ -589,7 +589,7 @@
         "tags": []
       },
       "post": {
-        "summary": "/api/application-form-submission/{id}",
+        "summary": "/api/formio-application-submission/{id}",
         "parameters": [
           {
             "name": "id",

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -316,9 +316,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/api/epa-data": {
+    "/api/epa-user-data": {
       "get": {
-        "summary": "/api/epa-data",
+        "summary": "/api/epa-user-data",
         "responses": {
           "200": {
             "description": "OK",
@@ -365,9 +365,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/api/bap-data": {
+    "/api/bap-sam-data": {
       "get": {
-        "summary": "/api/bap-data",
+        "summary": "/api/bap-sam-data",
         "responses": {
           "200": {
             "description": "OK",
@@ -376,22 +376,38 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "samResults": {
+                    "results": {
                       "type": "boolean",
                       "example": true
                     },
-                    "samEntities": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    },
-                    "rebateSubmissions": {
+                    "entities": {
                       "type": "array",
                       "items": {
                         "type": "object"
                       }
                     }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [],
+        "parameters": [{ "$ref": "#/components/parameters/scan" }]
+      }
+    },
+    "/api/bap-application-submissions": {
+      "get": {
+        "summary": "/api/bap-application-submissions",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
                   }
                 }
               }

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -517,9 +517,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/api/application-form-submissions": {
+    "/api/formio-application-submissions": {
       "get": {
-        "summary": "/api/application-form-submissions",
+        "summary": "/api/formio-application-submissions",
         "responses": {
           "200": {
             "description": "OK",


### PR DESCRIPTION
Split up BAP server endpoints that returns BAP data (no need to wait until BAP application submissions are returned before fetching them from Forms.gov), prefix data from where it's fetched (as now we'll be fetching submissions from both the BAP and Forms.gov for multiple forms), and better organize storage of data client-side in separate context components.