### PR TITLE
Feature/update s3 api to be form specific

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -41,7 +41,7 @@ jobs:
       # SAML_PRIVATE_KEY: ${{ secrets.SAML_PRIVATE_KEY }}
       JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
       JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
-      CSB_ENROLLMENT_PERIOD: open
+      CSB_ENROLLMENT_PERIOD: closed
       FORMIO_PKG_AUTH_TOKEN: ${{ secrets.FORMIO_PKG_AUTH_TOKEN }}
       FORMIO_BASE_URL: ${{ secrets.FORMIO_BASE_URL }}
       FORMIO_PROJECT_NAME: ${{ secrets.FORMIO_PROJECT_NAME }}

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -20,7 +20,7 @@ import {
   usePageFormioDispatch,
 } from "contexts/pageFormio";
 
-type FormType = "application" | "paymentRequest" | "closeOut";
+type FormType = "application" | "payment-request" | "close-out";
 
 export function Helpdesk() {
   const navigate = useNavigate();
@@ -97,8 +97,8 @@ export function Helpdesk() {
               className="usa-radio__input"
               type="radio"
               name="form-type"
-              value="paymentRequest"
-              checked={formType === "paymentRequest"}
+              value="payment-request"
+              checked={formType === "payment-request"}
               onChange={(ev) => {
                 setFormType(ev.target.value as FormType);
                 pageFormioDispatch({ type: "RESET_FORMIO_DATA" });
@@ -118,8 +118,8 @@ export function Helpdesk() {
               className="usa-radio__input"
               type="radio"
               name="form-type"
-              value="closeOut"
-              checked={formType === "closeOut"}
+              value="close-out"
+              checked={formType === "close-out"}
               onChange={(ev) => {
                 setFormType(ev.target.value as FormType);
                 pageFormioDispatch({ type: "RESET_FORMIO_DATA" });
@@ -211,7 +211,7 @@ export function Helpdesk() {
                         tooltip="Formio submission's MongoDB Object ID"
                       />
                     </th>
-                  ) : formType === "paymentRequest" ? (
+                  ) : formType === "payment-request" ? (
                     <th scope="col">
                       <TextWithTooltip
                         text="Rebate ID"
@@ -279,7 +279,7 @@ export function Helpdesk() {
 
                   {formType === "application" ? (
                     <td>{submission._id}</td>
-                  ) : formType === "paymentRequest" ? (
+                  ) : formType === "payment-request" ? (
                     <td>{submission.data.hidden_bap_rebate_id as string}</td>
                   ) : (
                     <td>&nbsp;</td>
@@ -289,7 +289,7 @@ export function Helpdesk() {
                     <td>
                       {submission.data.sam_hidden_applicant_name as string}
                     </td>
-                  ) : formType === "paymentRequest" ? (
+                  ) : formType === "payment-request" ? (
                     <td>{submission.data.applicantName as string}</td>
                   ) : (
                     <td>&nbsp;</td>
@@ -297,7 +297,7 @@ export function Helpdesk() {
 
                   {formType === "application" ? (
                     <td>{submission.data.last_updated_by as string}</td>
-                  ) : formType === "paymentRequest" ? (
+                  ) : formType === "payment-request" ? (
                     <td>{submission.data.hidden_current_user_email}</td>
                   ) : (
                     <td>&nbsp;</td>
@@ -389,7 +389,7 @@ export function Helpdesk() {
                       <>
                         <strong>Application ID:</strong> {submission._id}
                       </>
-                    ) : formType === "paymentRequest" ? (
+                    ) : formType === "payment-request" ? (
                       <>
                         <strong>Rebate ID:</strong>{" "}
                         {submission.data.hidden_bap_rebate_id}

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -97,7 +97,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
           const s3Formio = cloneDeep(formio);
           const mongoId = res.submission._id;
           const comboKey = res.submission.data.bap_hidden_entity_combo_key;
-          s3Formio.formUrl = `${serverUrl}/api/${mongoId}/${comboKey}`;
+          s3Formio.formUrl = `${serverUrl}/api/s3/payment-request/${mongoId}/${comboKey}`;
           return s3Provider(s3Formio);
         };
 
@@ -149,6 +149,8 @@ function PaymentRequestFormContent({ email }: { email: string }) {
   ) {
     return <Loading />;
   }
+
+  const formIsReadOnly = submission.state === "submitted";
 
   const entityComboKey = storedSubmissionData.bap_hidden_entity_combo_key;
   const entity = samEntities.data.entities.find((entity) => {
@@ -208,7 +210,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
             },
           }}
           options={{
-            readOnly: submission.state === "submitted",
+            readOnly: formIsReadOnly,
             noAlerts: true,
           }}
           onSubmit={(onSubmitSubmission: {
@@ -216,6 +218,8 @@ function PaymentRequestFormContent({ email }: { email: string }) {
             data: FormioSubmissionData;
             metadata: unknown;
           }) => {
+            if (formIsReadOnly) return;
+
             const data = { ...onSubmitSubmission.data };
 
             if (onSubmitSubmission.state === "submitted") {
@@ -296,11 +300,9 @@ function PaymentRequestFormContent({ email }: { email: string }) {
               metadata: unknown;
             };
           }) => {
-            const data = { ...onNextPageParam.submission.data };
+            if (formIsReadOnly) return;
 
-            // don't post an update if form is not in draft state
-            // (form has been already submitted, and fields are read-only)
-            if (submission.state !== "draft") return;
+            const data = { ...onNextPageParam.submission.data };
 
             // don't post an update if no changes have been made to the form
             // (ignoring current user fields)

--- a/app/server/app/middleware.js
+++ b/app/server/app/middleware.js
@@ -145,7 +145,11 @@ function checkClientRouteExists(req, res, next) {
   const clientRoutes = ["/", "/welcome", "/helpdesk", "/rebate/new"].map(
     (route) => `${subPath}${route}`
   );
-  if (!clientRoutes.includes(req.path) && !req.path.includes("/rebate/")) {
+  if (
+    !clientRoutes.includes(req.path) &&
+    !req.path.includes("/rebate/") &&
+    !req.path.includes("/payment-request/")
+  ) {
     return res.status(404).sendFile(resolve(__dirname, "public/404.html"));
   }
   next();

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -52,7 +52,7 @@ router.get("/formio-submission/:formType/:id", (req, res) => {
       });
   }
 
-  if (formType === "paymentRequest") {
+  if (formType === "payment-request") {
     const rebateId = id;
 
     const matchedPaymentRequestFormSubmissions =
@@ -145,7 +145,7 @@ router.post("/formio-submission/:formType/:id", (req, res) => {
       });
   }
 
-  if (formType === "paymentRequest") {
+  if (formType === "payment-request") {
     const rebateId = id;
 
     const matchedPaymentRequestFormSubmissions =

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -397,17 +397,17 @@ function verifyBapConnection(req, { name, args }) {
 
   function callback() {
     return name(...args).catch((err) => {
-        const message = `BAP Error: ${err}`;
-        log({ level: "error", message, req });
-        throw err;
-      });
+      const message = `BAP Error: ${err}`;
+      log({ level: "error", message, req });
+      throw err;
+    });
   }
 
   if (!bapConnection) {
     const message = `BAP connection has not yet been initialized.`;
     log({ level: "info", message });
     return setupConnection(req.app).then(() => callback());
-    }
+  }
 
   return bapConnection
     .identity((err, res) => {

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -437,9 +437,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/api/{mongoId}/{comboKey}/storage/s3": {
+    "/api/s3/{formType}/{mongoId}/{comboKey}/storage/s3": {
       "get": {
-        "summary": "/api/{mongoId}/{comboKey}/storage/s3",
+        "summary": "/api/s3/{formType}/{mongoId}/{comboKey}/storage/s3",
         "responses": {
           "200": {
             "description": "OK"
@@ -447,6 +447,14 @@
         },
         "tags": [],
         "parameters": [
+          {
+            "name": "formType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "mongoId",
             "in": "path",
@@ -467,7 +475,7 @@
         ]
       },
       "post": {
-        "summary": "/api/{mongoId}/{comboKey}/storage/s3",
+        "summary": "/api/s3/{formType}/{mongoId}/{comboKey}/storage/s3",
         "responses": {
           "200": {
             "description": "OK"
@@ -475,6 +483,14 @@
         },
         "tags": [],
         "parameters": [
+          {
+            "name": "formType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "mongoId",
             "in": "path",


### PR DESCRIPTION
Update S3 server API endpoints to include form type, so we send the appropriate responses based on that's form's "open enrollment" status.

_NOTE:_ for now, only we only have a concept of "open enrollment" for the **Application** form, but we'll update the app to support that for the **Payment Request** form as well, in a future release.