### PR TITLE
Feature/update fetching formio application submissions

### DIFF
--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -194,6 +194,7 @@ router.get("/formio-application-submissions", storeBapComboKeys, (req, res) => {
     `${req.bapComboKeys.join("&data.bap_hidden_entity_combo_key=")}` +
     `&select=_id,state,modified,` +
     `data.last_updated_by,` +
+    `data.bap_hidden_entity_combo_key` +
     `data.applicantUEI,` +
     `data.applicantEfti,` +
     `data.applicantEfti_display,` +


### PR DESCRIPTION
Add bap combo key to field returned in formio application form submissions data (was accidentally removed in last PR where we intentionally limited the fields returned)