### PR TITLE
Feature/update bap form submissions query

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -223,6 +223,8 @@ async function queryForBapFormSubmissionsStatuses(req, comboKeys) {
     return item.Parent_Rebate_ID__c;
   });
 
+  if (parentRebateIds.length === 0) return [];
+
   // `SELECT
   //   UEI_EFTI_Combo_Key__c,
   //   CSB_Form_ID__c,


### PR DESCRIPTION
Update BAP form submissions statuses query to return an empty array if the first query for parent rebate ids is empty.