### PR TITLE
Feature/fix notifications bug

### DIFF
--- a/app/client/src/components/confirmationDialog.tsx
+++ b/app/client/src/components/confirmationDialog.tsx
@@ -2,7 +2,7 @@ import { Fragment, useRef } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 // ---
-import { useDialogState, useDialogDispatch } from "contexts/dialog";
+import { useDialogState, useDialogActions } from "contexts/dialog";
 
 export function ConfirmationDialog() {
   const {
@@ -15,7 +15,7 @@ export function ConfirmationDialog() {
     confirmedAction,
     dismissedAction,
   } = useDialogState();
-  const dialogDispatch = useDialogDispatch();
+  const { resetDialog } = useDialogActions();
 
   const cancelRef = useRef<HTMLButtonElement>(null);
 
@@ -28,7 +28,7 @@ export function ConfirmationDialog() {
         open={dialogShown}
         onClose={(ev) => {
           dismissable && dismissedAction && dismissedAction();
-          dismissable && dialogDispatch({ type: "RESET_DIALOG" });
+          dismissable && resetDialog();
         }}
       >
         <Transition.Child
@@ -63,7 +63,7 @@ export function ConfirmationDialog() {
                         className="tw-rounded-md tw-bg-white tw-text-gray-400 tw-transition-none hover:tw-text-gray-700 focus:tw-text-gray-700"
                         onClick={(ev) => {
                           dismissedAction && dismissedAction();
-                          dialogDispatch({ type: "RESET_DIALOG" });
+                          resetDialog();
                         }}
                       >
                         <span className="tw-sr-only">Close</span>
@@ -88,7 +88,7 @@ export function ConfirmationDialog() {
                           className="usa-button"
                           onClick={(ev) => {
                             confirmedAction();
-                            dialogDispatch({ type: "RESET_DIALOG" });
+                            resetDialog();
                           }}
                         >
                           {confirmText}
@@ -101,7 +101,7 @@ export function ConfirmationDialog() {
                             className="usa-button"
                             onClick={(ev) => {
                               dismissedAction && dismissedAction();
-                              dialogDispatch({ type: "RESET_DIALOG" });
+                              resetDialog();
                             }}
                             ref={cancelRef}
                           >

--- a/app/client/src/components/notifications.tsx
+++ b/app/client/src/components/notifications.tsx
@@ -6,11 +6,14 @@ import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { XCircleIcon } from "@heroicons/react/24/outline";
 import { XMarkIcon } from "@heroicons/react/20/solid";
 // ---
-import { useNotificationsContext } from "contexts/notifications";
+import {
+  useNotificationsState,
+  useNotificationsActions,
+} from "contexts/notifications";
 
 export function Notifications() {
-  const { state, dismissNotification } = useNotificationsContext();
-  const { displayed, body, type } = state;
+  const { displayed, body, type } = useNotificationsState();
+  const { dismissNotification } = useNotificationsActions();
 
   return (
     <div className="twpf">

--- a/app/client/src/components/userDashboard.tsx
+++ b/app/client/src/components/userDashboard.tsx
@@ -14,7 +14,7 @@ import {
 } from "../config";
 import { useHelpdeskAccess } from "components/app";
 import { Loading } from "components/loading";
-import { Action, useDialogDispatch } from "contexts/dialog";
+import { useDialogActions } from "contexts/dialog";
 
 type CsbData = {
   submissionPeriodOpen: {
@@ -141,7 +141,7 @@ export function UserDashboard(props: { email: string }) {
   const csbData = useCsbData();
   const bapSamData = useBapSamData();
 
-  const dialogDispatch = useDialogDispatch();
+  const { displayDialog } = useDialogActions();
   const helpdeskAccess = useHelpdeskAccess();
 
   const onAllRebatesPage = pathname === "/";
@@ -152,31 +152,6 @@ export function UserDashboard(props: { email: string }) {
   const applicationFormOpen = csbData
     ? csbData.submissionPeriodOpen.application
     : false;
-
-  /**
-   * When provided a destination location to navigate to, creates an action
-   * object that can be dispatched to the `DialogProvider` context component,
-   * which the `ConfirmationDialog` component (rendered in the `App` component's
-   * `ProtectedRoute` component) uses to display the provided info.
-   */
-  function createDialogNavAction(destination: string): Action {
-    return {
-      type: "DISPLAY_DIALOG",
-      payload: {
-        dismissable: true,
-        heading: "Are you sure you want to navigate away from this page?",
-        description: (
-          <p>
-            If you haven’t saved the current form, any changes you’ve made will
-            be lost.
-          </p>
-        ),
-        confirmText: "Yes",
-        dismissText: "Cancel",
-        confirmedAction: () => navigate(destination),
-      },
-    };
-  }
 
   if (!csbData || !bapSamData) {
     return <Loading />;
@@ -240,8 +215,20 @@ export function UserDashboard(props: { email: string }) {
               onClick={(ev) => {
                 if (onApplicationFormPage || onPaymentRequestFormPage) {
                   ev.preventDefault();
-                  const action = createDialogNavAction("/");
-                  dialogDispatch(action);
+                  displayDialog({
+                    dismissable: true,
+                    heading:
+                      "Are you sure you want to navigate away from this page?",
+                    description: (
+                      <p>
+                        If you haven’t saved the current form, any changes
+                        you’ve made will be lost.
+                      </p>
+                    ),
+                    confirmText: "Yes",
+                    dismissText: "Cancel",
+                    confirmedAction: () => navigate("/"),
+                  });
                 }
               }}
             >
@@ -295,8 +282,20 @@ export function UserDashboard(props: { email: string }) {
                   onClick={(ev) => {
                     if (onApplicationFormPage || onPaymentRequestFormPage) {
                       ev.preventDefault();
-                      const action = createDialogNavAction("/helpdesk");
-                      dialogDispatch(action);
+                      displayDialog({
+                        dismissable: true,
+                        heading:
+                          "Are you sure you want to navigate away from this page?",
+                        description: (
+                          <p>
+                            If you haven’t saved the current form, any changes
+                            you’ve made will be lost.
+                          </p>
+                        ),
+                        confirmText: "Yes",
+                        dismissText: "Cancel",
+                        confirmedAction: () => navigate("/helpdesk"),
+                      });
                     }
                   }}
                 >

--- a/app/client/src/contexts/dialog.tsx
+++ b/app/client/src/contexts/dialog.tsx
@@ -21,7 +21,7 @@ type State = {
   dismissedAction?: () => void;
 };
 
-export type Action =
+type Action =
   | {
       type: "DISPLAY_DIALOG";
       payload: {
@@ -122,7 +122,7 @@ export function DialogProvider({ children }: Props) {
 }
 
 /**
- * Returns state stored in `DialogProvider` context component.
+ * Custom hook that returns state stored in `DialogProvider` context component.
  */
 export function useDialogState() {
   const context = useContext(StateContext);
@@ -134,14 +134,56 @@ export function useDialogState() {
 }
 
 /**
- * Returns `dispatch` method for dispatching actions to update state stored in
- * `DialogProvider` context component.
+ * Custom hook that returns `dispatch` method for dispatching actions to update
+ * state stored in `DialogProvider` context component.
  */
-export function useDialogDispatch() {
+function useDialogDispatch() {
   const context = useContext(DispatchContext);
   if (context === undefined) {
     const message = `useDialogDispatch must be used within a DialogProvider`;
     throw new Error(message);
   }
   return context;
+}
+
+/**
+ * Custom hook that returns functions to dispatch actions to display a dialog,
+ * update a dialog's description, and reset (hide) a displayed dialog.
+ */
+export function useDialogActions() {
+  const dispatch = useDialogDispatch();
+
+  return {
+    displayDialog(options: {
+      dismissable: boolean;
+      heading: string;
+      description: ReactNode;
+      confirmText: string;
+      dismissText?: string;
+      confirmedAction: () => void;
+      dismissedAction?: () => void;
+    }) {
+      return dispatch({
+        type: "DISPLAY_DIALOG",
+        payload: {
+          dismissable: options.dismissable,
+          heading: options.heading,
+          description: options.description,
+          confirmText: options.confirmText,
+          dismissText: options.dismissText,
+          confirmedAction: options.confirmedAction,
+          dismissedAction: options.dismissedAction,
+        },
+      });
+    },
+    updateDialogDescription(description: ReactNode) {
+      return dispatch({
+        type: "UPDATE_DIALOG_DESCRIPTION",
+        payload: { description },
+      });
+    },
+    resetDialog() {
+      return dispatch({ type: "RESET_DIALOG" });
+    },
+  };
 }

--- a/app/client/src/contexts/notifications.tsx
+++ b/app/client/src/contexts/notifications.tsx
@@ -77,7 +77,7 @@ export function NotificationsProvider({ children }: Props) {
 /**
  * Returns state stored in `NotificationsProvider` context component.
  */
-function useNotificationsState() {
+export function useNotificationsState() {
   const context = useContext(StateContext);
   if (context === undefined) {
     const message = `useNotificationsState must be called within a NotificationsProvider`;
@@ -100,16 +100,14 @@ function useNotificationsDispatch() {
 }
 
 /**
- * Custom hook that returns notifications current state, functions to display
- * each notification type (info, success, warning, or error), and a function to
- * dismiss a currently displayed notification.
+ * Custom hook that returns functions to display each notification type (info,
+ * success, warning, or error), and a function to dismiss a currently displayed
+ * notification.
  */
-export function useNotificationsContext() {
-  const state = useNotificationsState();
+export function useNotificationsActions() {
   const dispatch = useNotificationsDispatch();
 
   return {
-    state,
     displayInfoNotification(body: ReactNode) {
       return dispatch({
         type: "DISPLAY_NOTIFICATION",

--- a/app/client/src/contexts/notifications.tsx
+++ b/app/client/src/contexts/notifications.tsx
@@ -75,7 +75,8 @@ export function NotificationsProvider({ children }: Props) {
 }
 
 /**
- * Returns state stored in `NotificationsProvider` context component.
+ * Custom hook that returns state stored in `NotificationsProvider` context
+ * component.
  */
 export function useNotificationsState() {
   const context = useContext(StateContext);
@@ -87,8 +88,8 @@ export function useNotificationsState() {
 }
 
 /**
- * Returns `dispatch` method for dispatching actions to update state stored in
- * `NotificationsProvider` context component.
+ * Custom hook that returns `dispatch` method for dispatching actions to update
+ * state stored in `NotificationsProvider` context component.
  */
 function useNotificationsDispatch() {
   const context = useContext(DispatchContext);
@@ -100,9 +101,9 @@ function useNotificationsDispatch() {
 }
 
 /**
- * Custom hook that returns functions to display each notification type (info,
- * success, warning, or error), and a function to dismiss a currently displayed
- * notification.
+ * Custom hook that returns functions to dispatch actions to display each
+ * notification type (info, success, warning, or error), and dismiss a currently
+ * displayed notification.
  */
 export function useNotificationsActions() {
   const dispatch = useNotificationsDispatch();

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -17,7 +17,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/tooltip";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
-import { useNotificationsContext } from "contexts/notifications";
+import { useNotificationsActions } from "contexts/notifications";
 
 type BapFormSubmission = {
   UEI_EFTI_Combo_Key__c: string; // UEI + EFTI combo key
@@ -705,7 +705,7 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
 
   const csbData = useCsbData();
   const bapSamData = useBapSamData();
-  const { displayErrorNotification } = useNotificationsContext();
+  const { displayErrorNotification } = useNotificationsActions();
 
   // NOTE: used to display a loading indicator inside the new Payment Request button
   const [postDataResponsePending, setPostDataResponsePending] = useState(false);
@@ -719,7 +719,7 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
   const applicationSelectedButNoPaymentRequest =
     applicationSelected && !Boolean(paymentRequest.formio);
 
-  /** matched SAM.gov entity for the application */
+  /** matched SAM.gov entity for the Application submission */
   const entity = bapSamData.entities.find((entity) => {
     return (
       entity.ENTITY_STATUS__c === "Active" &&

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -18,7 +18,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
 import { useDialogDispatch } from "contexts/dialog";
-import { useNotificationsContext } from "contexts/notifications";
+import { useNotificationsActions } from "contexts/notifications";
 
 type FormioSubmission = {
   [field: string]: unknown;
@@ -115,7 +115,7 @@ export function ApplicationForm() {
     displaySuccessNotification,
     displayErrorNotification,
     dismissNotification,
-  } = useNotificationsContext();
+  } = useNotificationsActions();
 
   const submissionsQueries = useSubmissionsQueries();
   const rebates = useRebates();
@@ -295,6 +295,7 @@ export function ApplicationForm() {
     (submission.state === "submitted" || !applicationFormOpen) &&
     !applicationNeedsEdits;
 
+  /** matched SAM.gov entity for the Application submission */
   const entity = bapSamData.entities.find((entity) => {
     return (
       entity.ENTITY_STATUS__c === "Active" &&

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -13,7 +13,7 @@ import { MarkdownContent } from "components/markdownContent";
 import { TextWithTooltip } from "components/tooltip";
 import { useContentData } from "components/app";
 import { useCsbData } from "components/userDashboard";
-import { useDialogDispatch } from "contexts/dialog";
+import { useDialogActions } from "contexts/dialog";
 
 type FormType = "application" | "payment-request" | "close-out";
 
@@ -42,7 +42,7 @@ export function Helpdesk() {
 
   const content = useContentData();
   const csbData = useCsbData();
-  const dialogDispatch = useDialogDispatch();
+  const { displayDialog } = useDialogActions();
   const helpdeskAccess = useHelpdeskAccess();
 
   const [formType, setFormType] = useState<FormType>("application");
@@ -324,25 +324,22 @@ export function Helpdesk() {
                           (formType === "close-out" && !closeOutFormOpen)
                       }
                       onClick={(_ev) => {
-                        dialogDispatch({
-                          type: "DISPLAY_DIALOG",
-                          payload: {
-                            dismissable: true,
-                            heading:
-                              "Are you sure you want to change this submission's state back to draft?",
-                            description: (
-                              <p>
-                                Once the submission is back in a draft state,
-                                all users with access to this submission will be
-                                able to further edit it.
-                              </p>
-                            ),
-                            confirmText: "Yes",
-                            dismissText: "Cancel",
-                            confirmedAction: () => {
-                              setFormDisplayed(false);
-                              mutation.mutate();
-                            },
+                        displayDialog({
+                          dismissable: true,
+                          heading:
+                            "Are you sure you want to change this submission's state back to draft?",
+                          description: (
+                            <p>
+                              Once the submission is back in a draft state, all
+                              users with access to this submission will be able
+                              to further edit it.
+                            </p>
+                          ),
+                          confirmText: "Yes",
+                          dismissText: "Cancel",
+                          confirmedAction: () => {
+                            setFormDisplayed(false);
+                            mutation.mutate();
                           },
                         });
                       }}

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -17,7 +17,7 @@ import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { useContentData } from "components/app";
 import { useCsbData, useBapSamData } from "components/userDashboard";
-import { useNotificationsContext } from "contexts/notifications";
+import { useNotificationsActions } from "contexts/notifications";
 
 type FormioSubmission = {
   [field: string]: unknown;
@@ -109,7 +109,7 @@ export function PaymentRequestForm() {
     displaySuccessNotification,
     displayErrorNotification,
     dismissNotification,
-  } = useNotificationsContext();
+  } = useNotificationsActions();
 
   const submissionsQueries = useSubmissionsQueries();
   const rebates = useRebates();
@@ -184,6 +184,7 @@ export function PaymentRequestForm() {
     ((submission.state === "submitted" || !paymentRequestFormOpen) &&
       !paymentRequestNeedsEdits);
 
+  /** matched SAM.gov entity for the Payment Request submission */
   const entity = bapSamData.entities.find((entity) => {
     return (
       entity.ENTITY_STATUS__c === "Active" &&


### PR DESCRIPTION
## Related Issues:
* CSBAPP-2

## Main Changes:
Fixes a bug where a user's entered form data is lost if they typed something into an input:
1) after clicking "Next" or "Save" and
2) before the server responds with the successfully posted data

## Steps To Test:
1. Navigate to a form page (application or payment request), click "Next" and then quickly enter in text into a form field input before the server responds with a "success" message from posting the data.

## TODO:
- [x] Consider rendering an overlay when form data is being posted to the server to prevent user from entering any further inputs before the server responds.
