### PR TITLE
Feature/further build out payment request features

### DIFF
--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -292,15 +292,14 @@ function useSortedSubmissions(submissions: { [rebateId: string]: Rebate }) {
           (r1.application.formio.state === "submitted" &&
             !r1AapplicationHasBeenUpdated));
 
-      // Application has been selected, but a Payment Request submission has not
-      // yet been created
-      const r1ApplicationSelectedButNoPaymentRequest =
+      const r1ApplicationHasBeenSelectedButNoPaymentRequest =
         r1.application.bap?.rebateStatus === "Selected" &&
-        !r1.paymentRequest.formio;
+        !Boolean(r1.paymentRequest.formio);
 
       // first sort by Applications needing edits or selected Applications that
       // still need Payment Requests, then sort by most recient formio modified date
-      return r1ApplicationNeedsEdits || r1ApplicationSelectedButNoPaymentRequest
+      return r1ApplicationNeedsEdits ||
+        r1ApplicationHasBeenSelectedButNoPaymentRequest
         ? -1
         : mostRecientR2Modified - mostRecientR1Modified;
     });
@@ -319,6 +318,9 @@ function ApplicationSubmission({ rebate }: { rebate: Rebate }) {
 
   const applicationHasBeenSelected =
     application.bap?.rebateStatus === "Selected";
+
+  const applicationHasBeenSelectedButNoPaymentRequest =
+    applicationHasBeenSelected && !Boolean(paymentRequest.formio);
 
   const {
     applicantUEI,
@@ -371,10 +373,7 @@ function ApplicationSubmission({ rebate }: { rebate: Rebate }) {
   return (
     <tr
       className={
-        // Application needs edits, or it has been selected and
-        // a Payment Request submission has not yet been created
-        applicationNeedsEdits ||
-        (applicationHasBeenSelected && !paymentRequest.formio)
+        applicationNeedsEdits || applicationHasBeenSelectedButNoPaymentRequest
           ? highlightedTableRowClassNames
           : defaultTableRowClassNames
       }
@@ -620,6 +619,9 @@ function PaymentRequestSubmission({ rebate }: { rebate: Rebate }) {
   const applicationHasBeenSelected =
     application.bap?.rebateStatus === "Selected";
 
+  const applicationHasBeenSelectedButNoPaymentRequest =
+    applicationHasBeenSelected && !Boolean(paymentRequest.formio);
+
   /** matched SAM.gov entity for the application */
   const entity = samEntities.data.entities.find((entity) => {
     return (
@@ -629,8 +631,7 @@ function PaymentRequestSubmission({ rebate }: { rebate: Rebate }) {
     );
   });
 
-  // Application has been selected, but a Payment Request submission has not yet been created
-  if (applicationHasBeenSelected && !paymentRequest.formio) {
+  if (applicationHasBeenSelectedButNoPaymentRequest) {
     return (
       <tr className={highlightedTableRowClassNames}>
         <th scope="row" colSpan={6}>

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -47,7 +47,7 @@ export function ApplicationForm() {
 
   // create ref to storedSubmissionData, so the latest value can be referenced
   // in the Form component's `onNextPage` event prop
-  const storedSubmissionDataRef = useRef(storedSubmissionData);
+  const storedSubmissionDataRef = useRef<FormioSubmissionData>({});
 
   // initially empty, but will be set once the user attemts to submit the form
   // (both successfully and unsuccessfully). passed to the to the <Form />
@@ -78,8 +78,8 @@ export function ApplicationForm() {
         if (data.hasOwnProperty("ncesDataSource")) delete data.ncesDataSource;
         if (data.hasOwnProperty("ncesDataLookup")) delete data.ncesDataLookup;
 
-        setStoredSubmissionData((prevData) => {
-          storedSubmissionDataRef.current = data;
+        setStoredSubmissionData((_prevData) => {
+          storedSubmissionDataRef.current = cloneDeep(data);
           return data;
         });
 
@@ -216,38 +216,6 @@ export function ApplicationForm() {
               submission.state === "submitted",
             noAlerts: true,
           }}
-          onChange={(onChangeSubmission: {
-            [field: string]: unknown;
-            changed: {
-              [field: string]: unknown;
-              component: {
-                [field: string]: unknown;
-                key: string;
-              };
-            };
-          }) => {
-            // NOTE: For some unknown reason, whenever the bus info's "Save"
-            // button (the component w/ the key "busInformation") is clicked
-            // the `storedSubmissionDataRef` value is mutated, which invalidates
-            // the isEqual() early return "dirty check" used in the onNextPage
-            // event callback below (as the two objects being compared are now
-            // equal). That means if the user changed any of the bus info fields
-            // (which are displayed via a Formio "Edit Grid" component, which
-            // includes its own "Save" button that must be clicked) and clicked
-            // the form's "Next" button without making any other form field
-            // changes, the "dirty check" incorrectly fails, and the updated
-            // form data was not posted. The fix below should resolve that issue
-            // as now we're intentionally mutating the `storedSubmissionDataRef`
-            // to an empty object whenever the Edit Grid's "Save" button is
-            // clicked (which must be clicked to close the bus info fields) to
-            // guarantee the "dirty check" succeeds the next time the form's
-            // "Next" button is clicked.
-            if (
-              onChangeSubmission?.changed?.component?.key === "busInformation"
-            ) {
-              storedSubmissionDataRef.current = {};
-            }
-          }}
           onSubmit={(onSubmitSubmission: {
             state: "submitted" | "draft";
             data: FormioSubmissionData;
@@ -284,8 +252,8 @@ export function ApplicationForm() {
               { ...onSubmitSubmission, data }
             )
               .then((res) => {
-                setStoredSubmissionData((prevData) => {
-                  storedSubmissionDataRef.current = res.data;
+                setStoredSubmissionData((_prevData) => {
+                  storedSubmissionDataRef.current = cloneDeep(res.data);
                   return res.data;
                 });
 
@@ -376,8 +344,8 @@ export function ApplicationForm() {
               { ...onNextPageParam.submission, data, state: "draft" }
             )
               .then((res) => {
-                setStoredSubmissionData((prevData) => {
-                  storedSubmissionDataRef.current = res.data;
+                setStoredSubmissionData((_prevData) => {
+                  storedSubmissionDataRef.current = cloneDeep(res.data);
                   return res.data;
                 });
 

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -43,7 +43,7 @@ export function PaymentRequestForm() {
 
   // create ref to storedSubmissionData, so the latest value can be referenced
   // in the Form component's `onNextPage` event prop
-  const storedSubmissionDataRef = useRef(storedSubmissionData);
+  const storedSubmissionDataRef = useRef<FormioSubmissionData>({});
 
   // initially empty, but will be set once the user attemts to submit the form
   // (both successfully and unsuccessfully). passed to the to the <Form />
@@ -71,8 +71,8 @@ export function PaymentRequestForm() {
 
         const data = { ...res.submission.data };
 
-        setStoredSubmissionData((prevData) => {
-          storedSubmissionDataRef.current = data;
+        setStoredSubmissionData((_prevData) => {
+          storedSubmissionDataRef.current = cloneDeep(data);
           return data;
         });
 
@@ -210,8 +210,8 @@ export function PaymentRequestForm() {
               }
             )
               .then((res) => {
-                setStoredSubmissionData((prevData) => {
-                  storedSubmissionDataRef.current = res.data;
+                setStoredSubmissionData((_prevData) => {
+                  storedSubmissionDataRef.current = cloneDeep(res.data);
                   return res.data;
                 });
 
@@ -301,8 +301,8 @@ export function PaymentRequestForm() {
               }
             )
               .then((res) => {
-                setStoredSubmissionData((prevData) => {
-                  storedSubmissionDataRef.current = res.data;
+                setStoredSubmissionData((_prevData) => {
+                  storedSubmissionDataRef.current = cloneDeep(res.data);
                   return res.data;
                 });
 

--- a/app/client/src/styles.css
+++ b/app/client/src/styles.css
@@ -55,8 +55,3 @@
 [data-reach-tooltip] {
   z-index: 100000;
 }
-
-/* --- CSB --- */
-.csb-needs-edits {
-  background-color: #d9e8f6 !important; /* USWDS primary-lighter */
-}


### PR DESCRIPTION
Applies a few small (but important) updates:
- Moves Applications marked as "Needs Edits" to the top of the table, and updates their styling method to be the same as "Selected" Applications (visually they'll still look the same with the blue background).

- Removes work-around code that fixed Application form submission form "dirty check" and implements it in a cleaner way for both the Application form and the Payment Request form (aside: JavaScript really needs a native deep copy operator, but we're already using lodash's `cloneDeep` so that's the solution here).

- Unifies some code in the `allRebates.tsx` file for better readability/maintainability.