### PR TITLE
Feature/unify github actions workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -118,7 +118,7 @@ jobs:
           cf set-env $APP_NAME "SAML_ENTITY_ID" "$SAML_ENTITY_ID" > /dev/null
           cf set-env $APP_NAME "SAML_IDP_CERT" "$SAML_IDP_CERT" > /dev/null
           cf set-env $APP_NAME "SAML_PUBLIC_KEY" "$SAML_PUBLIC_KEY" > /dev/null
-          cf set-env $APP_NAME "SAML_PRIVATE_KEY" "$SAML_PRIVATE_KEY" > /dev/null
+          # cf set-env $APP_NAME "SAML_PRIVATE_KEY" "$SAML_PRIVATE_KEY" > /dev/null
           cf set-env $APP_NAME "JWT_PUBLIC_KEY" "$JWT_PUBLIC_KEY" > /dev/null
           cf set-env $APP_NAME "JWT_PRIVATE_KEY" "$JWT_PRIVATE_KEY" > /dev/null
           cf set-env $APP_NAME "CSB_ENROLLMENT_PERIOD" "$CSB_ENROLLMENT_PERIOD" > /dev/null

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -38,6 +38,7 @@ jobs:
       SAML_ENTITY_ID: ${{ secrets.SAML_ENTITY_ID }}
       SAML_IDP_CERT: ${{ secrets.SAML_IDP_CERT }}
       SAML_PUBLIC_KEY: ${{ secrets.SAML_PUBLIC_KEY }}
+      # SAML_PRIVATE_KEY: ${{ secrets.SAML_PRIVATE_KEY }}
       JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
       JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
       CSB_ENROLLMENT_PERIOD: open
@@ -117,6 +118,7 @@ jobs:
           cf set-env $APP_NAME "SAML_ENTITY_ID" "$SAML_ENTITY_ID" > /dev/null
           cf set-env $APP_NAME "SAML_IDP_CERT" "$SAML_IDP_CERT" > /dev/null
           cf set-env $APP_NAME "SAML_PUBLIC_KEY" "$SAML_PUBLIC_KEY" > /dev/null
+          # cf set-env $APP_NAME "SAML_PRIVATE_KEY" "$SAML_PRIVATE_KEY" > /dev/null
           cf set-env $APP_NAME "JWT_PUBLIC_KEY" "$JWT_PUBLIC_KEY" > /dev/null
           cf set-env $APP_NAME "JWT_PRIVATE_KEY" "$JWT_PRIVATE_KEY" > /dev/null
           cf set-env $APP_NAME "CSB_ENROLLMENT_PERIOD" "$CSB_ENROLLMENT_PERIOD" > /dev/null


### PR DESCRIPTION
Keep `SAML_PRIVATE_KEY` in dev and proto GitHub Actions workflow files (for consistency across environments), just commented out as they're not needed for the SAML setup in those apps