### PR TITLE
Feature/add initial close out form

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -24,6 +24,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { Welcome } from "routes/welcome";
 import { Dashboard } from "components/dashboard";
 import { ConfirmationDialog } from "components/confirmationDialog";
+import { Notifications } from "components/notifications";
 import { Helpdesk } from "routes/helpdesk";
 import { AllRebates } from "routes/allRebates";
 import { NewApplicationForm } from "routes/newApplicationForm";
@@ -264,6 +265,7 @@ function ProtectedRoute({ children }: { children: JSX.Element }) {
   return (
     <TooltipProvider>
       <ConfirmationDialog />
+      <Notifications />
       {children}
     </TooltipProvider>
   );

--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -223,8 +223,10 @@ export function useHelpdeskAccess() {
 
 function ProtectedRoute() {
   const { pathname } = useLocation();
-  const { isAuthenticating, isAuthenticated } = useUserState();
+  const { isAuthenticating, isAuthenticated, epaUserData } = useUserState();
   const userDispatch = useUserDispatch();
+
+  const email = epaUserData.status !== "success" ? "" : epaUserData.data.mail;
 
   /**
    * check if user is already logged in or needs to be logged out (which will
@@ -267,7 +269,7 @@ function ProtectedRoute() {
     <TooltipProvider>
       <ConfirmationDialog />
       <Notifications />
-      <UserDashboard />
+      <UserDashboard email={email} />
     </TooltipProvider>
   );
 }

--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -290,12 +290,9 @@ export function App() {
           <Route index element={<AllRebates />} />
           <Route path="helpdesk" element={<Helpdesk />} />
           <Route path="rebate/new" element={<NewApplicationForm />} />
-          <Route path="rebate/:mongoId" element={<ApplicationForm />} />
-          <Route
-            path="payment-request/:rebateId"
-            element={<PaymentRequestForm />}
-          />
-          <Route path="close-out/:rebateId" element={<CloseOutForm />} />
+          <Route path="rebate/:id" element={<ApplicationForm />} />
+          <Route path="payment-request/:id" element={<PaymentRequestForm />} />
+          <Route path="close-out/:id" element={<CloseOutForm />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>

--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -221,14 +221,15 @@ export function useHelpdeskAccess() {
   return helpdeskAccess;
 }
 
-// Wrapper Component for any routes that need authenticated access
-function ProtectedRoute({ children }: { children: JSX.Element }) {
+function ProtectedRoute() {
   const { pathname } = useLocation();
   const { isAuthenticating, isAuthenticated } = useUserState();
   const userDispatch = useUserDispatch();
 
-  // check if user is already logged in or needs to be logged out (which will
-  // redirect them to the "/welcome" route)
+  /**
+   * check if user is already logged in or needs to be logged out (which will
+   * redirect them to the "/welcome" route)
+   */
   const verifyUser = useCallback(() => {
     getData<EpaUserData>(`${serverUrl}/api/epa-user-data`)
       .then((res) => {
@@ -266,7 +267,7 @@ function ProtectedRoute({ children }: { children: JSX.Element }) {
     <TooltipProvider>
       <ConfirmationDialog />
       <Notifications />
-      {children}
+      <Dashboard />
     </TooltipProvider>
   );
 }
@@ -285,14 +286,7 @@ export function App() {
     <BrowserRouter basename={serverBasePath}>
       <Routes>
         <Route path="/welcome" element={<Welcome />} />
-        <Route
-          path="/"
-          element={
-            <ProtectedRoute>
-              <Dashboard />
-            </ProtectedRoute>
-          }
-        >
+        <Route path="/" element={<ProtectedRoute />}>
           <Route index element={<AllRebates />} />
           <Route path="helpdesk" element={<Helpdesk />} />
           <Route path="rebate/new" element={<NewApplicationForm />} />

--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -29,6 +29,7 @@ import { AllRebates } from "routes/allRebates";
 import { NewApplicationForm } from "routes/newApplicationForm";
 import { ApplicationForm } from "routes/applicationForm";
 import { PaymentRequestForm } from "routes/paymentRequestForm";
+import { CloseOutForm } from "routes/closeOutForm";
 import { useDialogDispatch, useDialogState } from "contexts/dialog";
 import { EpaUserData, useUserState, useUserDispatch } from "contexts/user";
 
@@ -269,14 +270,14 @@ function ProtectedRoute({ children }: { children: JSX.Element }) {
 }
 
 export function App() {
-  useSiteAlertBanner();
-  useDisclaimerBanner();
-
   useQuery({
     queryKey: ["content"],
     queryFn: () => getData<Content>(`${serverUrl}/api/content`),
     refetchOnWindowFocus: false,
   });
+
+  useSiteAlertBanner();
+  useDisclaimerBanner();
 
   return (
     <BrowserRouter basename={serverBasePath}>
@@ -291,18 +292,6 @@ export function App() {
           }
         >
           <Route index element={<AllRebates />} />
-          {/*
-            NOTE: The helpdesk route is only accessible to users who should have
-            access to it. When a user tries to access the `Helpdesk` route, an
-            API call to the server is made (`/helpdesk-access`). Verification
-            happens on the server via the user's EPA WAA groups stored in the
-            JWT, and server responds appropriately. If user is a member of the
-            appropriate WAA groups, they'll have access to the route, otherwise
-            they'll be redirected to the index route (`AllRebates`). This same
-            API call happens inside the `Dashboard` component as well, to
-            determine whether a button/link to the helpdesk route should be
-            displayed.
-          */}
           <Route path="helpdesk" element={<Helpdesk />} />
           <Route path="rebate/new" element={<NewApplicationForm />} />
           <Route path="rebate/:mongoId" element={<ApplicationForm />} />
@@ -310,6 +299,7 @@ export function App() {
             path="payment-request/:rebateId"
             element={<PaymentRequestForm />}
           />
+          <Route path="close-out/:rebateId" element={<CloseOutForm />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>

--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -22,7 +22,7 @@ import { serverBasePath, serverUrl, cloudSpace, getData } from "../config";
 import { Loading } from "components/loading";
 import { MarkdownContent } from "components/markdownContent";
 import { Welcome } from "routes/welcome";
-import { Dashboard } from "components/dashboard";
+import { UserDashboard } from "components/userDashboard";
 import { ConfirmationDialog } from "components/confirmationDialog";
 import { Notifications } from "components/notifications";
 import { Helpdesk } from "routes/helpdesk";
@@ -267,7 +267,7 @@ function ProtectedRoute() {
     <TooltipProvider>
       <ConfirmationDialog />
       <Notifications />
-      <Dashboard />
+      <UserDashboard />
     </TooltipProvider>
   );
 }

--- a/app/client/src/components/dashboard.tsx
+++ b/app/client/src/components/dashboard.tsx
@@ -14,7 +14,6 @@ import {
 } from "../config";
 import { useHelpdeskAccess } from "components/app";
 import { Loading } from "components/loading";
-import { Notifications } from "components/notifications";
 import { Action, useDialogDispatch } from "contexts/dialog";
 import { useUserState } from "contexts/user";
 
@@ -312,8 +311,6 @@ export function Dashboard() {
       </div>
 
       <Outlet />
-
-      <Notifications />
     </div>
   );
 }

--- a/app/client/src/components/notifications.tsx
+++ b/app/client/src/components/notifications.tsx
@@ -6,14 +6,11 @@ import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { XCircleIcon } from "@heroicons/react/24/outline";
 import { XMarkIcon } from "@heroicons/react/20/solid";
 // ---
-import {
-  useNotificationsState,
-  useNotificationsDispatch,
-} from "contexts/notifications";
+import { useNotificationsContext } from "contexts/notifications";
 
 export function Notifications() {
-  const notificationsDispatch = useNotificationsDispatch();
-  const { displayed, body, type } = useNotificationsState();
+  const { state, dismissNotification } = useNotificationsContext();
+  const { displayed, body, type } = state;
 
   return (
     <div className="twpf">
@@ -67,9 +64,7 @@ export function Notifications() {
                     <button
                       type="button"
                       className="tw-inline-flex tw-rounded-md tw-bg-white tw-text-gray-400 tw-transition-none hover:tw-text-gray-700 focus:tw-text-gray-700"
-                      onClick={() => {
-                        notificationsDispatch({ type: "DISMISS_NOTIFICATION" });
-                      }}
+                      onClick={() => dismissNotification()}
                     >
                       <span className="tw-sr-only">Close</span>
                       <XMarkIcon

--- a/app/client/src/components/notifications.tsx
+++ b/app/client/src/components/notifications.tsx
@@ -19,7 +19,7 @@ export function Notifications() {
     <div className="twpf">
       <div
         aria-live="assertive"
-        className="tw-pointer-events-none tw-fixed tw-inset-0 tw-flex tw-items-end tw-p-4 sm:tw-items-start"
+        className="tw-pointer-events-none tw-fixed tw-inset-0 tw-z-10 tw-flex tw-items-end tw-p-4 sm:tw-items-start"
       >
         <div className="tw-flex tw-w-full tw-flex-col tw-items-center tw-space-y-4 sm:tw-items-end">
           <Transition

--- a/app/client/src/components/userDashboard.tsx
+++ b/app/client/src/components/userDashboard.tsx
@@ -308,7 +308,7 @@ export function UserDashboard(props: { email: string }) {
         </nav>
       </div>
 
-      <Outlet />
+      <Outlet context={{ email }} />
     </div>
   );
 }

--- a/app/client/src/components/userDashboard.tsx
+++ b/app/client/src/components/userDashboard.tsx
@@ -15,7 +15,6 @@ import {
 import { useHelpdeskAccess } from "components/app";
 import { Loading } from "components/loading";
 import { Action, useDialogDispatch } from "contexts/dialog";
-import { useUserState } from "contexts/user";
 
 type CsbData = {
   submissionPeriodOpen: {
@@ -113,7 +112,9 @@ function IconText(props: {
   );
 }
 
-export function UserDashboard() {
+export function UserDashboard(props: { email: string }) {
+  const { email } = props;
+
   const { pathname } = useLocation();
   const navigate = useNavigate();
 
@@ -137,7 +138,6 @@ export function UserDashboard() {
     refetchOnWindowFocus: false,
   });
 
-  const { epaUserData } = useUserState();
   const csbData = useCsbData();
   const bapSamData = useBapSamData();
 
@@ -210,9 +210,7 @@ export function UserDashboard() {
       <div className="desktop:display-flex flex-justify border-bottom">
         <nav className="desktop:order-last mobile-lg:display-flex flex-align-center flex-justify-end">
           <p className="margin-bottom-1 margin-right-1">
-            <span>
-              {epaUserData.status === "success" && epaUserData.data.mail}
-            </span>
+            <span>{email}</span>
           </p>
 
           <a

--- a/app/client/src/components/userDashboard.tsx
+++ b/app/client/src/components/userDashboard.tsx
@@ -113,7 +113,7 @@ function IconText(props: {
   );
 }
 
-export function Dashboard() {
+export function UserDashboard() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
 

--- a/app/client/src/contexts/notifications.tsx
+++ b/app/client/src/contexts/notifications.tsx
@@ -98,3 +98,44 @@ export function useNotificationsDispatch() {
   }
   return context;
 }
+
+/**
+ * Custom hook that returns functions to display each notification type (info,
+ * success, warning, or error) and a function to dismisses a currently displayed
+ * notification.
+ */
+export function useNotifications() {
+  const dispatch = useNotificationsDispatch();
+
+  return {
+    displayInfoNotification: (body: ReactNode) => {
+      return dispatch({
+        type: "DISPLAY_NOTIFICATION",
+        payload: { type: "info" as const, body },
+      });
+    },
+    displaySuccessNotification(body: ReactNode) {
+      return dispatch({
+        type: "DISPLAY_NOTIFICATION",
+        payload: { type: "success" as const, body },
+      });
+    },
+    displayWarningNotification(body: ReactNode) {
+      return dispatch({
+        type: "DISPLAY_NOTIFICATION",
+        payload: { type: "warning" as const, body },
+      });
+    },
+    displayErrorNotification(body: ReactNode) {
+      return dispatch({
+        type: "DISPLAY_NOTIFICATION",
+        payload: { type: "error" as const, body },
+      });
+    },
+    dismissNotification() {
+      return dispatch({
+        type: "DISMISS_NOTIFICATION",
+      });
+    },
+  };
+}

--- a/app/client/src/contexts/notifications.tsx
+++ b/app/client/src/contexts/notifications.tsx
@@ -104,7 +104,7 @@ export function useNotificationsDispatch() {
  * success, warning, or error) and a function to dismisses a currently displayed
  * notification.
  */
-export function useNotifications() {
+export function useNotificationsActions() {
   const dispatch = useNotificationsDispatch();
 
   return {

--- a/app/client/src/contexts/notifications.tsx
+++ b/app/client/src/contexts/notifications.tsx
@@ -77,7 +77,7 @@ export function NotificationsProvider({ children }: Props) {
 /**
  * Returns state stored in `NotificationsProvider` context component.
  */
-export function useNotificationsState() {
+function useNotificationsState() {
   const context = useContext(StateContext);
   if (context === undefined) {
     const message = `useNotificationsState must be called within a NotificationsProvider`;
@@ -90,7 +90,7 @@ export function useNotificationsState() {
  * Returns `dispatch` method for dispatching actions to update state stored in
  * `NotificationsProvider` context component.
  */
-export function useNotificationsDispatch() {
+function useNotificationsDispatch() {
   const context = useContext(DispatchContext);
   if (context === undefined) {
     const message = `useNotificationsDispatch must be used within a NotificationsProvider`;
@@ -100,15 +100,17 @@ export function useNotificationsDispatch() {
 }
 
 /**
- * Custom hook that returns functions to display each notification type (info,
- * success, warning, or error) and a function to dismisses a currently displayed
- * notification.
+ * Custom hook that returns notifications current state, functions to display
+ * each notification type (info, success, warning, or error), and a function to
+ * dismiss a currently displayed notification.
  */
-export function useNotificationsActions() {
+export function useNotificationsContext() {
+  const state = useNotificationsState();
   const dispatch = useNotificationsDispatch();
 
   return {
-    displayInfoNotification: (body: ReactNode) => {
+    state,
+    displayInfoNotification(body: ReactNode) {
       return dispatch({
         type: "DISPLAY_NOTIFICATION",
         payload: { type: "info" as const, body },

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -4,11 +4,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import reportWebVitals from "./reportWebVitals";
 // ---
-import { DialogProvider } from "contexts/dialog";
-import { UserProvider } from "contexts/user";
-import { NotificationsProvider } from "contexts/notifications";
 import { ErrorBoundary } from "components/errorBoundary";
 import { App } from "components/app";
+import { DialogProvider } from "contexts/dialog";
+import { NotificationsProvider } from "contexts/notifications";
+import { UserProvider } from "contexts/user";
 import "./tailwind-preflight.css";
 import "./styles.css";
 
@@ -20,11 +20,11 @@ render(
     <QueryClientProvider client={queryClient}>
       <ErrorBoundary>
         <DialogProvider>
-          <UserProvider>
-            <NotificationsProvider>
+          <NotificationsProvider>
+            <UserProvider>
               <App />
-            </NotificationsProvider>
-          </UserProvider>
+            </UserProvider>
+          </NotificationsProvider>
         </DialogProvider>
       </ErrorBoundary>
 

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -1,6 +1,11 @@
 import { Fragment, useEffect, useState } from "react";
 import type { LinkProps } from "react-router-dom";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import {
+  Link,
+  useNavigate,
+  useOutletContext,
+  useSearchParams,
+} from "react-router-dom";
 import { useQueryClient, useQueries } from "@tanstack/react-query";
 import icons from "uswds/img/sprite.svg";
 // ---
@@ -12,7 +17,6 @@ import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/tooltip";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
-import { useUserState } from "contexts/user";
 import { useNotificationsDispatch } from "contexts/notifications";
 
 type BapFormSubmission = {
@@ -427,14 +431,15 @@ function ButtonLink(props: { type: "edit" | "view"; to: LinkProps["to"] }) {
   );
 }
 
-function ApplicationSubmission({ rebate }: { rebate: Rebate }) {
+function ApplicationSubmission(props: { rebate: Rebate }) {
+  const { rebate } = props;
+  const { application, paymentRequest } = rebate;
+
   const csbData = useCsbData();
 
   if (!csbData) return null;
 
   const applicationFormOpen = csbData.submissionPeriodOpen.application;
-
-  const { application, paymentRequest } = rebate;
 
   const {
     applicantUEI,
@@ -669,24 +674,23 @@ save the form for the EFT indicator to be displayed. */
   );
 }
 
-function PaymentRequestSubmission({ rebate }: { rebate: Rebate }) {
+function PaymentRequestSubmission(props: { rebate: Rebate }) {
+  const { rebate } = props;
+  const { application, paymentRequest } = rebate;
+
   const navigate = useNavigate();
+  const { email } = useOutletContext<{ email: string }>();
 
   const csbData = useCsbData();
   const bapSamData = useBapSamData();
-  const { epaUserData } = useUserState();
   const notificationsDispatch = useNotificationsDispatch();
 
   // NOTE: used to display a loading indicator inside the new Payment Request button
   const [postDataResponsePending, setPostDataResponsePending] = useState(false);
 
   if (!csbData || !bapSamData) return null;
-  if (epaUserData.status !== "success") return null;
 
   const paymentRequestFormOpen = csbData.submissionPeriodOpen.paymentRequest;
-
-  const email = epaUserData.data.mail;
-  const { application, paymentRequest } = rebate;
 
   const applicationSelected = application.bap?.status === "Accepted";
 

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -216,7 +216,7 @@ export function useFetchedFormSubmissions() {
  * and Formio into a single `submissions` object, with the BAP assigned
  * `rebateId` as the keys.
  **/
-export function useCombinedSubmissions() {
+function useCombinedRebates() {
   const queryClient = useQueryClient();
 
   const bapFormSubmissions = queryClient.getQueryData<{
@@ -336,7 +336,7 @@ export function useCombinedSubmissions() {
  * - selected Applications submissions without a corresponding Payment Request
  *   submission
  **/
-export function useSortedRebates(rebates: { [rebateId: string]: Rebate }) {
+function useSortedRebates(rebates: { [rebateId: string]: Rebate }) {
   return Object.entries(rebates)
     .map(([rebateId, rebate]) => ({ rebateId, ...rebate }))
     .sort((r1, r2) => {
@@ -386,10 +386,10 @@ export function useSortedRebates(rebates: { [rebateId: string]: Rebate }) {
  * Custom hook that returns sorted rebates, and logs them if 'debug' search
  * parameter exists.
  */
-function useRebates() {
+export function useRebates() {
   const [searchParams] = useSearchParams();
 
-  const combinedRebates = useCombinedSubmissions();
+  const combinedRebates = useCombinedRebates();
   const sortedRebates = useSortedRebates(combinedRebates);
 
   // log combined 'sortedRebates' array if 'debug' search parameter exists

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -11,7 +11,7 @@ import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/tooltip";
 import { useContentData } from "components/app";
-import { useCsbData, useBapSamData } from "components/dashboard";
+import { useCsbData, useBapSamData } from "components/userDashboard";
 import { useUserState } from "contexts/user";
 import { useNotificationsDispatch } from "contexts/notifications";
 

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -17,7 +17,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/tooltip";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
-import { useNotificationsActions } from "contexts/notifications";
+import { useNotificationsContext } from "contexts/notifications";
 
 type BapFormSubmission = {
   UEI_EFTI_Combo_Key__c: string; // UEI + EFTI combo key
@@ -683,7 +683,7 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
 
   const csbData = useCsbData();
   const bapSamData = useBapSamData();
-  const { displayErrorNotification } = useNotificationsActions();
+  const { displayErrorNotification } = useNotificationsContext();
 
   // NOTE: used to display a loading indicator inside the new Payment Request button
   const [postDataResponsePending, setPostDataResponsePending] = useState(false);

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -17,7 +17,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/tooltip";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
-import { useNotificationsDispatch } from "contexts/notifications";
+import { useNotificationsActions } from "contexts/notifications";
 
 type BapFormSubmission = {
   UEI_EFTI_Combo_Key__c: string; // UEI + EFTI combo key
@@ -683,7 +683,7 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
 
   const csbData = useCsbData();
   const bapSamData = useBapSamData();
-  const notificationsDispatch = useNotificationsDispatch();
+  const { displayErrorNotification } = useNotificationsActions();
 
   // NOTE: used to display a loading indicator inside the new Payment Request button
   const [postDataResponsePending, setPostDataResponsePending] = useState(false);
@@ -736,23 +736,17 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
                 })
                 .catch((err) => {
                   setPostDataResponsePending(false);
-                  notificationsDispatch({
-                    type: "DISPLAY_NOTIFICATION",
-                    payload: {
-                      type: "error",
-                      body: (
-                        <>
-                          <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                            Error creating Payment Request{" "}
-                            <em>{application.bap?.rebateId}</em>.
-                          </p>
-                          <p className="tw-mt-1 tw-text-sm tw-text-gray-500">
-                            Please try again.
-                          </p>
-                        </>
-                      ),
-                    },
-                  });
+                  displayErrorNotification(
+                    <>
+                      <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                        Error creating Payment Request{" "}
+                        <em>{application.bap?.rebateId}</em>.
+                      </p>
+                      <p className="tw-mt-1 tw-text-sm tw-text-gray-500">
+                        Please try again.
+                      </p>
+                    </>
+                  );
                 });
             }}
           >

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -159,7 +159,7 @@ export function submissionNeedsEdits(options: {
 }
 
 /** Custom hook to fetch submissions from the BAP and Formio */
-export function useFetchedFormSubmissions() {
+export function useSubmissionsQueries() {
   return useQueries({
     queries: [
       {
@@ -908,14 +908,14 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
 
 export function AllRebates() {
   const content = useContentData();
-  const formSubmissionsQueries = useFetchedFormSubmissions();
+  const submissionsQueries = useSubmissionsQueries();
   const rebates = useRebates();
 
-  if (formSubmissionsQueries.some((query) => query.isFetching)) {
+  if (submissionsQueries.some((query) => query.isFetching)) {
     return <Loading />;
   }
 
-  if (formSubmissionsQueries.some((query) => query.isError)) {
+  if (submissionsQueries.some((query) => query.isError)) {
     return <Message type="error" text={messages.formSubmissionsError} />;
   }
 

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -18,7 +18,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
 import { useDialogDispatch } from "contexts/dialog";
-import { useNotifications } from "contexts/notifications";
+import { useNotificationsActions } from "contexts/notifications";
 
 type FormioSubmission = {
   [field: string]: unknown;
@@ -116,7 +116,7 @@ export function ApplicationForm() {
     // displayWarningNotification,
     displayErrorNotification,
     dismissNotification,
-  } = useNotifications();
+  } = useNotificationsActions();
 
   const submissionsQueries = useSubmissionsQueries();
   const rebates = useRebates();

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -64,11 +64,7 @@ function ApplicationFormContent({ email }: { email: string }) {
   const dialogDispatch = useDialogDispatch();
   const notificationsDispatch = useNotificationsDispatch();
 
-  const {
-    bapFormSubmissionsQuery,
-    formioApplicationSubmissionsQuery,
-    formioPaymentRequestSubmissionsQuery,
-  } = useFetchedFormSubmissions();
+  const formSubmissionsQueries = useFetchedFormSubmissions();
 
   const combinedRebates = useCombinedSubmissions();
   const sortedRebates = useSortedRebates(combinedRebates);
@@ -162,19 +158,11 @@ function ApplicationFormContent({ email }: { email: string }) {
     return <Loading />;
   }
 
-  if (
-    bapFormSubmissionsQuery.isFetching ||
-    formioApplicationSubmissionsQuery.isFetching ||
-    formioPaymentRequestSubmissionsQuery.isFetching
-  ) {
+  if (formSubmissionsQueries.some((query) => query.isFetching)) {
     return <Loading />;
   }
 
-  if (
-    bapFormSubmissionsQuery.isError ||
-    formioApplicationSubmissionsQuery.isError ||
-    formioPaymentRequestSubmissionsQuery.isError
-  ) {
+  if (formSubmissionsQueries.some((query) => query.isError)) {
     return <Message type="error" text={messages.formSubmissionsError} />;
   }
 

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -17,7 +17,7 @@ import { Loading } from "components/loading";
 import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { useContentData } from "components/app";
-import { useCsbData, useBapSamData } from "components/dashboard";
+import { useCsbData, useBapSamData } from "components/userDashboard";
 import { useDialogDispatch } from "contexts/dialog";
 import { useUserState } from "contexts/user";
 import { useNotificationsDispatch } from "contexts/notifications";

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -54,7 +54,7 @@ export function ApplicationForm() {
 
 function ApplicationFormContent({ email }: { email: string }) {
   const navigate = useNavigate();
-  const { mongoId } = useParams<"mongoId">(); // MongoDB ObjectId string
+  const { id: mongoId } = useParams<"id">(); // MongoDB ObjectId string
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
 

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -41,43 +41,9 @@ type ServerResponse =
       submission: FormioSubmission;
     };
 
-export function ApplicationForm() {
-  const navigate = useNavigate();
-  const { email } = useOutletContext<{ email: string }>();
-  const { id: mongoId } = useParams<"id">(); // MongoDB ObjectId string
-
+/** Custom hook to fetch Formio submission data */
+function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
   const queryClient = useQueryClient();
-  const content = useContentData();
-  const csbData = useCsbData();
-  const bapSamData = useBapSamData();
-  const dialogDispatch = useDialogDispatch();
-  const notificationsDispatch = useNotificationsDispatch();
-
-  const submissionsQueries = useSubmissionsQueries();
-  const rebates = useRebates();
-
-  /**
-   * Stores when the form is being submitted, so it can be referenced in the
-   * Form component's `onSubmit` event prop to prevent double submits
-   */
-  const formIsBeingSubmitted = useRef(false);
-
-  /**
-   * Stores the last succesfully submitted data, so it can be used in the Form
-   * component's `onNextPage` event prop's "dirty check" which determines if
-   * posting of updated data is needed (so we don't make needless requests if no
-   * field data in the form has changed).
-   */
-  const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
-
-  /**
-   * Stores the form data's state right after the user clicks the Save, Submit,
-   * or Next button. As soon as a post request to update the data succeeds, this
-   * pending submission data is reset to an empty object. This pending data,
-   * along with the submission data returned from the server is passed into the
-   * Form component's `submission` prop.
-   */
-  const pendingSubmissionData = useRef<{ [field: string]: unknown }>({});
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["application"] });
@@ -132,7 +98,48 @@ export function ApplicationForm() {
     },
   });
 
+  return { query, mutation };
+}
+
+export function ApplicationForm() {
+  const navigate = useNavigate();
+  const { email } = useOutletContext<{ email: string }>();
+  const { id: mongoId } = useParams<"id">(); // MongoDB ObjectId string
+
+  const content = useContentData();
+  const csbData = useCsbData();
+  const bapSamData = useBapSamData();
+  const dialogDispatch = useDialogDispatch();
+  const notificationsDispatch = useNotificationsDispatch();
+
+  const submissionsQueries = useSubmissionsQueries();
+  const rebates = useRebates();
+
+  const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  /**
+   * Stores when the form is being submitted, so it can be referenced in the
+   * Form component's `onSubmit` event prop to prevent double submits
+   */
+  const formIsBeingSubmitted = useRef(false);
+
+  /**
+   * Stores the last succesfully submitted data, so it can be used in the Form
+   * component's `onNextPage` event prop's "dirty check" which determines if
+   * posting of updated data is needed (so we don't make needless requests if no
+   * field data in the form has changed).
+   */
+  const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  /**
+   * Stores the form data's state right after the user clicks the Save, Submit,
+   * or Next button. As soon as a post request to update the data succeeds, this
+   * pending submission data is reset to an empty object. This pending data,
+   * along with the submission data returned from the server is passed into the
+   * Form component's `submission` prop.
+   */
+  const pendingSubmissionData = useRef<{ [field: string]: unknown }>({});
 
   if (!csbData || !bapSamData) {
     return <Loading />;
@@ -167,11 +174,13 @@ export function ApplicationForm() {
   const applicationNeedsEditsAndPaymentRequestExists =
     applicationNeedsEdits && !!rebate?.paymentRequest.formio;
 
-  // NOTE: If the Application form submission needs edits and there's a
-  // corresponding Payment Request form submission, display a confirmation
-  // dialog prompting the user to delete the Payment Request form submission,
-  // as it's data will no longer valid when the Application form submission's
-  // data is changed.
+  /**
+   * NOTE: If the Application form submission needs edits and there's a
+   * corresponding Payment Request form submission, display a confirmation
+   * dialog prompting the user to delete the Payment Request form submission,
+   * as it's data will no longer valid when the Application form submission's
+   * data is changed.
+   */
   if (applicationNeedsEditsAndPaymentRequestExists) {
     dialogDispatch({
       type: "DISPLAY_DIALOG",
@@ -300,11 +309,10 @@ export function ApplicationForm() {
     (submission.state === "submitted" || !applicationFormOpen) &&
     !applicationNeedsEdits;
 
-  const entityComboKey = submission.data.bap_hidden_entity_combo_key;
   const entity = bapSamData.entities.find((entity) => {
     return (
       entity.ENTITY_STATUS__c === "Active" &&
-      entity.ENTITY_COMBO_KEY__c === entityComboKey
+      entity.ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key
     );
   });
 

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, useRef } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Formio, Form } from "@formio/react";
 import { cloneDeep, isEqual } from "lodash";
@@ -10,8 +10,7 @@ import { getUserInfo } from "../utilities";
 import {
   submissionNeedsEdits,
   useFetchedFormSubmissions,
-  useCombinedSubmissions,
-  useSortedRebates,
+  useRebates,
 } from "routes/allRebates";
 import { Loading } from "components/loading";
 import { Message } from "components/message";
@@ -55,7 +54,6 @@ export function ApplicationForm() {
 function ApplicationFormContent({ email }: { email: string }) {
   const navigate = useNavigate();
   const { id: mongoId } = useParams<"id">(); // MongoDB ObjectId string
-  const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
 
   const content = useContentData();
@@ -65,16 +63,7 @@ function ApplicationFormContent({ email }: { email: string }) {
   const notificationsDispatch = useNotificationsDispatch();
 
   const formSubmissionsQueries = useFetchedFormSubmissions();
-
-  const combinedRebates = useCombinedSubmissions();
-  const sortedRebates = useSortedRebates(combinedRebates);
-
-  // log combined 'sortedRebates' array if 'debug' search parameter exists
-  useEffect(() => {
-    if (searchParams.has("debug") && sortedRebates.length > 0) {
-      console.log(sortedRebates);
-    }
-  }, [searchParams, sortedRebates]);
+  const rebates = useRebates();
 
   /**
    * Stores when the form is being submitted, so it can be referenced in the
@@ -175,9 +164,7 @@ function ApplicationFormContent({ email }: { email: string }) {
     return <Message type="error" text={text} />;
   }
 
-  const rebate = sortedRebates.find((item) => {
-    return item.application.formio._id === mongoId;
-  });
+  const rebate = rebates.find((r) => r.application.formio._id === mongoId);
 
   const applicationNeedsEdits = !rebate
     ? false

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -9,7 +9,7 @@ import { serverUrl, messages, getData, postData } from "../config";
 import { getUserInfo } from "../utilities";
 import {
   submissionNeedsEdits,
-  useFetchedFormSubmissions,
+  useSubmissionsQueries,
   useRebates,
 } from "routes/allRebates";
 import { Loading } from "components/loading";
@@ -47,14 +47,13 @@ export function ApplicationForm() {
   const { id: mongoId } = useParams<"id">(); // MongoDB ObjectId string
 
   const queryClient = useQueryClient();
-
   const content = useContentData();
   const csbData = useCsbData();
   const bapSamData = useBapSamData();
   const dialogDispatch = useDialogDispatch();
   const notificationsDispatch = useNotificationsDispatch();
 
-  const formSubmissionsQueries = useFetchedFormSubmissions();
+  const submissionsQueries = useSubmissionsQueries();
   const rebates = useRebates();
 
   /**
@@ -139,11 +138,11 @@ export function ApplicationForm() {
     return <Loading />;
   }
 
-  if (formSubmissionsQueries.some((query) => query.isFetching)) {
+  if (submissionsQueries.some((query) => query.isFetching)) {
     return <Loading />;
   }
 
-  if (formSubmissionsQueries.some((query) => query.isError)) {
+  if (submissionsQueries.some((query) => query.isError)) {
     return <Message type="error" text={messages.formSubmissionsError} />;
   }
 

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -113,7 +113,6 @@ export function ApplicationForm() {
   const {
     displayInfoNotification,
     displaySuccessNotification,
-    // displayWarningNotification,
     displayErrorNotification,
     dismissNotification,
   } = useNotificationsActions();

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -18,7 +18,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
 import { useDialogDispatch } from "contexts/dialog";
-import { useNotificationsDispatch } from "contexts/notifications";
+import { useNotifications } from "contexts/notifications";
 
 type FormioSubmission = {
   [field: string]: unknown;
@@ -110,7 +110,13 @@ export function ApplicationForm() {
   const csbData = useCsbData();
   const bapSamData = useBapSamData();
   const dialogDispatch = useDialogDispatch();
-  const notificationsDispatch = useNotificationsDispatch();
+  const {
+    displayInfoNotification,
+    displaySuccessNotification,
+    // displayWarningNotification,
+    displayErrorNotification,
+    dismissNotification,
+  } = useNotifications();
 
   const submissionsQueries = useSubmissionsQueries();
   const rebates = useRebates();
@@ -229,41 +235,29 @@ export function ApplicationForm() {
           const paymentRequest = rebate.paymentRequest.formio;
 
           if (!paymentRequest) {
-            notificationsDispatch({
-              type: "DISPLAY_NOTIFICATION",
-              payload: {
-                type: "error",
-                body: (
-                  <>
-                    <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                      Error deleting Payment Request <em>{rebate.rebateId}</em>.
-                    </p>
-                    <p className="tw-mt-1 tw-text-sm tw-text-gray-500">
-                      Please notify the helpdesk that a problem exists
-                      preventing the deletion of Payment Request form submission{" "}
-                      <em>{rebate.rebateId}</em>.
-                    </p>
-                  </>
-                ),
-              },
-            });
+            displayErrorNotification(
+              <>
+                <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                  Error deleting Payment Request <em>{rebate.rebateId}</em>.
+                </p>
+                <p className="tw-mt-1 tw-text-sm tw-text-gray-500">
+                  Please notify the helpdesk that a problem exists preventing
+                  the deletion of Payment Request form submission{" "}
+                  <em>{rebate.rebateId}</em>.
+                </p>
+              </>
+            );
 
             // NOTE: logging rebate for helpdesk debugging purposes
             console.log(rebate);
             return;
           }
 
-          notificationsDispatch({
-            type: "DISPLAY_NOTIFICATION",
-            payload: {
-              type: "info",
-              body: (
-                <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                  Deleting Payment Request <em>{rebate.rebateId}</em>...
-                </p>
-              ),
-            },
-          });
+          displayInfoNotification(
+            <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+              Deleting Payment Request <em>{rebate.rebateId}</em>...
+            </p>
+          );
 
           const url = `${serverUrl}/api/delete-formio-payment-request-submission`;
 
@@ -276,24 +270,17 @@ export function ApplicationForm() {
               window.location.reload();
             })
             .catch((err) => {
-              notificationsDispatch({
-                type: "DISPLAY_NOTIFICATION",
-                payload: {
-                  type: "error",
-                  body: (
-                    <>
-                      <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                        Error deleting Payment Request{" "}
-                        <em>{rebate.rebateId}</em>.
-                      </p>
-                      <p className="tw-mt-1 tw-text-sm tw-text-gray-500">
-                        Please reload the page to attempt the deletion again, or
-                        contact the helpdesk if the problem persists.
-                      </p>
-                    </>
-                  ),
-                },
-              });
+              displayErrorNotification(
+                <>
+                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                    Error deleting Payment Request <em>{rebate.rebateId}</em>.
+                  </p>
+                  <p className="tw-mt-1 tw-text-sm tw-text-gray-500">
+                    Please reload the page to attempt the deletion again, or
+                    contact the helpdesk if the problem persists.
+                  </p>
+                </>
+              );
             });
         },
         dismissedAction: () => navigate(`/payment-request/${rebate.rebateId}`),
@@ -399,21 +386,15 @@ export function ApplicationForm() {
             if (data.hasOwnProperty("ncesDataSource")) delete data.ncesDataSource; // prettier-ignore
             if (data.hasOwnProperty("ncesDataLookup")) delete data.ncesDataLookup; // prettier-ignore
 
-            notificationsDispatch({
-              type: "DISPLAY_NOTIFICATION",
-              payload: {
-                type: "info",
-                body: (
-                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                    {onSubmitSubmission.state === "submitted" ? (
-                      <>Submitting...</>
-                    ) : (
-                      <>Saving draft...</>
-                    )}
-                  </p>
-                ),
-              },
-            });
+            displayInfoNotification(
+              <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                {onSubmitSubmission.state === "submitted" ? (
+                  <>Submitting...</>
+                ) : (
+                  <>Saving draft...</>
+                )}
+              </p>
+            );
 
             pendingSubmissionData.current = data;
 
@@ -427,24 +408,17 @@ export function ApplicationForm() {
                 lastSuccesfullySubmittedData.current = cloneDeep(res.data);
                 pendingSubmissionData.current = {};
 
-                notificationsDispatch({
-                  type: "DISPLAY_NOTIFICATION",
-                  payload: {
-                    type: "success",
-                    body: (
-                      <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                        {onSubmitSubmission.state === "submitted" ? (
-                          <>
-                            Application <em>{mongoId}</em> submitted
-                            successfully.
-                          </>
-                        ) : (
-                          <>Draft saved successfully.</>
-                        )}
-                      </p>
-                    ),
-                  },
-                });
+                displaySuccessNotification(
+                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                    {onSubmitSubmission.state === "submitted" ? (
+                      <>
+                        Application <em>{mongoId}</em> submitted successfully.
+                      </>
+                    ) : (
+                      <>Draft saved successfully.</>
+                    )}
+                  </p>
+                );
 
                 if (onSubmitSubmission.state === "submitted") {
                   navigate("/");
@@ -452,28 +426,22 @@ export function ApplicationForm() {
 
                 if (onSubmitSubmission.state === "draft") {
                   setTimeout(() => {
-                    notificationsDispatch({ type: "DISMISS_NOTIFICATION" });
+                    dismissNotification();
                   }, 5000);
                 }
               },
               onError: (error, payload, context) => {
                 formIsBeingSubmitted.current = false;
 
-                notificationsDispatch({
-                  type: "DISPLAY_NOTIFICATION",
-                  payload: {
-                    type: "error",
-                    body: (
-                      <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                        {onSubmitSubmission.state === "submitted" ? (
-                          <>Error submitting Application form.</>
-                        ) : (
-                          <>Error saving draft.</>
-                        )}
-                      </p>
-                    ),
-                  },
-                });
+                displayErrorNotification(
+                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                    {onSubmitSubmission.state === "submitted" ? (
+                      <>Error submitting Application form.</>
+                    ) : (
+                      <>Error saving draft.</>
+                    )}
+                  </p>
+                );
               },
             });
           }}
@@ -504,17 +472,11 @@ export function ApplicationForm() {
             delete submittedData.hidden_current_user_name;
             if (isEqual(currentData, submittedData)) return;
 
-            notificationsDispatch({
-              type: "DISPLAY_NOTIFICATION",
-              payload: {
-                type: "info",
-                body: (
-                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                    Saving draft...
-                  </p>
-                ),
-              },
-            });
+            displayInfoNotification(
+              <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                Saving draft...
+              </p>
+            );
 
             pendingSubmissionData.current = data;
 
@@ -529,34 +491,22 @@ export function ApplicationForm() {
                 lastSuccesfullySubmittedData.current = cloneDeep(res.data);
                 pendingSubmissionData.current = {};
 
-                notificationsDispatch({
-                  type: "DISPLAY_NOTIFICATION",
-                  payload: {
-                    type: "success",
-                    body: (
-                      <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                        Draft saved successfully.
-                      </p>
-                    ),
-                  },
-                });
+                displaySuccessNotification(
+                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                    Draft saved successfully.
+                  </p>
+                );
 
                 setTimeout(() => {
-                  notificationsDispatch({ type: "DISMISS_NOTIFICATION" });
+                  dismissNotification();
                 }, 5000);
               },
               onError: (error, payload, context) => {
-                notificationsDispatch({
-                  type: "DISPLAY_NOTIFICATION",
-                  payload: {
-                    type: "error",
-                    body: (
-                      <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                        Error saving draft.
-                      </p>
-                    ),
-                  },
-                });
+                displayErrorNotification(
+                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                    Error saving draft.
+                  </p>
+                );
               },
             });
           }}

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -30,8 +30,16 @@ type FormioSubmission = {
 };
 
 type ServerResponse =
-  | { userAccess: false; formSchema: null; submission: null }
-  | { userAccess: true; formSchema: { url: string; json: object }; submission: FormioSubmission }; // prettier-ignore
+  | {
+      userAccess: false;
+      formSchema: null;
+      submission: null;
+    }
+  | {
+      userAccess: true;
+      formSchema: { url: string; json: object };
+      submission: FormioSubmission;
+    };
 
 export function ApplicationForm() {
   const navigate = useNavigate();

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -461,7 +461,7 @@ function ApplicationFormContent({ email }: { email: string }) {
                       <p className="tw-text-sm tw-font-medium tw-text-gray-900">
                         {onSubmitSubmission.state === "submitted" ? (
                           <>
-                            Application Form <em>{mongoId}</em> submitted
+                            Application <em>{mongoId}</em> submitted
                             successfully.
                           </>
                         ) : (

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -18,7 +18,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
 import { useDialogDispatch } from "contexts/dialog";
-import { useNotificationsActions } from "contexts/notifications";
+import { useNotificationsContext } from "contexts/notifications";
 
 type FormioSubmission = {
   [field: string]: unknown;
@@ -115,7 +115,7 @@ export function ApplicationForm() {
     displaySuccessNotification,
     displayErrorNotification,
     dismissNotification,
-  } = useNotificationsActions();
+  } = useNotificationsContext();
 
   const submissionsQueries = useSubmissionsQueries();
   const rebates = useRebates();

--- a/app/client/src/routes/closeOutForm.tsx
+++ b/app/client/src/routes/closeOutForm.tsx
@@ -1,0 +1,7 @@
+export function CloseOutForm() {
+  return (
+    <>
+      <p>(Close-Out form)</p>
+    </>
+  );
+}

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -12,7 +12,7 @@ import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/tooltip";
 import { useContentData } from "components/app";
-import { useCsbData } from "components/dashboard";
+import { useCsbData } from "components/userDashboard";
 import { useDialogDispatch } from "contexts/dialog";
 import { useUserState } from "contexts/user";
 

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -14,7 +14,6 @@ import { TextWithTooltip } from "components/tooltip";
 import { useContentData } from "components/app";
 import { useCsbData } from "components/userDashboard";
 import { useDialogDispatch } from "contexts/dialog";
-import { useUserState } from "contexts/user";
 
 type FormType = "application" | "payment-request" | "close-out";
 
@@ -38,7 +37,6 @@ export function Helpdesk() {
   const content = useContentData();
   const csbData = useCsbData();
   const dialogDispatch = useDialogDispatch();
-  const { epaUserData } = useUserState();
   const helpdeskAccess = useHelpdeskAccess();
 
   const [formType, setFormType] = useState<FormType>("application");
@@ -64,12 +62,7 @@ export function Helpdesk() {
 
   const { formSchema, submission } = query.data ?? {};
 
-  if (
-    !csbData ||
-    epaUserData.status !== "success" ||
-    helpdeskAccess === "idle" ||
-    helpdeskAccess === "pending"
-  ) {
+  if (!csbData || helpdeskAccess === "idle" || helpdeskAccess === "pending") {
     return <Loading />;
   }
 

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -27,8 +27,14 @@ type FormioSubmission = {
 };
 
 type ServerResponse =
-  | { formSchema: null; submission: null }
-  | { formSchema: { url: string; json: object }; submission: FormioSubmission };
+  | {
+      formSchema: null;
+      submission: null;
+    }
+  | {
+      formSchema: { url: string; json: object };
+      submission: FormioSubmission;
+    };
 
 export function Helpdesk() {
   const navigate = useNavigate();

--- a/app/client/src/routes/newApplicationForm.tsx
+++ b/app/client/src/routes/newApplicationForm.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useOutletContext } from "react-router-dom";
 import { Dialog, Transition } from "@headlessui/react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import icons from "uswds/img/sprite.svg";
@@ -16,7 +16,6 @@ import {
   useCsbData,
   useBapSamData,
 } from "components/userDashboard";
-import { useUserState } from "contexts/user";
 
 type FormioSubmission = {
   [field: string]: unknown;
@@ -58,11 +57,11 @@ function createNewApplication(email: string, entity: BapSamEntity) {
 
 export function NewApplicationForm() {
   const navigate = useNavigate();
+  const { email } = useOutletContext<{ email: string }>();
 
   const content = useContentData();
   const csbData = useCsbData();
   const bapSamData = useBapSamData();
-  const { epaUserData } = useUserState();
 
   const [message, setMessage] = useState<{
     displayed: boolean;
@@ -74,13 +73,11 @@ export function NewApplicationForm() {
     text: "",
   });
 
-  if (!csbData || !bapSamData || epaUserData.status !== "success") {
+  if (!csbData || !bapSamData) {
     return <Loading />;
   }
 
   const applicationFormOpen = csbData.submissionPeriodOpen.application;
-
-  const email = epaUserData.data.mail;
 
   const activeSamEntities = bapSamData.entities.filter((entity) => {
     return entity.ENTITY_STATUS__c === "Active";

--- a/app/client/src/routes/newApplicationForm.tsx
+++ b/app/client/src/routes/newApplicationForm.tsx
@@ -11,7 +11,11 @@ import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/tooltip";
 import { useContentData } from "components/app";
-import { BapSamEntity, useCsbData, useBapSamData } from "components/dashboard";
+import {
+  BapSamEntity,
+  useCsbData,
+  useBapSamData,
+} from "components/userDashboard";
 import { useUserState } from "contexts/user";
 
 type FormioSubmission = {

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -17,7 +17,7 @@ import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
-import { useNotificationsDispatch } from "contexts/notifications";
+import { useNotificationsActions } from "contexts/notifications";
 
 type FormioSubmission = {
   [field: string]: unknown;
@@ -104,7 +104,13 @@ export function PaymentRequestForm() {
   const content = useContentData();
   const csbData = useCsbData();
   const bapSamData = useBapSamData();
-  const notificationsDispatch = useNotificationsDispatch();
+  const {
+    displayInfoNotification,
+    displaySuccessNotification,
+    // displayWarningNotification,
+    displayErrorNotification,
+    dismissNotification,
+  } = useNotificationsActions();
 
   const submissionsQueries = useSubmissionsQueries();
   const rebates = useRebates();
@@ -274,21 +280,15 @@ export function PaymentRequestForm() {
 
             const data = { ...onSubmitSubmission.data };
 
-            notificationsDispatch({
-              type: "DISPLAY_NOTIFICATION",
-              payload: {
-                type: "info",
-                body: (
-                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                    {onSubmitSubmission.state === "submitted" ? (
-                      <>Submitting...</>
-                    ) : (
-                      <>Saving draft...</>
-                    )}
-                  </p>
-                ),
-              },
-            });
+            displayInfoNotification(
+              <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                {onSubmitSubmission.state === "submitted" ? (
+                  <>Submitting...</>
+                ) : (
+                  <>Saving draft...</>
+                )}
+              </p>
+            );
 
             pendingSubmissionData.current = data;
 
@@ -305,24 +305,18 @@ export function PaymentRequestForm() {
                 lastSuccesfullySubmittedData.current = cloneDeep(res.data);
                 pendingSubmissionData.current = {};
 
-                notificationsDispatch({
-                  type: "DISPLAY_NOTIFICATION",
-                  payload: {
-                    type: "success",
-                    body: (
-                      <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                        {onSubmitSubmission.state === "submitted" ? (
-                          <>
-                            Payment Request <em>{rebateId}</em> submitted
-                            successfully.
-                          </>
-                        ) : (
-                          <>Draft saved successfully.</>
-                        )}
-                      </p>
-                    ),
-                  },
-                });
+                displaySuccessNotification(
+                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                    {onSubmitSubmission.state === "submitted" ? (
+                      <>
+                        Payment Request <em>{rebateId}</em> submitted
+                        successfully.
+                      </>
+                    ) : (
+                      <>Draft saved successfully.</>
+                    )}
+                  </p>
+                );
 
                 if (onSubmitSubmission.state === "submitted") {
                   navigate("/");
@@ -330,28 +324,22 @@ export function PaymentRequestForm() {
 
                 if (onSubmitSubmission.state === "draft") {
                   setTimeout(() => {
-                    notificationsDispatch({ type: "DISMISS_NOTIFICATION" });
+                    dismissNotification();
                   }, 5000);
                 }
               },
               onError: (error, payload, context) => {
                 formIsBeingSubmitted.current = false;
 
-                notificationsDispatch({
-                  type: "DISPLAY_NOTIFICATION",
-                  payload: {
-                    type: "error",
-                    body: (
-                      <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                        {onSubmitSubmission.state === "submitted" ? (
-                          <>Error submitting Payment Request form.</>
-                        ) : (
-                          <>Error saving draft.</>
-                        )}
-                      </p>
-                    ),
-                  },
-                });
+                displayErrorNotification(
+                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                    {onSubmitSubmission.state === "submitted" ? (
+                      <>Error submitting Payment Request form.</>
+                    ) : (
+                      <>Error saving draft.</>
+                    )}
+                  </p>
+                );
               },
             });
           }}
@@ -378,17 +366,11 @@ export function PaymentRequestForm() {
             delete submittedData.hidden_current_user_name;
             if (isEqual(currentData, submittedData)) return;
 
-            notificationsDispatch({
-              type: "DISPLAY_NOTIFICATION",
-              payload: {
-                type: "info",
-                body: (
-                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                    Saving draft...
-                  </p>
-                ),
-              },
-            });
+            displayInfoNotification(
+              <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                Saving draft...
+              </p>
+            );
 
             pendingSubmissionData.current = data;
 
@@ -406,34 +388,22 @@ export function PaymentRequestForm() {
                 lastSuccesfullySubmittedData.current = cloneDeep(res.data);
                 pendingSubmissionData.current = {};
 
-                notificationsDispatch({
-                  type: "DISPLAY_NOTIFICATION",
-                  payload: {
-                    type: "success",
-                    body: (
-                      <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                        Draft saved successfully.
-                      </p>
-                    ),
-                  },
-                });
+                displaySuccessNotification(
+                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                    Draft saved successfully.
+                  </p>
+                );
 
                 setTimeout(() => {
-                  notificationsDispatch({ type: "DISMISS_NOTIFICATION" });
+                  dismissNotification();
                 }, 5000);
               },
               onError: (error, payload, context) => {
-                notificationsDispatch({
-                  type: "DISPLAY_NOTIFICATION",
-                  payload: {
-                    type: "error",
-                    body: (
-                      <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                        Error saving draft.
-                      </p>
-                    ),
-                  },
-                });
+                displayErrorNotification(
+                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                    Error saving draft.
+                  </p>
+                );
               },
             });
           }}

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useEffect, useRef } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useRef } from "react";
+import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Formio, Form } from "@formio/react";
 import { cloneDeep, isEqual } from "lodash";
@@ -17,7 +17,6 @@ import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
-import { useUserState } from "contexts/user";
 import { useNotificationsDispatch } from "contexts/notifications";
 
 type FormioSubmission = {
@@ -34,24 +33,8 @@ type ServerResponse =
   | { userAccess: true; formSchema: { url: string; json: object }; submission: FormioSubmission }; // prettier-ignore
 
 export function PaymentRequestForm() {
-  const { epaUserData } = useUserState();
-  const email = epaUserData.status !== "success" ? "" : epaUserData.data.mail;
-
-  /**
-   * NOTE: The child component only uses the email from the `user` context, but
-   * the `epaUserData.data` object includes an `exp` field that changes whenever
-   * the JWT is refreshed. Since the user verification process `verifyUser()`
-   * gets called from the parent `ProtectedRoute` component, we need to memoize
-   * the email address (which won't change) to prevent the child component from
-   * needlessly re-rendering.
-   */
-  return useMemo(() => {
-    return <PaymentRequestFormContent email={email} />;
-  }, [email]);
-}
-
-function PaymentRequestFormContent({ email }: { email: string }) {
   const navigate = useNavigate();
+  const { email } = useOutletContext<{ email: string }>();
   const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
   const queryClient = useQueryClient();
 
@@ -137,7 +120,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
 
   const { userAccess, formSchema, submission } = query.data ?? {};
 
-  if (email === "" || !csbData || !bapSamData) {
+  if (!csbData || !bapSamData) {
     return <Loading />;
   }
 

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -29,8 +29,16 @@ type FormioSubmission = {
 };
 
 type ServerResponse =
-  | { userAccess: false; formSchema: null; submission: null }
-  | { userAccess: true; formSchema: { url: string; json: object }; submission: FormioSubmission }; // prettier-ignore
+  | {
+      userAccess: false;
+      formSchema: null;
+      submission: null;
+    }
+  | {
+      userAccess: true;
+      formSchema: { url: string; json: object };
+      submission: FormioSubmission;
+    };
 
 export function PaymentRequestForm() {
   const navigate = useNavigate();

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -17,7 +17,7 @@ import { Loading } from "components/loading";
 import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { useContentData } from "components/app";
-import { useCsbData, useBapSamData } from "components/dashboard";
+import { useCsbData, useBapSamData } from "components/userDashboard";
 import { useUserState } from "contexts/user";
 import { useNotificationsDispatch } from "contexts/notifications";
 

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -17,7 +17,7 @@ import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
-import { useNotificationsActions } from "contexts/notifications";
+import { useNotificationsContext } from "contexts/notifications";
 
 type FormioSubmission = {
   [field: string]: unknown;
@@ -109,7 +109,7 @@ export function PaymentRequestForm() {
     displaySuccessNotification,
     displayErrorNotification,
     dismissNotification,
-  } = useNotificationsActions();
+  } = useNotificationsContext();
 
   const submissionsQueries = useSubmissionsQueries();
   const rebates = useRebates();

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -9,7 +9,7 @@ import { serverUrl, messages, getData, postData } from "../config";
 import { getUserInfo } from "../utilities";
 import {
   submissionNeedsEdits,
-  useFetchedFormSubmissions,
+  useSubmissionsQueries,
   useRebates,
 } from "routes/allRebates";
 import { Loading } from "components/loading";
@@ -44,14 +44,14 @@ export function PaymentRequestForm() {
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
   const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
-  const queryClient = useQueryClient();
 
+  const queryClient = useQueryClient();
   const content = useContentData();
   const csbData = useCsbData();
   const bapSamData = useBapSamData();
   const notificationsDispatch = useNotificationsDispatch();
 
-  const formSubmissionsQueries = useFetchedFormSubmissions();
+  const submissionsQueries = useSubmissionsQueries();
   const rebates = useRebates();
 
   /**
@@ -132,11 +132,11 @@ export function PaymentRequestForm() {
     return <Loading />;
   }
 
-  if (formSubmissionsQueries.some((query) => query.isFetching)) {
+  if (submissionsQueries.some((query) => query.isFetching)) {
     return <Loading />;
   }
 
-  if (formSubmissionsQueries.some((query) => query.isError)) {
+  if (submissionsQueries.some((query) => query.isError)) {
     return <Message type="error" text={messages.formSubmissionsError} />;
   }
 

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -107,7 +107,6 @@ export function PaymentRequestForm() {
   const {
     displayInfoNotification,
     displaySuccessNotification,
-    // displayWarningNotification,
     displayErrorNotification,
     dismissNotification,
   } = useNotificationsActions();

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -339,7 +339,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
                       <p className="tw-text-sm tw-font-medium tw-text-gray-900">
                         {onSubmitSubmission.state === "submitted" ? (
                           <>
-                            Payment Request Form <em>{rebateId}</em> submitted
+                            Payment Request <em>{rebateId}</em> submitted
                             successfully.
                           </>
                         ) : (

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -62,11 +62,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
   const bapSamData = useBapSamData();
   const notificationsDispatch = useNotificationsDispatch();
 
-  const {
-    bapFormSubmissionsQuery,
-    formioApplicationSubmissionsQuery,
-    formioPaymentRequestSubmissionsQuery,
-  } = useFetchedFormSubmissions();
+  const formSubmissionsQueries = useFetchedFormSubmissions();
 
   const combinedRebates = useCombinedSubmissions();
   const sortedRebates = useSortedRebates(combinedRebates);
@@ -156,19 +152,11 @@ function PaymentRequestFormContent({ email }: { email: string }) {
     return <Loading />;
   }
 
-  if (
-    bapFormSubmissionsQuery.isFetching ||
-    formioApplicationSubmissionsQuery.isFetching ||
-    formioPaymentRequestSubmissionsQuery.isFetching
-  ) {
+  if (formSubmissionsQueries.some((query) => query.isFetching)) {
     return <Loading />;
   }
 
-  if (
-    bapFormSubmissionsQuery.isError ||
-    formioApplicationSubmissionsQuery.isError ||
-    formioPaymentRequestSubmissionsQuery.isError
-  ) {
+  if (formSubmissionsQueries.some((query) => query.isError)) {
     return <Message type="error" text={messages.formSubmissionsError} />;
   }
 

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, useRef } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Formio, Form } from "@formio/react";
 import { cloneDeep, isEqual } from "lodash";
@@ -10,8 +10,7 @@ import { getUserInfo } from "../utilities";
 import {
   submissionNeedsEdits,
   useFetchedFormSubmissions,
-  useCombinedSubmissions,
-  useSortedRebates,
+  useRebates,
 } from "routes/allRebates";
 import { Loading } from "components/loading";
 import { Message } from "components/message";
@@ -54,7 +53,6 @@ export function PaymentRequestForm() {
 function PaymentRequestFormContent({ email }: { email: string }) {
   const navigate = useNavigate();
   const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
-  const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
 
   const content = useContentData();
@@ -63,16 +61,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
   const notificationsDispatch = useNotificationsDispatch();
 
   const formSubmissionsQueries = useFetchedFormSubmissions();
-
-  const combinedRebates = useCombinedSubmissions();
-  const sortedRebates = useSortedRebates(combinedRebates);
-
-  // log combined 'sortedRebates' array if 'debug' search parameter exists
-  useEffect(() => {
-    if (searchParams.has("debug") && sortedRebates.length > 0) {
-      console.log(sortedRebates);
-    }
-  }, [searchParams, sortedRebates]);
+  const rebates = useRebates();
 
   /**
    * Stores when the form is being submitted, so it can be referenced in the
@@ -169,7 +158,7 @@ function PaymentRequestFormContent({ email }: { email: string }) {
     return <Message type="error" text={text} />;
   }
 
-  const rebate = sortedRebates.find((item) => item.rebateId === rebateId);
+  const rebate = rebates.find((r) => r.rebateId === rebateId);
 
   const applicationNeedsEdits = !rebate
     ? false

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -53,7 +53,7 @@ export function PaymentRequestForm() {
 
 function PaymentRequestFormContent({ email }: { email: string }) {
   const navigate = useNavigate();
-  const { rebateId } = useParams<"rebateId">(); // CSB Rebate ID (6 digits)
+  const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
 

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -1,4 +1,4 @@
-import { BapSamEntity } from "components/dashboard";
+import { BapSamEntity } from "components/userDashboard";
 
 /**
  * Returns a user’s title and name when provided an email address and a SAM.gov


### PR DESCRIPTION
## Related Issues:
* CSBAPP-5

## Main Changes:
Adds a new stub route and component for the Close-Out form. As there's lots of duplicated code between the Application form page and the Payment Request form page, instead of further duplicating it in the new Close-Out form page, I took the opportunity to refactor a good bit of that code, which should make the app more maintainable in the long run.

## Steps To Test:
1. Run app – all should still function as normal.
2. A new route exists at `/close-out/:id` (NOTE: just a placeholder page for now)

## TODO:
- [ ] Update the server app routes to support fetching the close-out data, and flesh out the the Close-Out form route component to display the close-out form component
