### PR TITLE
Feature/fix formio field typo

### DIFF
--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -194,7 +194,7 @@ router.get("/formio-application-submissions", storeBapComboKeys, (req, res) => {
     `${req.bapComboKeys.join("&data.bap_hidden_entity_combo_key=")}` +
     `&select=_id,state,modified,` +
     `data.last_updated_by,` +
-    `data.bap_hidden_entity_combo_key` +
+    `data.bap_hidden_entity_combo_key,` +
     `data.applicantUEI,` +
     `data.applicantEfti,` +
     `data.applicantEfti_display,` +


### PR DESCRIPTION
Add missing comma in userSubmissionsUrl in selected fields to return (take 2!)