### PR TITLE
Feature/further build out payment request

### DIFF
--- a/app/client/src/components/loading.tsx
+++ b/app/client/src/components/loading.tsx
@@ -1,6 +1,7 @@
 // NOTE: React JSX doesn't support namespaces, so `uswds/img/loader.svg` copied
 // into app's `images/loader.svg` with namespace tags removed
 import loader from "images/loader.svg";
+import loaderWhite from "images/loader-white.svg";
 
 export function Loading() {
   return (
@@ -8,5 +9,15 @@ export function Loading() {
       <span className="usa-sr-only">Loading...</span>
       <img src={loader} alt="" className="height-5 is-loading" />
     </div>
+  );
+}
+
+export function LoadingButtonIcon() {
+  return (
+    <img
+      src={loaderWhite}
+      alt="Loading..."
+      className="margin-left-105 margin-y-neg-05 height-2 is-loading"
+    />
   );
 }

--- a/app/client/src/contexts/formio.tsx
+++ b/app/client/src/contexts/formio.tsx
@@ -60,6 +60,16 @@ export type FormioPaymentRequestSubmission = {
   };
 };
 
+export type FormioCloseOutSubmission = {
+  [field: string]: unknown;
+  _id: string; // MongoDB ObjectId string
+  state: "submitted" | "draft";
+  modified: string; // ISO 8601 date string
+  data: {
+    [field: string]: unknown;
+  };
+};
+
 type State = {
   applicationSubmissions:
     | { status: "idle"; data: [] }

--- a/app/client/src/images/loader-white.svg
+++ b/app/client/src/images/loader-white.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  version="1.0"
+  width="80px"
+  height="80px"
+  viewBox="0 0 128 128"
+>
+  <g>
+    <path
+      d="M38.52 33.37L21.36 16.2A63.6 63.6 0 0 1 59.5.16v24.3a39.5 39.5 0 0 0-20.98 8.92z"
+      fill="#ffffff"
+      fill-opacity="1"
+    />
+    <path
+      d="M38.52 33.37L21.36 16.2A63.6 63.6 0 0 1 59.5.16v24.3a39.5 39.5 0 0 0-20.98 8.92z"
+      fill="#c0c0c0"
+      fill-opacity="0.25"
+      transform="rotate(45 64 64)"
+    />
+    <path
+      d="M38.52 33.37L21.36 16.2A63.6 63.6 0 0 1 59.5.16v24.3a39.5 39.5 0 0 0-20.98 8.92z"
+      fill="#c0c0c0"
+      fill-opacity="0.25"
+      transform="rotate(90 64 64)"
+    />
+    <path
+      d="M38.52 33.37L21.36 16.2A63.6 63.6 0 0 1 59.5.16v24.3a39.5 39.5 0 0 0-20.98 8.92z"
+      fill="#c0c0c0"
+      fill-opacity="0.25"
+      transform="rotate(135 64 64)"
+    />
+    <path
+      d="M38.52 33.37L21.36 16.2A63.6 63.6 0 0 1 59.5.16v24.3a39.5 39.5 0 0 0-20.98 8.92z"
+      fill="#c0c0c0"
+      fill-opacity="0.25"
+      transform="rotate(180 64 64)"
+    />
+    <path
+      d="M38.52 33.37L21.36 16.2A63.6 63.6 0 0 1 59.5.16v24.3a39.5 39.5 0 0 0-20.98 8.92z"
+      fill="#c0c0c0"
+      fill-opacity="0.25"
+      transform="rotate(225 64 64)"
+    />
+    <path
+      d="M38.52 33.37L21.36 16.2A63.6 63.6 0 0 1 59.5.16v24.3a39.5 39.5 0 0 0-20.98 8.92z"
+      fill="#c0c0c0"
+      fill-opacity="0.25"
+      transform="rotate(270 64 64)"
+    />
+    <path
+      d="M38.52 33.37L21.36 16.2A63.6 63.6 0 0 1 59.5.16v24.3a39.5 39.5 0 0 0-20.98 8.92z"
+      fill="#c0c0c0"
+      fill-opacity="0.25"
+      transform="rotate(315 64 64)"
+    />
+    <animateTransform
+      attributeName="transform"
+      type="rotate"
+      values="0 64 64;45 64 64;90 64 64;135 64 64;180 64 64;225 64 64;270 64 64;315 64 64"
+      calcMode="discrete"
+      dur="720ms"
+      repeatCount="indefinite"
+    ></animateTransform>
+  </g>
+</svg>

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -618,7 +618,8 @@ function PaymentRequestSubmission({ rebate }: { rebate: Rebate }) {
   // return if a Payment Request submission has not been created for this rebate
   if (!paymentRequest.formio) return null;
 
-  const { last_updated_by, hidden_bap_rebate_id } = paymentRequest.formio.data;
+  const { hidden_current_user_email, hidden_bap_rebate_id } =
+    paymentRequest.formio.data;
 
   const date = new Date(paymentRequest.formio.modified).toLocaleDateString();
   const time = new Date(paymentRequest.formio.modified).toLocaleTimeString();
@@ -768,7 +769,7 @@ function PaymentRequestSubmission({ rebate }: { rebate: Rebate }) {
       <td className={statusStyles}>&nbsp;</td>
 
       <td className={statusStyles}>
-        {last_updated_by}
+        {hidden_current_user_email}
         <br />
         <span title={`${date} ${time}`}>{date}</span>
       </td>

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -53,6 +53,8 @@ function useFetchedFormioApplicationSubmissions() {
   const dispatch = useFormioDispatch();
 
   useEffect(() => {
+    // while not used in this code, SAM.gov entities are used in the server
+    // app's `/api/formio-application-submissions` route controller
     if (samEntities.status !== "success" || !samEntities.data.results) {
       return;
     }
@@ -73,11 +75,13 @@ function useFetchedFormioApplicationSubmissions() {
 }
 
 /** Custom hook to fetch Application form submissions from the BAP */
-function useFetchedBapApplicationSubmissions() {
+export function useFetchedBapApplicationSubmissions() {
   const { samEntities } = useBapState();
   const dispatch = useBapDispatch();
 
   useEffect(() => {
+    // while not used in this code, SAM.gov entities are used in the server
+    // app's `/api/bap-application-submissions` route controller
     if (samEntities.status !== "success" || !samEntities.data.results) {
       return;
     }

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -6,6 +6,7 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import { serverUrl, getData, postData } from "../config";
 import { getUserInfo } from "../utilities";
+import { useFetchedBapApplicationSubmissions } from "routes/allRebates";
 import { Loading } from "components/loading";
 import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
@@ -36,6 +37,8 @@ export function ApplicationForm() {
   useEffect(() => {
     dispatch({ type: "RESET_STATE" });
   }, [dispatch]);
+
+  useFetchedBapApplicationSubmissions();
 
   // set when form submission data is initially fetched, and then re-set each
   // time a successful update of the submission data is posted to forms.gov

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -431,7 +431,6 @@ router.post(
         // issue with the field being changed to an object when the form loads
         const newSubmission = {
           data: {
-            last_updated_by: email,
             hidden_current_user_email: email,
             hidden_current_user_title: title,
             hidden_current_user_name: name,


### PR DESCRIPTION
Implements some UI/UX improvements to the dashboard around payment requests:
- Adds a loading icon after a new payment request button is clicked (while the BAP fetch and Formio/Forms.gov post is happening)
- Correctly shows the last updated user's email for payment requests in table
- Sorts submissions by Formio last modified date across all three forms (while still grouping by Rebate ID)
- Highlights Applications that have been "Selected" but no payment request have been created yet, and moves those rows to the top of the table

Additionally, fixes a bug that caused a never ending loading spinner if a user accessed an Application form submission page directly (either not visiting the dashboard first, e.g. clicking a hyperlink to it, or refreshing the page after visiting the page), due to the BAP data for that submission no longer being cached in memory.