### PR TITLE
Feature/fix form re-rendering bug

### DIFF
--- a/app/client/src/contexts/page.tsx
+++ b/app/client/src/contexts/page.tsx
@@ -37,11 +37,6 @@ export type FormioFetchedResponse =
     };
 
 type State = {
-  message: {
-    displayed: boolean;
-    type: "info" | "success" | "warning" | "error";
-    text: string;
-  };
   formio:
     | { status: "idle"; data: NoFormioData }
     | { status: "pending"; data: NoFormioData }
@@ -51,11 +46,6 @@ type State = {
 
 type Action =
   | { type: "RESET_STATE" }
-  | {
-      type: "DISPLAY_MESSAGE";
-      payload: { type: "info" | "success" | "warning" | "error"; text: string };
-    }
-  | { type: "RESET_MESSAGE" }
   | { type: "FETCH_FORMIO_DATA_REQUEST" }
   | {
       type: "FETCH_FORMIO_DATA_SUCCESS";
@@ -67,11 +57,6 @@ const StateContext = createContext<State | undefined>(undefined);
 const DispatchContext = createContext<Dispatch<Action> | undefined>(undefined);
 
 const initialState: State = {
-  message: {
-    displayed: false,
-    type: "info",
-    text: "",
-  },
   formio: {
     status: "idle",
     data: {
@@ -86,29 +71,6 @@ function reducer(state: State, action: Action): State {
   switch (action.type) {
     case "RESET_STATE": {
       return initialState;
-    }
-
-    case "DISPLAY_MESSAGE": {
-      const { type, text } = action.payload;
-      return {
-        ...state,
-        message: {
-          displayed: true,
-          type,
-          text,
-        },
-      };
-    }
-
-    case "RESET_MESSAGE": {
-      return {
-        ...state,
-        message: {
-          displayed: false,
-          type: "info",
-          text: "",
-        },
-      };
     }
 
     case "FETCH_FORMIO_DATA_REQUEST": {

--- a/app/client/src/contexts/pageFormio.tsx
+++ b/app/client/src/contexts/pageFormio.tsx
@@ -45,7 +45,7 @@ type State = {
 };
 
 type Action =
-  | { type: "RESET_STATE" }
+  | { type: "RESET_FORMIO_DATA" }
   | { type: "FETCH_FORMIO_DATA_REQUEST" }
   | {
       type: "FETCH_FORMIO_DATA_SUCCESS";
@@ -69,7 +69,7 @@ const initialState: State = {
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
-    case "RESET_STATE": {
+    case "RESET_FORMIO_DATA": {
       return initialState;
     }
 
@@ -119,7 +119,7 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-export function PageProvider({ children }: Props) {
+export function PageFormioProvider({ children }: Props) {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   return (
@@ -132,12 +132,12 @@ export function PageProvider({ children }: Props) {
 }
 
 /**
- * Returns state stored in `PageProvider` context component.
+ * Returns state stored in `PageFormioProvider` context component.
  */
-export function usePageState() {
+export function usePageFormioState() {
   const context = useContext(StateContext);
   if (context === undefined) {
-    const message = `usePageState must be called within a PageProvider`;
+    const message = `usePageFormioState must be called within a PageFormioProvider`;
     throw new Error(message);
   }
   return context;
@@ -145,12 +145,12 @@ export function usePageState() {
 
 /**
  * Returns `dispatch` method for dispatching actions to update state stored in
- * `PageProvider` context component.
+ * `PageFormioProvider` context component.
  */
-export function usePageDispatch() {
+export function usePageFormioDispatch() {
   const context = useContext(DispatchContext);
   if (context === undefined) {
-    const message = `usePageDispatch must be used within a PageProvider`;
+    const message = `usePageFormioDispatch must be used within a PageFormioProvider`;
     throw new Error(message);
   }
   return context;

--- a/app/client/src/contexts/pageMessage.tsx
+++ b/app/client/src/contexts/pageMessage.tsx
@@ -1,0 +1,96 @@
+import {
+  Dispatch,
+  ReactNode,
+  createContext,
+  useContext,
+  useReducer,
+} from "react";
+
+type Props = {
+  children: ReactNode;
+};
+
+type State = {
+  displayed: boolean;
+  type: "info" | "success" | "warning" | "error";
+  text: string;
+};
+
+type Action =
+  | {
+      type: "DISPLAY_MESSAGE";
+      payload: { type: "info" | "success" | "warning" | "error"; text: string };
+    }
+  | { type: "RESET_MESSAGE" };
+
+const StateContext = createContext<State | undefined>(undefined);
+const DispatchContext = createContext<Dispatch<Action> | undefined>(undefined);
+
+const initialState: State = {
+  displayed: false,
+  type: "info",
+  text: "",
+};
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "DISPLAY_MESSAGE": {
+      const { type, text } = action.payload;
+      return {
+        displayed: true,
+        type,
+        text,
+      };
+    }
+
+    case "RESET_MESSAGE": {
+      return {
+        displayed: false,
+        type: "info",
+        text: "",
+      };
+    }
+
+    default: {
+      const message = `Unhandled action type: ${action}`;
+      throw new Error(message);
+    }
+  }
+}
+
+export function PageMessageProvider({ children }: Props) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <StateContext.Provider value={state}>
+      <DispatchContext.Provider value={dispatch}>
+        {children}
+      </DispatchContext.Provider>
+    </StateContext.Provider>
+  );
+}
+
+/**
+ * Returns state stored in `PageMessageProvider` context component.
+ */
+export function usePageMessageState() {
+  const context = useContext(StateContext);
+  if (context === undefined) {
+    const message = `usePageMessageState must be called within a PageMessageProvider`;
+    throw new Error(message);
+  }
+  return context;
+}
+
+/**
+ * Returns `dispatch` method for dispatching actions to update state stored in
+ * `PageMessageProvider` context component.
+ */
+export function usePageMessageDispatch() {
+  const context = useContext(DispatchContext);
+  if (context === undefined) {
+    const message = `usePageMessageDispatch must be used within a PageMessageProvider`;
+    throw new Error(message);
+  }
+  return context;
+}

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -8,6 +8,7 @@ import { UserProvider } from "contexts/user";
 import { CsbProvider } from "contexts/csb";
 import { BapProvider } from "contexts/bap";
 import { FormioProvider } from "contexts/formio";
+import { PageMessageProvider } from "contexts/pageMessage";
 import { PageProvider } from "contexts/page";
 import { ErrorBoundary } from "components/errorBoundary";
 import { App } from "components/app";
@@ -24,9 +25,11 @@ render(
             <CsbProvider>
               <BapProvider>
                 <FormioProvider>
-                  <PageProvider>
-                    <App />
-                  </PageProvider>
+                  <PageMessageProvider>
+                    <PageProvider>
+                      <App />
+                    </PageProvider>
+                  </PageMessageProvider>
                 </FormioProvider>
               </BapProvider>
             </CsbProvider>

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -9,7 +9,7 @@ import { CsbProvider } from "contexts/csb";
 import { BapProvider } from "contexts/bap";
 import { FormioProvider } from "contexts/formio";
 import { PageMessageProvider } from "contexts/pageMessage";
-import { PageProvider } from "contexts/page";
+import { PageFormioProvider } from "contexts/pageFormio";
 import { ErrorBoundary } from "components/errorBoundary";
 import { App } from "components/app";
 import "./styles.css";
@@ -26,9 +26,9 @@ render(
               <BapProvider>
                 <FormioProvider>
                   <PageMessageProvider>
-                    <PageProvider>
+                    <PageFormioProvider>
                       <App />
-                    </PageProvider>
+                    </PageFormioProvider>
                   </PageMessageProvider>
                 </FormioProvider>
               </BapProvider>

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -15,11 +15,21 @@ import { useUserState } from "contexts/user";
 import { useCsbState } from "contexts/csb";
 import { useBapState } from "contexts/bap";
 import {
+  usePageMessageState,
+  usePageMessageDispatch,
+} from "contexts/pageMessage";
+import {
   FormioSubmissionData,
   FormioFetchedResponse,
   usePageState,
   usePageDispatch,
 } from "contexts/page";
+
+function PageMessage() {
+  const { displayed, type, text } = usePageMessageState();
+  if (!displayed) return null;
+  return <Message type={type} text={text} />;
+}
 
 export function ApplicationForm() {
   const { epaUserData } = useUserState();
@@ -46,8 +56,14 @@ function ApplicationFormContent({ email }: { email: string }) {
   const { csbData } = useCsbState();
   const { samEntities, applicationSubmissions: bapApplicationSubmissions } =
     useBapState();
-  const { message, formio } = usePageState();
+  const { formio } = usePageState();
+  const pageMessageDispatch = usePageMessageDispatch();
   const pageDispatch = usePageDispatch();
+
+  // reset page message state since it's used across pages
+  useEffect(() => {
+    pageMessageDispatch({ type: "RESET_MESSAGE" });
+  }, [pageMessageDispatch]);
 
   // reset page context state
   useEffect(() => {
@@ -184,7 +200,7 @@ function ApplicationFormContent({ email }: { email: string }) {
         />
       )}
 
-      {message.displayed && <Message type={message.type} text={message.text} />}
+      <PageMessage />
 
       <ul className="usa-icon-list">
         <li className="usa-icon-list__item">
@@ -248,14 +264,14 @@ function ApplicationFormContent({ email }: { email: string }) {
             }
 
             if (onSubmitSubmission.state === "submitted") {
-              pageDispatch({
+              pageMessageDispatch({
                 type: "DISPLAY_MESSAGE",
                 payload: { type: "info", text: "Submitting form..." },
               });
             }
 
             if (onSubmitSubmission.state === "draft") {
-              pageDispatch({
+              pageMessageDispatch({
                 type: "DISPLAY_MESSAGE",
                 payload: { type: "info", text: "Saving form..." },
               });
@@ -276,7 +292,7 @@ function ApplicationFormContent({ email }: { email: string }) {
                 setPendingSubmissionData({});
 
                 if (onSubmitSubmission.state === "submitted") {
-                  pageDispatch({
+                  pageMessageDispatch({
                     type: "DISPLAY_MESSAGE",
                     payload: {
                       type: "success",
@@ -285,14 +301,14 @@ function ApplicationFormContent({ email }: { email: string }) {
                   });
 
                   setTimeout(() => {
-                    pageDispatch({ type: "RESET_MESSAGE" });
+                    pageMessageDispatch({ type: "RESET_MESSAGE" });
                     navigate("/");
                   }, 5000);
                   return;
                 }
 
                 if (onSubmitSubmission.state === "draft") {
-                  pageDispatch({
+                  pageMessageDispatch({
                     type: "DISPLAY_MESSAGE",
                     payload: {
                       type: "success",
@@ -301,12 +317,12 @@ function ApplicationFormContent({ email }: { email: string }) {
                   });
 
                   setTimeout(() => {
-                    pageDispatch({ type: "RESET_MESSAGE" });
+                    pageMessageDispatch({ type: "RESET_MESSAGE" });
                   }, 5000);
                 }
               })
               .catch((err) => {
-                pageDispatch({
+                pageMessageDispatch({
                   type: "DISPLAY_MESSAGE",
                   payload: {
                     type: "error",
@@ -348,7 +364,7 @@ function ApplicationFormContent({ email }: { email: string }) {
             delete storedDataToCheck.hidden_current_user_name;
             if (isEqual(dataToCheck, storedDataToCheck)) return;
 
-            pageDispatch({
+            pageMessageDispatch({
               type: "DISPLAY_MESSAGE",
               payload: { type: "info", text: "Saving form..." },
             });
@@ -367,7 +383,7 @@ function ApplicationFormContent({ email }: { email: string }) {
 
                 setPendingSubmissionData({});
 
-                pageDispatch({
+                pageMessageDispatch({
                   type: "DISPLAY_MESSAGE",
                   payload: {
                     type: "success",
@@ -376,11 +392,11 @@ function ApplicationFormContent({ email }: { email: string }) {
                 });
 
                 setTimeout(() => {
-                  pageDispatch({ type: "RESET_MESSAGE" });
+                  pageMessageDispatch({ type: "RESET_MESSAGE" });
                 }, 5000);
               })
               .catch((err) => {
-                pageDispatch({
+                pageMessageDispatch({
                   type: "DISPLAY_MESSAGE",
                   payload: {
                     type: "error",
@@ -392,7 +408,7 @@ function ApplicationFormContent({ email }: { email: string }) {
         />
       </div>
 
-      {message.displayed && <Message type={message.type} text={message.text} />}
+      <PageMessage />
     </div>
   );
 }

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -21,9 +21,9 @@ import {
 import {
   FormioSubmissionData,
   FormioFetchedResponse,
-  usePageState,
-  usePageDispatch,
-} from "contexts/page";
+  usePageFormioState,
+  usePageFormioDispatch,
+} from "contexts/pageFormio";
 
 function PageMessage() {
   const { displayed, type, text } = usePageMessageState();
@@ -56,19 +56,19 @@ function ApplicationFormContent({ email }: { email: string }) {
   const { csbData } = useCsbState();
   const { samEntities, applicationSubmissions: bapApplicationSubmissions } =
     useBapState();
-  const { formio } = usePageState();
+  const { formio } = usePageFormioState();
   const pageMessageDispatch = usePageMessageDispatch();
-  const pageDispatch = usePageDispatch();
+  const pageFormioDispatch = usePageFormioDispatch();
 
   // reset page message state since it's used across pages
   useEffect(() => {
     pageMessageDispatch({ type: "RESET_MESSAGE" });
   }, [pageMessageDispatch]);
 
-  // reset page context state
+  // reset page formio state since it's used across pages
   useEffect(() => {
-    pageDispatch({ type: "RESET_STATE" });
-  }, [pageDispatch]);
+    pageFormioDispatch({ type: "RESET_FORMIO_DATA" });
+  }, [pageFormioDispatch]);
 
   useFetchedBapApplicationSubmissions();
 
@@ -89,7 +89,7 @@ function ApplicationFormContent({ email }: { email: string }) {
     useState<FormioSubmissionData>({});
 
   useEffect(() => {
-    pageDispatch({ type: "FETCH_FORMIO_DATA_REQUEST" });
+    pageFormioDispatch({ type: "FETCH_FORMIO_DATA_REQUEST" });
 
     getData(`${serverUrl}/api/formio-application-submission/${mongoId}`)
       .then((res: FormioFetchedResponse) => {
@@ -115,15 +115,15 @@ function ApplicationFormContent({ email }: { email: string }) {
           return data;
         });
 
-        pageDispatch({
+        pageFormioDispatch({
           type: "FETCH_FORMIO_DATA_SUCCESS",
           payload: { data: res },
         });
       })
       .catch((err) => {
-        pageDispatch({ type: "FETCH_FORMIO_DATA_FAILURE" });
+        pageFormioDispatch({ type: "FETCH_FORMIO_DATA_FAILURE" });
       });
-  }, [mongoId, pageDispatch]);
+  }, [mongoId, pageFormioDispatch]);
 
   if (formio.status === "idle") {
     return null;

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -16,9 +16,9 @@ import { useUserState } from "contexts/user";
 import { useCsbState } from "contexts/csb";
 import {
   FormioFetchedResponse,
-  usePageState,
-  usePageDispatch,
-} from "contexts/page";
+  usePageFormioState,
+  usePageFormioDispatch,
+} from "contexts/pageFormio";
 
 type FormType = "application" | "paymentRequest" | "closeOut";
 
@@ -29,14 +29,14 @@ export function Helpdesk() {
   const dialogDispatch = useDialogDispatch();
   const { epaUserData } = useUserState();
   const { csbData } = useCsbState();
-  const { formio } = usePageState();
-  const pageDispatch = usePageDispatch();
+  const { formio } = usePageFormioState();
+  const pageFormioDispatch = usePageFormioDispatch();
   const helpdeskAccess = useHelpdeskAccess();
 
-  // reset page context state
+  // reset page formio state since it's used across pages
   useEffect(() => {
-    pageDispatch({ type: "RESET_STATE" });
-  }, [pageDispatch]);
+    pageFormioDispatch({ type: "RESET_FORMIO_DATA" });
+  }, [pageFormioDispatch]);
 
   const [formType, setFormType] = useState<FormType>("application");
   const [searchId, setSearchId] = useState("");
@@ -80,7 +80,7 @@ export function Helpdesk() {
               checked={formType === "application"}
               onChange={(ev) => {
                 setFormType(ev.target.value as FormType);
-                pageDispatch({ type: "RESET_STATE" });
+                pageFormioDispatch({ type: "RESET_FORMIO_DATA" });
               }}
             />
             <label
@@ -101,7 +101,7 @@ export function Helpdesk() {
               checked={formType === "paymentRequest"}
               onChange={(ev) => {
                 setFormType(ev.target.value as FormType);
-                pageDispatch({ type: "RESET_STATE" });
+                pageFormioDispatch({ type: "RESET_FORMIO_DATA" });
               }}
             />
             <label
@@ -122,7 +122,7 @@ export function Helpdesk() {
               checked={formType === "closeOut"}
               onChange={(ev) => {
                 setFormType(ev.target.value as FormType);
-                pageDispatch({ type: "RESET_STATE" });
+                pageFormioDispatch({ type: "RESET_FORMIO_DATA" });
               }}
               disabled={true} // NOTE: disabled until the close-out form is created
             />
@@ -141,19 +141,19 @@ export function Helpdesk() {
           onSubmit={(ev) => {
             ev.preventDefault();
             setFormDisplayed(false);
-            pageDispatch({ type: "FETCH_FORMIO_DATA_REQUEST" });
+            pageFormioDispatch({ type: "FETCH_FORMIO_DATA_REQUEST" });
             getData(
               `${serverUrl}/help/formio-submission/${formType}/${searchId}`
             )
               .then((res: FormioFetchedResponse) => {
                 if (!res.submission) return;
-                pageDispatch({
+                pageFormioDispatch({
                   type: "FETCH_FORMIO_DATA_SUCCESS",
                   payload: { data: res },
                 });
               })
               .catch((err) => {
-                pageDispatch({ type: "FETCH_FORMIO_DATA_FAILURE" });
+                pageFormioDispatch({ type: "FETCH_FORMIO_DATA_FAILURE" });
               });
           }}
         >
@@ -334,7 +334,7 @@ export function Helpdesk() {
                             cancelText: "Cancel",
                             confirmedAction: () => {
                               setFormDisplayed(false);
-                              pageDispatch({
+                              pageFormioDispatch({
                                 type: "FETCH_FORMIO_DATA_REQUEST",
                               });
                               postData(
@@ -342,13 +342,13 @@ export function Helpdesk() {
                                 {}
                               )
                                 .then((res: FormioFetchedResponse) => {
-                                  pageDispatch({
+                                  pageFormioDispatch({
                                     type: "FETCH_FORMIO_DATA_SUCCESS",
                                     payload: { data: res },
                                   });
                                 })
                                 .catch((err) => {
-                                  pageDispatch({
+                                  pageFormioDispatch({
                                     type: "FETCH_FORMIO_DATA_FAILURE",
                                   });
                                 });

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -20,9 +20,9 @@ import {
 import {
   FormioSubmissionData,
   FormioFetchedResponse,
-  usePageState,
-  usePageDispatch,
-} from "contexts/page";
+  usePageFormioState,
+  usePageFormioDispatch,
+} from "contexts/pageFormio";
 
 function PageMessage() {
   const { displayed, type, text } = usePageMessageState();
@@ -54,19 +54,19 @@ function PaymentRequestFormContent({ email }: { email: string }) {
   const { content } = useContentState();
   const { csbData } = useCsbState();
   const { samEntities } = useBapState();
-  const { formio } = usePageState();
+  const { formio } = usePageFormioState();
   const pageMessageDispatch = usePageMessageDispatch();
-  const pageDispatch = usePageDispatch();
+  const pageFormioDispatch = usePageFormioDispatch();
 
   // reset page message state since it's used across pages
   useEffect(() => {
     pageMessageDispatch({ type: "RESET_MESSAGE" });
   }, [pageMessageDispatch]);
 
-  // reset page context state
+  // reset page formio state since it's used across pages
   useEffect(() => {
-    pageDispatch({ type: "RESET_STATE" });
-  }, [pageDispatch]);
+    pageFormioDispatch({ type: "RESET_FORMIO_DATA" });
+  }, [pageFormioDispatch]);
 
   // set when form submission data is initially fetched, and then re-set each
   // time a successful update of the submission data is posted to forms.gov
@@ -85,7 +85,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
     useState<FormioSubmissionData>({});
 
   useEffect(() => {
-    pageDispatch({ type: "FETCH_FORMIO_DATA_REQUEST" });
+    pageFormioDispatch({ type: "FETCH_FORMIO_DATA_REQUEST" });
 
     getData(`${serverUrl}/api/formio-payment-request-submission/${rebateId}`)
       .then((res: FormioFetchedResponse) => {
@@ -108,15 +108,15 @@ function PaymentRequestFormContent({ email }: { email: string }) {
           return data;
         });
 
-        pageDispatch({
+        pageFormioDispatch({
           type: "FETCH_FORMIO_DATA_SUCCESS",
           payload: { data: res },
         });
       })
       .catch((err) => {
-        pageDispatch({ type: "FETCH_FORMIO_DATA_FAILURE" });
+        pageFormioDispatch({ type: "FETCH_FORMIO_DATA_FAILURE" });
       });
-  }, [rebateId, pageDispatch]);
+  }, [rebateId, pageFormioDispatch]);
 
   if (formio.status === "idle") {
     return null;

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -14,11 +14,21 @@ import { useUserState } from "contexts/user";
 import { useCsbState } from "contexts/csb";
 import { useBapState } from "contexts/bap";
 import {
+  usePageMessageState,
+  usePageMessageDispatch,
+} from "contexts/pageMessage";
+import {
   FormioSubmissionData,
   FormioFetchedResponse,
   usePageState,
   usePageDispatch,
 } from "contexts/page";
+
+function PageMessage() {
+  const { displayed, type, text } = usePageMessageState();
+  if (!displayed) return null;
+  return <Message type={type} text={text} />;
+}
 
 export function PaymentRequestForm() {
   const { epaUserData } = useUserState();
@@ -44,8 +54,14 @@ function PaymentRequestFormContent({ email }: { email: string }) {
   const { content } = useContentState();
   const { csbData } = useCsbState();
   const { samEntities } = useBapState();
-  const { message, formio } = usePageState();
+  const { formio } = usePageState();
+  const pageMessageDispatch = usePageMessageDispatch();
   const pageDispatch = usePageDispatch();
+
+  // reset page message state since it's used across pages
+  useEffect(() => {
+    pageMessageDispatch({ type: "RESET_MESSAGE" });
+  }, [pageMessageDispatch]);
 
   // reset page context state
   useEffect(() => {
@@ -162,7 +178,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
         />
       )}
 
-      {message.displayed && <Message type={message.type} text={message.text} />}
+      <PageMessage />
 
       <ul className="usa-icon-list">
         <li className="usa-icon-list__item">
@@ -203,14 +219,14 @@ function PaymentRequestFormContent({ email }: { email: string }) {
             const data = { ...onSubmitSubmission.data };
 
             if (onSubmitSubmission.state === "submitted") {
-              pageDispatch({
+              pageMessageDispatch({
                 type: "DISPLAY_MESSAGE",
                 payload: { type: "info", text: "Submitting form..." },
               });
             }
 
             if (onSubmitSubmission.state === "draft") {
-              pageDispatch({
+              pageMessageDispatch({
                 type: "DISPLAY_MESSAGE",
                 payload: { type: "info", text: "Saving form..." },
               });
@@ -234,7 +250,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
                 setPendingSubmissionData({});
 
                 if (onSubmitSubmission.state === "submitted") {
-                  pageDispatch({
+                  pageMessageDispatch({
                     type: "DISPLAY_MESSAGE",
                     payload: {
                       type: "success",
@@ -243,14 +259,14 @@ function PaymentRequestFormContent({ email }: { email: string }) {
                   });
 
                   setTimeout(() => {
-                    pageDispatch({ type: "RESET_MESSAGE" });
+                    pageMessageDispatch({ type: "RESET_MESSAGE" });
                     navigate("/");
                   }, 5000);
                   return;
                 }
 
                 if (onSubmitSubmission.state === "draft") {
-                  pageDispatch({
+                  pageMessageDispatch({
                     type: "DISPLAY_MESSAGE",
                     payload: {
                       type: "success",
@@ -259,12 +275,12 @@ function PaymentRequestFormContent({ email }: { email: string }) {
                   });
 
                   setTimeout(() => {
-                    pageDispatch({ type: "RESET_MESSAGE" });
+                    pageMessageDispatch({ type: "RESET_MESSAGE" });
                   }, 5000);
                 }
               })
               .catch((err) => {
-                pageDispatch({
+                pageMessageDispatch({
                   type: "DISPLAY_MESSAGE",
                   payload: {
                     type: "error",
@@ -298,7 +314,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
             delete storedDataToCheck.hidden_current_user_name;
             if (isEqual(dataToCheck, storedDataToCheck)) return;
 
-            pageDispatch({
+            pageMessageDispatch({
               type: "DISPLAY_MESSAGE",
               payload: { type: "info", text: "Saving form..." },
             });
@@ -324,7 +340,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
 
                 setPendingSubmissionData({});
 
-                pageDispatch({
+                pageMessageDispatch({
                   type: "DISPLAY_MESSAGE",
                   payload: {
                     type: "success",
@@ -333,11 +349,11 @@ function PaymentRequestFormContent({ email }: { email: string }) {
                 });
 
                 setTimeout(() => {
-                  pageDispatch({ type: "RESET_MESSAGE" });
+                  pageMessageDispatch({ type: "RESET_MESSAGE" });
                 }, 5000);
               })
               .catch((err) => {
-                pageDispatch({
+                pageMessageDispatch({
                   type: "DISPLAY_MESSAGE",
                   payload: {
                     type: "error",
@@ -349,7 +365,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
         />
       </div>
 
-      {message.displayed && <Message type={message.type} text={message.text} />}
+      <PageMessage />
     </div>
   );
 }


### PR DESCRIPTION
Split up `page` context component into `pageMessage` and `pageFormio`, as the combined page state was causing the Application Form and Payment Request Forms to re-render when a page message was rendered.