### PR TITLE
Feature/update payment request read only logic

### DIFF
--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -156,18 +156,17 @@ function PaymentRequestFormContent({ email }: { email: string }) {
     return <Loading />;
   }
 
-  const match = bapFormSubmissions.data.paymentRequests.find((bapSub) => {
-    return bapSub.Parent_Rebate_ID__c === rebateId;
-  });
+  // const match = bapFormSubmissions.data.paymentRequests.find((bapSub) => {
+  //   return bapSub.Parent_Rebate_ID__c === rebateId;
+  // });
 
-  const bap = {
-    status: match?.Parent_CSB_Rebate__r?.CSB_Payment_Request_Status__c || null,
-  };
+  // const bap = {
+  //   status: match?.Parent_CSB_Rebate__r?.CSB_Payment_Request_Status__c || null,
+  // };
 
-  const paymentRequestNeedsEdits = bap.status === "Edits Requested";
+  // const paymentRequestNeedsEdits = bap.status === "Edits Requested";
 
-  const formIsReadOnly =
-    !paymentRequestNeedsEdits || submission.state === "submitted";
+  const formIsReadOnly = submission.state === "submitted";
 
   const entityComboKey = storedSubmissionData.bap_hidden_entity_combo_key;
   const entity = samEntities.data.entities.find((entity) => {


### PR DESCRIPTION
Update payment request form's read-only logic to only take submission state into account until open enrollment functionality for the payment request form has been implemented