### PR TITLE
Feature/update helpdesk access logic

### DIFF
--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -13,7 +13,6 @@ const {
 } = require("../config/formio");
 const {
   ensureAuthenticated,
-  ensureHelpdesk,
   storeBapComboKeys,
   verifyMongoObjectId,
 } = require("../middleware");
@@ -146,11 +145,6 @@ router.get("/content", (req, res) => {
 });
 
 router.use(ensureAuthenticated);
-
-// --- verification used to check if user has access to the /helpdesk route (using ensureHelpdesk middleware)
-router.get("/helpdesk-access", ensureHelpdesk, (req, res) => {
-  res.sendStatus(200);
-});
 
 // --- get CSB app specific data (open enrollment status, etc.)
 router.get("/csb-data", (req, res) => {

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -207,6 +207,22 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "tags": []
@@ -263,6 +279,22 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "tags": []
@@ -278,41 +310,6 @@
               "application/json": {
                 "schema": {
                   "type": "object"
-                }
-              }
-            }
-          }
-        },
-        "tags": [],
-        "parameters": [{ "$ref": "#/components/parameters/scan" }]
-      }
-    },
-    "/api/helpdesk-access": {
-      "get": {
-        "summary": "/api/helpdesk-access",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string",
-                      "example": "Unauthorized"
-                    }
-                  }
                 }
               }
             }


### PR DESCRIPTION
## Related Issues:
* CSBAPP-30

## Main Changes:
* Removes `/api/helpdesk-access` route, as the logic for whether the user should have helpdesk access is already available in the client app (from the fetched `epaUserData`). The main driver for this is to reduce unnecessary 401 errors that occur for non-helpdesk users whenever the app starts. Users don't see that error, but the Cloud.gov logs are needlessly noisy from those errors, which aren't actual real errors at all. NOTE: if a user tried to access a helpdesk API directly, those helpdesk access errors are still logged.

## Steps To Test:
1. Log-in as a non-helpdesk user, and open the Network tab of the browser's developer tools – there should no longer be a 401 error as the `/api/helpdesk-access` route has been removed.
