### PR TITLE
Feature/update form submission logic

### DIFF
--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -1,5 +1,10 @@
 import { Fragment, useEffect, useState } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import {
+  Link,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from "react-router-dom";
 import icons from "uswds/img/sprite.svg";
 // ---
 import { serverUrl, messages, getData, postData } from "../config";
@@ -23,6 +28,10 @@ import {
   usePageMessageState,
   usePageMessageDispatch,
 } from "contexts/pageMessage";
+
+type LocationState = {
+  submissionSuccessMessage: string;
+};
 
 type Rebate = {
   application: {
@@ -336,10 +345,21 @@ function PageMessage() {
 }
 
 function ApplicationSubmission({ rebate }: { rebate: Rebate }) {
+  const location = useLocation();
   const navigate = useNavigate();
 
   const { csbData } = useCsbState();
   const pageMessageDispatch = usePageMessageDispatch();
+
+  const submissionSuccessMessage =
+    (location.state as LocationState)?.submissionSuccessMessage || null;
+
+  if (submissionSuccessMessage) {
+    pageMessageDispatch({
+      type: "DISPLAY_MESSAGE",
+      payload: { type: "success", text: submissionSuccessMessage },
+    });
+  }
 
   if (csbData.status !== "success") return null;
   const { enrollmentClosed } = csbData.data;

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -303,15 +303,8 @@ function ApplicationFormContent({ email }: { email: string }) {
                 setPendingSubmissionData({});
 
                 if (onSubmitSubmission.state === "submitted") {
-                  pageMessageDispatch({
-                    type: "DISPLAY_MESSAGE",
-                    payload: {
-                      type: "success",
-                      text: "Form successfully submitted.",
-                    },
-                  });
-
-                  navigate("/");
+                  const submissionSuccessMessage = `Application Form ${mongoId} successfully submitted.`;
+                  navigate("/", { state: { submissionSuccessMessage } });
                 }
 
                 if (onSubmitSubmission.state === "draft") {

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -311,11 +311,7 @@ function ApplicationFormContent({ email }: { email: string }) {
                     },
                   });
 
-                  setTimeout(() => {
-                    pageMessageDispatch({ type: "RESET_MESSAGE" });
-                    navigate("/");
-                  }, 5000);
-                  return;
+                  navigate("/");
                 }
 
                 if (onSubmitSubmission.state === "draft") {

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -72,6 +72,10 @@ function ApplicationFormContent({ email }: { email: string }) {
 
   useFetchedBapApplicationSubmissions();
 
+  // create ref to store when form is being submitted, so it can be referenced
+  // in the Form component's `onSubmit` event prop, to prevent double submits
+  const formIsBeingSubmitted = useRef(false);
+
   // set when form submission data is initially fetched, and then re-set each
   // time a successful update of the submission data is posted to forms.gov
   const [storedSubmissionData, setStoredSubmissionData] =
@@ -254,6 +258,12 @@ function ApplicationFormContent({ email }: { email: string }) {
           }) => {
             if (formIsReadOnly) return;
 
+            // account for when form is being submitted to prevent double submits
+            if (formIsBeingSubmitted.current) return;
+            if (onSubmitSubmission.state === "submitted") {
+              formIsBeingSubmitted.current = true;
+            }
+
             const data = { ...onSubmitSubmission.data };
 
             // remove `ncesDataSource` and `ncesDataLookup` fields
@@ -323,6 +333,8 @@ function ApplicationFormContent({ email }: { email: string }) {
                 }
               })
               .catch((err) => {
+                formIsBeingSubmitted.current = false;
+
                 pageMessageDispatch({
                   type: "DISPLAY_MESSAGE",
                   payload: {

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -68,6 +68,10 @@ function PaymentRequestFormContent({ email }: { email: string }) {
     pageFormioDispatch({ type: "RESET_FORMIO_DATA" });
   }, [pageFormioDispatch]);
 
+  // create ref to store when form is being submitted, so it can be referenced
+  // in the Form component's `onSubmit` event prop, to prevent double submits
+  const formIsBeingSubmitted = useRef(false);
+
   // set when form submission data is initially fetched, and then re-set each
   // time a successful update of the submission data is posted to forms.gov
   const [storedSubmissionData, setStoredSubmissionData] =
@@ -233,6 +237,12 @@ function PaymentRequestFormContent({ email }: { email: string }) {
           }) => {
             if (formIsReadOnly) return;
 
+            // account for when form is being submitted to prevent double submits
+            if (formIsBeingSubmitted.current) return;
+            if (onSubmitSubmission.state === "submitted") {
+              formIsBeingSubmitted.current = true;
+            }
+
             const data = { ...onSubmitSubmission.data };
 
             if (onSubmitSubmission.state === "submitted") {
@@ -297,6 +307,8 @@ function PaymentRequestFormContent({ email }: { email: string }) {
                 }
               })
               .catch((err) => {
+                formIsBeingSubmitted.current = false;
+
                 pageMessageDispatch({
                   type: "DISPLAY_MESSAGE",
                   payload: {

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -277,15 +277,8 @@ function PaymentRequestFormContent({ email }: { email: string }) {
                 setPendingSubmissionData({});
 
                 if (onSubmitSubmission.state === "submitted") {
-                  pageMessageDispatch({
-                    type: "DISPLAY_MESSAGE",
-                    payload: {
-                      type: "success",
-                      text: "Form successfully submitted.",
-                    },
-                  });
-
-                  navigate("/");
+                  const submissionSuccessMessage = `Payment Request Form ${rebateId} successfully submitted.`;
+                  navigate("/", { state: { submissionSuccessMessage } });
                 }
 
                 if (onSubmitSubmission.state === "draft") {

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -285,11 +285,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
                     },
                   });
 
-                  setTimeout(() => {
-                    pageMessageDispatch({ type: "RESET_MESSAGE" });
-                    navigate("/");
-                  }, 5000);
-                  return;
+                  navigate("/");
                 }
 
                 if (onSubmitSubmission.state === "draft") {


### PR DESCRIPTION
Updates form submission logic to prevent double submits and reduce the risk a user could click "Previous" and re-save a form (thereby changing it's state from "submitted" back to "draft") during the five seconds delay we showed a successful submission banner message to the user before re-directing them back to their dashboard.

Now that five second delay is gone and the user is re-directed back to the dashboard immediately where the successful submission message is shown.