### PR TITLE
Feature/update helpdesk update button disabled logic

### DIFF
--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -319,7 +319,8 @@ export function Helpdesk() {
                     <button
                       className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
                       disabled={
-                        enrollmentClosed || submission.state === "draft"
+                        submission.state === "draft" ||
+                        (formType === "application" && enrollmentClosed)
                       }
                       onClick={(_ev) => {
                         dialogDispatch({


### PR DESCRIPTION
Update logic that sets helpdesk's Update button to be disabled to account for form type when checking the 'open enrollment' status