### PR TITLE
Feature/implement payment request form deletion

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -141,7 +141,12 @@ function useInactivityDialog(callback: () => void) {
         payload: {
           dismissable: false,
           heading: "Inactivity Warning",
-          description: `You will be automatically logged out in ${logoutTimer} seconds due to inactivity.`,
+          description: (
+            <p>
+              You will be automatically logged out in {logoutTimer} seconds due
+              to inactivity.
+            </p>
+          ),
           confirmText: "Stay logged in",
           confirmedAction: () => {
             callback();

--- a/app/client/src/components/confirmationDialog.tsx
+++ b/app/client/src/components/confirmationDialog.tsx
@@ -16,8 +16,9 @@ export function ConfirmationDialog() {
     heading,
     description,
     confirmText,
-    cancelText,
+    dismissText,
     confirmedAction,
+    dismissedAction,
   } = useDialogState();
   const dialogDispatch = useDialogDispatch();
 
@@ -27,6 +28,7 @@ export function ConfirmationDialog() {
     <AlertDialogOverlay
       isOpen={dialogShown}
       onDismiss={(ev) => {
+        dismissable && dismissedAction && dismissedAction();
         dismissable && dialogDispatch({ type: "RESET_DIALOG" });
       }}
       leastDestructiveRef={cancelRef}
@@ -58,14 +60,17 @@ export function ConfirmationDialog() {
                   </button>
                 </li>
 
-                {dismissable && cancelText && (
+                {dismissable && dismissText && (
                   <li className="usa-button-group__item">
                     <button
                       ref={cancelRef}
                       className="usa-button"
-                      onClick={(ev) => dialogDispatch({ type: "RESET_DIALOG" })}
+                      onClick={(ev) => {
+                        dismissedAction && dismissedAction();
+                        dialogDispatch({ type: "RESET_DIALOG" });
+                      }}
                     >
-                      {cancelText}
+                      {dismissText}
                     </button>
                   </li>
                 )}
@@ -77,7 +82,10 @@ export function ConfirmationDialog() {
             <button
               className="usa-button usa-modal__close"
               aria-label="Close this window"
-              onClick={(ev) => dialogDispatch({ type: "RESET_DIALOG" })}
+              onClick={(ev) => {
+                dismissedAction && dismissedAction();
+                dialogDispatch({ type: "RESET_DIALOG" });
+              }}
             >
               <svg
                 className="usa-icon"

--- a/app/client/src/components/confirmationDialog.tsx
+++ b/app/client/src/components/confirmationDialog.tsx
@@ -41,9 +41,7 @@ export function ConfirmationDialog() {
             </AlertDialogLabel>
 
             <AlertDialogDescription>
-              <div className="usa-prose">
-                <p>{description}</p>
-              </div>
+              <div className="usa-prose">{description}</div>
             </AlertDialogDescription>
 
             <div className="usa-modal__footer">

--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -136,8 +136,12 @@ export function Dashboard() {
       payload: {
         dismissable: true,
         heading: "Are you sure you want to navigate away from this page?",
-        description:
-          "If you haven’t saved the current form, any changes you’ve made will be lost.",
+        description: (
+          <p>
+            If you haven’t saved the current form, any changes you’ve made will
+            be lost.
+          </p>
+        ),
         confirmText: "Yes",
         dismissText: "Cancel",
         confirmedAction: () => navigate(destination),

--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -139,7 +139,7 @@ export function Dashboard() {
         description:
           "If you haven’t saved the current form, any changes you’ve made will be lost.",
         confirmText: "Yes",
-        cancelText: "Cancel",
+        dismissText: "Cancel",
         confirmedAction: () => navigate(destination),
       },
     };

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -68,6 +68,8 @@ export const messages = {
   paymentRequestFormClosed:
     "The CSB Payment Request form enrollment period is closed.",
   closeOutFormClosed: "The CSB Close-Out form enrollment period is closed.",
+  paymentRequestFormWillBeDeleted:
+    "The Application form submission associated with this Payment Request form submission requires edits. As soon that Application form submission has been re-opened for editing, this Payment Request form submission will be deleted.",
 };
 
 async function fetchData(url: string, options: RequestInit) {

--- a/app/client/src/contexts/bap.tsx
+++ b/app/client/src/contexts/bap.tsx
@@ -43,10 +43,10 @@ export type BapSamEntity = {
 };
 
 export type BapFormSubmission = {
-  UEI_EFTI_Combo_Key__c: string;
+  UEI_EFTI_Combo_Key__c: string; // UEI + EFTI combo key
   CSB_Form_ID__c: string; // MongoDB ObjectId string
   CSB_Modified_Full_String__c: string; // ISO 8601 date string
-  CSB_Review_Item_ID__c: string; // CSB Rebate ID w/ form/version ID (9 digits)
+  CSB_Review_Item_ID__c: string; // CSB Rebate ID with form/version ID (9 digits)
   Parent_Rebate_ID__c: string; // CSB Rebate ID (6 digits)
   Record_Type_Name__c:
     | "CSB Funding Request"

--- a/app/client/src/contexts/dialog.tsx
+++ b/app/client/src/contexts/dialog.tsx
@@ -14,7 +14,7 @@ type State = {
   dialogShown: boolean;
   dismissable: boolean;
   heading: string;
-  description: string;
+  description: ReactNode;
   confirmText: string;
   dismissText?: string;
   confirmedAction: () => void;
@@ -27,7 +27,7 @@ export type Action =
       payload: {
         dismissable: boolean;
         heading: string;
-        description: string;
+        description: ReactNode;
         confirmText: string;
         dismissText?: string;
         confirmedAction: () => void;
@@ -37,7 +37,7 @@ export type Action =
   | {
       type: "UPDATE_DIALOG_DESCRIPTION";
       payload: {
-        description: string;
+        description: ReactNode;
       };
     }
   | { type: "RESET_DIALOG" };
@@ -83,7 +83,7 @@ function reducer(state: State, action: Action): State {
         dialogShown: false,
         dismissable: true,
         heading: "",
-        description: "",
+        description: null,
         confirmText: "",
         dismissText: "",
         confirmedAction: () => {},
@@ -103,7 +103,7 @@ export function DialogProvider({ children }: Props) {
     dialogShown: false,
     dismissable: true,
     heading: "",
-    description: "",
+    description: null,
     confirmText: "",
     dismissText: "",
     confirmedAction: () => {},

--- a/app/client/src/contexts/dialog.tsx
+++ b/app/client/src/contexts/dialog.tsx
@@ -16,8 +16,9 @@ type State = {
   heading: string;
   description: string;
   confirmText: string;
-  cancelText?: string;
+  dismissText?: string;
   confirmedAction: () => void;
+  dismissedAction?: () => void;
 };
 
 export type Action =
@@ -28,8 +29,9 @@ export type Action =
         heading: string;
         description: string;
         confirmText: string;
-        cancelText?: string;
+        dismissText?: string;
         confirmedAction: () => void;
+        dismissedAction?: () => void;
       };
     }
   | {
@@ -50,9 +52,10 @@ function reducer(state: State, action: Action): State {
         heading,
         description,
         confirmText,
-        cancelText,
+        dismissText,
         dismissable,
         confirmedAction,
+        dismissedAction,
       } = action.payload;
 
       return {
@@ -61,8 +64,9 @@ function reducer(state: State, action: Action): State {
         heading,
         description,
         confirmText,
-        cancelText,
+        dismissText,
         confirmedAction,
+        dismissedAction,
       };
     }
 
@@ -81,8 +85,9 @@ function reducer(state: State, action: Action): State {
         heading: "",
         description: "",
         confirmText: "",
-        cancelText: "",
+        dismissText: "",
         confirmedAction: () => {},
+        dismissedAction: () => {},
       };
     }
 
@@ -100,8 +105,9 @@ export function DialogProvider({ children }: Props) {
     heading: "",
     description: "",
     confirmText: "",
-    cancelText: "",
+    dismissText: "",
     confirmedAction: () => {},
+    dismissedAction: () => {},
   };
 
   const [state, dispatch] = useReducer(reducer, initialState);

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -41,10 +41,10 @@ type FormioSubmission =
   | FormioCloseOutSubmission;
 
 type BapSubmission = {
-  modified: string | null;
-  comboKey: string | null;
-  rebateId: string | null;
-  reviewItemId: string | null;
+  modified: string | null; // ISO 8601 date string
+  comboKey: string | null; // UEI + EFTI combo key
+  rebateId: string | null; // CSB Rebate ID (6 digits)
+  reviewItemId: string | null; // CSB Rebate ID with form/version ID (9 digits)
   status: string | null;
 };
 
@@ -662,7 +662,7 @@ function PaymentRequestSubmission({ rebate }: { rebate: Rebate }) {
                 entity,
                 comboKey: application.bap.comboKey,
                 rebateId: application.bap.rebateId, // CSB Rebate ID (6 digits)
-                reviewItemId: application.bap.reviewItemId, // CSB Rebate ID w/ form/version ID (9 digits)
+                reviewItemId: application.bap.reviewItemId, // CSB Rebate ID with form/version ID (9 digits)
                 applicationFormModified: application.bap.modified,
               })
                 .then((res) => {

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -277,30 +277,10 @@ function ApplicationFormContent({ email }: { email: string }) {
               }, 5000);
             })
             .catch((err) => {
-              pageMessageDispatch({ type: "RESET_MESSAGE" });
-
-              dialogDispatch({
-                type: "DISPLAY_DIALOG",
-                payload: {
-                  dismissable: true,
-                  heading: "Error Deleting Submission",
-                  description: (
-                    <>
-                      <p>
-                        Error deleting Payment Request form submission{" "}
-                        <strong>{rebate.rebateId}</strong>.
-                      </p>
-                      <p>
-                        Please please select the button below or reload the page
-                        to attempt the deletion again, or contact the helpdesk
-                        if the problem persists.
-                      </p>
-                    </>
-                  ),
-                  confirmText: "Reload Page",
-                  confirmedAction: () => window.location.reload(),
-                  dismissedAction: () => window.location.reload(),
-                },
+              const text = `Error deleting Payment Request form submission ${rebate.rebateId}. Please reload the page to attempt the deletion again, or contact the helpdesk if the problem persists.`;
+              pageMessageDispatch({
+                type: "DISPLAY_MESSAGE",
+                payload: { type: "error", text },
               });
             });
         },

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -338,7 +338,7 @@ export function Helpdesk() {
                             description:
                               "Once the submission is back in a draft state, all users with access to this submission will be able to further edit it.",
                             confirmText: "Yes",
-                            cancelText: "Cancel",
+                            dismissText: "Cancel",
                             confirmedAction: () => {
                               setFormDisplayed(false);
                               formioFormDispatch({

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -335,8 +335,13 @@ export function Helpdesk() {
                             dismissable: true,
                             heading:
                               "Are you sure you want to change this submission's state back to draft?",
-                            description:
-                              "Once the submission is back in a draft state, all users with access to this submission will be able to further edit it.",
+                            description: (
+                              <p>
+                                Once the submission is back in a draft state,
+                                all users with access to this submission will be
+                                able to further edit it.
+                              </p>
+                            ),
                             confirmText: "Yes",
                             dismissText: "Cancel",
                             confirmedAction: () => {

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -214,13 +214,23 @@ function PaymentRequestFormContent({ email }: { email: string }) {
         bap: rebate.paymentRequest.bap,
       });
 
-  // TODO: if a corresponding application needs edits, display a message to the
-  // user that this payment request will be deleted.
-  console.log({ applicationNeedsEdits, paymentRequestNeedsEdits });
+  // NOTE: If a corresponding Application form submission needs edits, a warning
+  // message is displayed that this Payment Request form submission will be
+  // deleted, and the form will be rendered read-only.
+  if (applicationNeedsEdits) {
+    pageMessageDispatch({
+      type: "DISPLAY_MESSAGE",
+      payload: {
+        type: "warning",
+        text: messages.paymentRequestFormWillBeDeleted,
+      },
+    });
+  }
 
   const formIsReadOnly =
-    (submission.state === "submitted" || !paymentRequestFormOpen) &&
-    !paymentRequestNeedsEdits;
+    applicationNeedsEdits ||
+    ((submission.state === "submitted" || !paymentRequestFormOpen) &&
+      !paymentRequestNeedsEdits);
 
   const entityComboKey = storedSubmissionData.bap_hidden_entity_combo_key;
   const entity = samEntities.data.entities.find((entity) => {

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -654,7 +654,7 @@ router.post(
 
 // --- delete an existing Payment Request form submission from Forms.gov
 router.post(
-  "delete-formio-payment-request-submission",
+  "/delete-formio-payment-request-submission",
   storeBapComboKeys,
   (req, res) => {
     const { submission } = req.body;
@@ -691,19 +691,14 @@ router.post(
           return res.status(400).json({ message });
         }
 
-        // TODO: delete submission from Forms.gov
-        // logging BAP Application form submission data and
-        // Formio Payment Request form submission data for now
-        console.log({ application, submission });
-
-        // axiosFormio(req)
-        //   .delete(`${paymentRequestFormApiPath}/submission/${mongoId}`)
-        //   .then((axiosRes) => axiosRes.data)
-        //   .then((response) => res.json(response))
-        //   .catch((error) => {
-        //     const message = `Error deleting Forms.gov Payment Request form submission ${rebateId}`;
-        //     return res.status(error?.response?.status || 500).json({ message });
-        //   });
+        axiosFormio(req)
+          .delete(`${paymentRequestFormApiPath}/submission/${mongoId}`)
+          .then((axiosRes) => axiosRes.data)
+          .then((response) => res.json(response))
+          .catch((error) => {
+            const message = `Error deleting Forms.gov Payment Request form submission ${rebateId}`;
+            return res.status(error?.response?.status || 500).json({ message });
+          });
       })
       .catch((error) => {
         const message = `Error getting form submissions statuses from BAP`;

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -677,7 +677,7 @@ router.post(
       .then((submissions) => {
         const application = submissions.find((submission) => {
           return (
-            submission.CSB_Form_ID__c === mongoId &&
+            submission.Parent_Rebate_ID__c === rebateId &&
             submission.Record_Type_Name__c === "CSB Funding Request"
           );
         });

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -226,7 +226,7 @@ async function queryForBapFormSubmissionsStatuses(req, comboKeys) {
         UEI_EFTI_Combo_Key__c: 1,
         CSB_Form_ID__c: 1, // MongoDB ObjectId string
         CSB_Modified_Full_String__c: 1, // ISO 8601 date string
-        CSB_Review_Item_ID__c: 1, // CSB Rebate ID w/ form/version ID (9 digits)
+        CSB_Review_Item_ID__c: 1, // CSB Rebate ID with form/version ID (9 digits)
         Parent_Rebate_ID__c: 1, // CSB Rebate ID (6 digits)
         Record_Type_Name__c: 1, // 'CSB Funding Request' | 'CSB Payment Request' | 'CSB Closeout Request'
         "Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c": 1,


### PR DESCRIPTION
Adds logic to app that will prompt the user to delete a Payment Request form submission when edits are requested on the corresponding Application form submission.

No deletion will occur without the user's explicit action and they cannot edit the Application form submission needing edits until they've explicitly confirmed their intent on deleting the associated Payment Request form submission.