### PR TITLE
Feature/reduce data passed to prf deletion api endpoint

### DIFF
--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -255,6 +255,20 @@ function ApplicationFormContent({ email }: { email: string }) {
         ),
         confirmText: "Delete Payment Request Form Submission",
         confirmedAction: () => {
+          const paymentRequest = rebate.paymentRequest.formio;
+
+          if (!paymentRequest) {
+            const text = `Please notify the helpdesk that a problem exists preventing the deletion of Payment Request form submission ${rebate.rebateId}.`;
+            pageMessageDispatch({
+              type: "DISPLAY_MESSAGE",
+              payload: { type: "error", text },
+            });
+
+            // NOTE: logging rebate for helpdesk debugging purposes
+            console.log(rebate);
+            return;
+          }
+
           const text = `Deleting Payment Request form submission ${rebate.rebateId}...`;
           pageMessageDispatch({
             type: "DISPLAY_MESSAGE",
@@ -263,7 +277,11 @@ function ApplicationFormContent({ email }: { email: string }) {
 
           postData(
             `${serverUrl}/api/delete-formio-payment-request-submission`,
-            { submission: rebate.paymentRequest.formio }
+            {
+              mongoId: paymentRequest._id,
+              rebateId: paymentRequest.data.hidden_bap_rebate_id,
+              comboKey: paymentRequest.data.bap_hidden_entity_combo_key,
+            }
           )
             .then((res) => {
               const text = `Payment Request form submission ${rebate.rebateId} successfully deleted. This page will reload in 5 seconds.`;

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -657,11 +657,7 @@ router.post(
   "/delete-formio-payment-request-submission",
   storeBapComboKeys,
   (req, res) => {
-    const { submission } = req.body;
-
-    const mongoId = submission._id;
-    const rebateId = submission.data.hidden_bap_rebate_id;
-    const comboKey = submission.data.bap_hidden_entity_combo_key;
+    const { mongoId, rebateId, comboKey } = req.body;
 
     // verify post data includes one of user's BAP combo keys
     if (!req.bapComboKeys.includes(comboKey)) {


### PR DESCRIPTION
Update payment request submission deletion API endpoint to pass minimum fields needed (mongoId, rebateId, and comboKey) instead of entire formio submission data