### PR TITLE
Feature/build out close out form functionality

### DIFF
--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -340,17 +340,6 @@ export function ApplicationForm() {
         />
       )}
 
-      <Dialog as="div" open={dataIsPosting.current} onClose={(ev) => {}}>
-        <div className="tw-fixed tw-inset-0 tw-bg-black/30" />
-        <div className="tw-fixed tw-inset-0 tw-z-20">
-          <div className="tw-flex tw-min-h-full tw-items-center tw-justify-center">
-            <Dialog.Panel className="tw-rounded-lg tw-bg-white tw-px-4 tw-pb-4 tw-shadow-xl">
-              <Loading />
-            </Dialog.Panel>
-          </div>
-        </div>
-      </Dialog>
-
       <ul className="usa-icon-list">
         <li className="usa-icon-list__item">
           <div className="usa-icon-list__icon text-primary">
@@ -376,6 +365,17 @@ export function ApplicationForm() {
           </li>
         )}
       </ul>
+
+      <Dialog as="div" open={dataIsPosting.current} onClose={(ev) => {}}>
+        <div className="tw-fixed tw-inset-0 tw-bg-black/30" />
+        <div className="tw-fixed tw-inset-0 tw-z-20">
+          <div className="tw-flex tw-min-h-full tw-items-center tw-justify-center">
+            <Dialog.Panel className="tw-rounded-lg tw-bg-white tw-px-4 tw-pb-4 tw-shadow-xl">
+              <Loading />
+            </Dialog.Panel>
+          </div>
+        </div>
+      </Dialog>
 
       <div className="csb-form">
         <Form

--- a/app/client/src/routes/closeOutForm.tsx
+++ b/app/client/src/routes/closeOutForm.tsx
@@ -1,7 +1,416 @@
+import { useEffect, useRef } from "react";
+import { useNavigate, useOutletContext, useParams } from "react-router-dom";
+import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
+import { Dialog } from "@headlessui/react";
+import { Formio, Form } from "@formio/react";
+import { cloneDeep, isEqual } from "lodash";
+import icons from "uswds/img/sprite.svg";
+// ---
+import { serverUrl, messages } from "../config";
+import {
+  getData,
+  postData,
+  useContentData,
+  useCsbData,
+  useBapSamData,
+  useSubmissionsQueries,
+  useRebates,
+  submissionNeedsEdits,
+  getUserInfo,
+} from "../utilities";
+import { Loading } from "components/loading";
+import { Message } from "components/message";
+import { MarkdownContent } from "components/markdownContent";
+import { useNotificationsActions } from "contexts/notifications";
+
+type FormioSubmission = {
+  [field: string]: unknown;
+  _id: string; // MongoDB ObjectId string
+  modified: string; // ISO 8601 date string
+  metadata: { [field: string]: unknown };
+  data: { [field: string]: unknown };
+  state: "submitted" | "draft";
+};
+
+type ServerResponse =
+  | {
+      userAccess: false;
+      formSchema: null;
+      submission: null;
+    }
+  | {
+      userAccess: true;
+      formSchema: { url: string; json: object };
+      submission: FormioSubmission;
+    };
+
+/** Custom hook to fetch Formio submission data */
+function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.resetQueries({ queryKey: ["close-out"] });
+  }, [queryClient]);
+
+  const url = `${serverUrl}/api/formio-close-out-submission/${rebateId}`;
+
+  const query = useQuery({
+    queryKey: ["close-out", { id: rebateId }],
+    queryFn: () => {
+      return getData<ServerResponse>(url).then((res) => {
+        // set up s3 re-route to wrapper app
+        const s3Provider = Formio.Providers.providers.storage.s3;
+        Formio.Providers.providers.storage.s3 = function (formio: any) {
+          const s3Formio = cloneDeep(formio);
+          const mongoId = res.submission?._id;
+          const comboKey = res.submission?.data.bap_hidden_entity_combo_key;
+          s3Formio.formUrl = `${serverUrl}/api/s3/close-out/${mongoId}/${comboKey}`;
+          return s3Provider(s3Formio);
+        };
+
+        return Promise.resolve(res);
+      });
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (updatedSubmission: {
+      mongoId: string;
+      submission: {
+        data: { [field: string]: unknown };
+        metadata: { [field: string]: unknown };
+        state: "submitted" | "draft";
+      };
+    }) => {
+      return postData<FormioSubmission>(url, updatedSubmission);
+    },
+    onSuccess: (res) => {
+      return queryClient.setQueryData<ServerResponse>(
+        ["close-out", { id: rebateId }],
+        (prevData) => {
+          return prevData?.submission
+            ? { ...prevData, submission: res }
+            : prevData;
+        }
+      );
+    },
+  });
+
+  return { query, mutation };
+}
+
 export function CloseOutForm() {
+  const navigate = useNavigate();
+  const { email } = useOutletContext<{ email: string }>();
+  const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
+
+  const content = useContentData();
+  const csbData = useCsbData();
+  const bapSamData = useBapSamData();
+  const {
+    displaySuccessNotification,
+    displayErrorNotification,
+    dismissNotification,
+  } = useNotificationsActions();
+
+  const submissionsQueries = useSubmissionsQueries();
+  const rebates = useRebates();
+
+  const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
+  const { userAccess, formSchema, submission } = query.data ?? {};
+
+  /**
+   * Stores when data is being posted to the server, so a loading overlay can
+   * be rendered over the form, preventing the user from losing input data when
+   * the form is re-rendered with data returned from the server's successful
+   * post response.
+   */
+  const dataIsPosting = useRef(false);
+
+  /**
+   * Stores when the form is being submitted, so it can be referenced in the
+   * Form component's `onSubmit` event prop to prevent double submits.
+   */
+  const formIsBeingSubmitted = useRef(false);
+
+  /**
+   * Stores the form data's state right after the user clicks the Save, Submit,
+   * or Next button. As soon as a post request to update the data succeeds, this
+   * pending submission data is reset to an empty object. This pending data,
+   * along with the submission data returned from the server is passed into the
+   * Form component's `submission` prop.
+   */
+  const pendingSubmissionData = useRef<{ [field: string]: unknown }>({});
+
+  /**
+   * Stores the last succesfully submitted data, so it can be used in the Form
+   * component's `onNextPage` event prop's "dirty check" which determines if
+   * posting of updated data is needed (so we don't make needless requests if no
+   * field data in the form has changed).
+   */
+  const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  if (!csbData || !bapSamData) {
+    return <Loading />;
+  }
+
+  if (submissionsQueries.some((query) => query.isFetching)) {
+    return <Loading />;
+  }
+
+  if (submissionsQueries.some((query) => query.isError)) {
+    return <Message type="error" text={messages.formSubmissionsError} />;
+  }
+
+  if (query.isInitialLoading) {
+    return <Loading />;
+  }
+
+  if (query.isError || !userAccess || !formSchema || !submission) {
+    const text = `The requested submission does not exist, or you do not have access. Please contact support if you believe this is a mistake.`;
+    return <Message type="error" text={text} />;
+  }
+
+  const rebate = rebates.find((r) => r.rebateId === rebateId);
+
+  const closeOutNeedsEdits = !rebate
+    ? false
+    : submissionNeedsEdits({
+        formio: rebate.closeOut.formio,
+        bap: rebate.closeOut.bap,
+      });
+
+  const closeOutFormOpen = csbData.submissionPeriodOpen.closeOut;
+
+  const formIsReadOnly =
+    (submission.state === "submitted" || !closeOutFormOpen) &&
+    !closeOutNeedsEdits;
+
+  /** matched SAM.gov entity for the Close-Out submission */
+  const entity = bapSamData.entities.find((entity) => {
+    return (
+      entity.ENTITY_STATUS__c === "Active" &&
+      entity.ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key
+    );
+  });
+
+  // TODO: do we need to account for when ENTITY_STATUS__c does not equal "Active" (e.g. its expired)?
+  if (!entity) return null;
+
+  const { title, name } = getUserInfo(email, entity);
+
   return (
-    <>
-      <p>(Close-Out form)</p>
-    </>
+    <div className="margin-top-2">
+      {content && (
+        <MarkdownContent
+          className="margin-top-4"
+          children={
+            submission.state === "draft"
+              ? content.draftCloseOutIntro
+              : submission.state === "submitted"
+              ? content.submittedCloseOutIntro
+              : ""
+          }
+        />
+      )}
+
+      <ul className="usa-icon-list">
+        <li className="usa-icon-list__item">
+          <div className="usa-icon-list__icon text-primary">
+            <svg className="usa-icon" aria-hidden="true" role="img">
+              <use href={`${icons}#local_offer`} />
+            </svg>
+          </div>
+          <div className="usa-icon-list__content">
+            <strong>Rebate ID:</strong> {rebateId}
+          </div>
+        </li>
+      </ul>
+
+      <Dialog as="div" open={dataIsPosting.current} onClose={(ev) => {}}>
+        <div className="tw-fixed tw-inset-0 tw-bg-black/30" />
+        <div className="tw-fixed tw-inset-0 tw-z-20">
+          <div className="tw-flex tw-min-h-full tw-items-center tw-justify-center">
+            <Dialog.Panel className="tw-rounded-lg tw-bg-white tw-px-4 tw-pb-4 tw-shadow-xl">
+              <Loading />
+            </Dialog.Panel>
+          </div>
+        </div>
+      </Dialog>
+
+      <div className="csb-form">
+        <Form
+          form={formSchema.json}
+          url={formSchema.url} // NOTE: used for file uploads
+          submission={{
+            data: {
+              ...submission.data,
+              last_updated_by: email,
+              hidden_current_user_email: email,
+              hidden_current_user_title: title,
+              hidden_current_user_name: name,
+              ...pendingSubmissionData.current,
+            },
+          }}
+          options={{
+            readOnly: formIsReadOnly,
+            noAlerts: true,
+          }}
+          onSubmit={(onSubmitSubmission: {
+            data: { [field: string]: unknown };
+            metadata: { [field: string]: unknown };
+            state: "submitted" | "draft";
+          }) => {
+            if (formIsReadOnly) return;
+
+            // account for when form is being submitted to prevent double submits
+            if (formIsBeingSubmitted.current) return;
+            if (onSubmitSubmission.state === "submitted") {
+              formIsBeingSubmitted.current = true;
+            }
+
+            const data = { ...onSubmitSubmission.data };
+
+            const updatedSubmission = {
+              mongoId: submission._id,
+              submission: {
+                ...onSubmitSubmission,
+                data,
+              },
+            };
+
+            dismissNotification({ id: 0 });
+            dataIsPosting.current = true;
+            pendingSubmissionData.current = data;
+
+            mutation.mutate(updatedSubmission, {
+              onSuccess: (res, payload, context) => {
+                pendingSubmissionData.current = {};
+                lastSuccesfullySubmittedData.current = cloneDeep(res.data);
+
+                /** success notification id */
+                const id = Date.now();
+
+                displaySuccessNotification({
+                  id,
+                  body: (
+                    <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                      {onSubmitSubmission.state === "submitted" ? (
+                        <>
+                          Close-Out <em>{rebateId}</em> submitted successfully.
+                        </>
+                      ) : (
+                        <>Draft saved successfully.</>
+                      )}
+                    </p>
+                  ),
+                });
+
+                if (onSubmitSubmission.state === "submitted") {
+                  /**
+                   * NOTE: we'll keep the success notification displayed and
+                   * redirect the user to their dashboard
+                   */
+                  navigate("/");
+                }
+
+                if (onSubmitSubmission.state === "draft") {
+                  setTimeout(() => dismissNotification({ id }), 5000);
+                }
+              },
+              onError: (error, payload, context) => {
+                displayErrorNotification({
+                  id: Date.now(),
+                  body: (
+                    <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                      {onSubmitSubmission.state === "submitted" ? (
+                        <>Error submitting Close-Out form.</>
+                      ) : (
+                        <>Error saving draft.</>
+                      )}
+                    </p>
+                  ),
+                });
+              },
+              onSettled: (data, error, payload, context) => {
+                dataIsPosting.current = false;
+                formIsBeingSubmitted.current = false;
+              },
+            });
+          }}
+          onNextPage={(onNextPageParam: {
+            page: number;
+            submission: {
+              data: { [field: string]: unknown };
+              metadata: { [field: string]: unknown };
+            };
+          }) => {
+            if (formIsReadOnly) return;
+
+            const data = { ...onNextPageParam.submission.data };
+
+            // "dirty check" – don't post an update if no changes have been made
+            // to the form (ignoring current user fields)
+            const currentData = { ...data };
+            const submittedData = { ...lastSuccesfullySubmittedData.current };
+            delete currentData.hidden_current_user_email;
+            delete currentData.hidden_current_user_title;
+            delete currentData.hidden_current_user_name;
+            delete submittedData.hidden_current_user_email;
+            delete submittedData.hidden_current_user_title;
+            delete submittedData.hidden_current_user_name;
+            if (isEqual(currentData, submittedData)) return;
+
+            const updatedSubmission = {
+              mongoId: submission._id,
+              submission: {
+                ...onNextPageParam.submission,
+                data,
+                state: "draft" as const,
+              },
+            };
+
+            dismissNotification({ id: 0 });
+            dataIsPosting.current = true;
+            pendingSubmissionData.current = data;
+
+            mutation.mutate(updatedSubmission, {
+              onSuccess: (res, payload, context) => {
+                pendingSubmissionData.current = {};
+                lastSuccesfullySubmittedData.current = cloneDeep(res.data);
+
+                /** success notification id */
+                const id = Date.now();
+
+                displaySuccessNotification({
+                  id,
+                  body: (
+                    <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                      Draft saved successfully.
+                    </p>
+                  ),
+                });
+
+                setTimeout(() => dismissNotification({ id }), 5000);
+              },
+              onError: (error, payload, context) => {
+                displayErrorNotification({
+                  id: Date.now(),
+                  body: (
+                    <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                      Error saving draft.
+                    </p>
+                  ),
+                });
+              },
+              onSettled: (data, error, payload, context) => {
+                dataIsPosting.current = false;
+              },
+            });
+          }}
+        />
+      </div>
+    </div>
   );
 }

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -239,17 +239,6 @@ export function PaymentRequestForm() {
         />
       )}
 
-      <Dialog as="div" open={dataIsPosting.current} onClose={(ev) => {}}>
-        <div className="tw-fixed tw-inset-0 tw-bg-black/30" />
-        <div className="tw-fixed tw-inset-0 tw-z-20">
-          <div className="tw-flex tw-min-h-full tw-items-center tw-justify-center">
-            <Dialog.Panel className="tw-rounded-lg tw-bg-white tw-px-4 tw-pb-4 tw-shadow-xl">
-              <Loading />
-            </Dialog.Panel>
-          </div>
-        </div>
-      </Dialog>
-
       <ul className="usa-icon-list">
         <li className="usa-icon-list__item">
           <div className="usa-icon-list__icon text-primary">
@@ -262,6 +251,17 @@ export function PaymentRequestForm() {
           </div>
         </li>
       </ul>
+
+      <Dialog as="div" open={dataIsPosting.current} onClose={(ev) => {}}>
+        <div className="tw-fixed tw-inset-0 tw-bg-black/30" />
+        <div className="tw-fixed tw-inset-0 tw-z-20">
+          <div className="tw-flex tw-min-h-full tw-items-center tw-justify-center">
+            <Dialog.Panel className="tw-rounded-lg tw-bg-white tw-px-4 tw-pb-4 tw-shadow-xl">
+              <Loading />
+            </Dialog.Panel>
+          </div>
+        </div>
+      </Dialog>
 
       <div className="csb-form">
         <Form

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -136,6 +136,13 @@ type FormioCloseOutSubmission = {
   modified: string; // ISO 8601 date string
   data: {
     [field: string]: unknown;
+    // fields injected upon new draft Payment Request submission creation:
+    bap_hidden_entity_combo_key: string;
+    hidden_prf_modified: string; // ISO 8601 date string
+    hidden_current_user_email: string;
+    hidden_current_user_title: string;
+    hidden_current_user_name: string;
+    hidden_bap_rebate_id: string;
   };
 };
 
@@ -370,8 +377,7 @@ function useCombinedRebates() {
     const comboKey = bapMatch?.UEI_EFTI_Combo_Key__c || null;
     const rebateId = bapMatch?.Parent_Rebate_ID__c || null;
     const reviewItemId = bapMatch?.CSB_Review_Item_ID__c || null;
-    const status =
-      bapMatch?.Parent_CSB_Rebate__r?.CSB_Funding_Request_Status__c || null;
+    const status = bapMatch?.Parent_CSB_Rebate__r?.CSB_Funding_Request_Status__c || null; // prettier-ignore
 
     /**
      * NOTE: If new Application form submissions have been reciently created in
@@ -417,8 +423,7 @@ function useCombinedRebates() {
     const comboKey = bapMatch?.UEI_EFTI_Combo_Key__c || null;
     const rebateId = bapMatch?.Parent_Rebate_ID__c || null;
     const reviewItemId = bapMatch?.CSB_Review_Item_ID__c || null;
-    const status =
-      bapMatch?.Parent_CSB_Rebate__r?.CSB_Payment_Request_Status__c || null;
+    const status = bapMatch?.Parent_CSB_Rebate__r?.CSB_Payment_Request_Status__c || null; // prettier-ignore
 
     /**
      * NOTE: If the BAP ETL is running, there should be a submission with a
@@ -442,7 +447,24 @@ function useCombinedRebates() {
    * submission data.
    */
   for (const formioSubmission of formioCloseOutSubmissions) {
-    console.log(formioSubmission); // TODO
+    const formioBapRebateId = formioSubmission.data.hidden_bap_rebate_id;
+
+    const bapMatch = bapFormSubmissions.closeOuts.find((bapSub) => {
+      return bapSub.Parent_Rebate_ID__c === formioBapRebateId;
+    });
+
+    const modified = bapMatch?.CSB_Modified_Full_String__c || null;
+    const comboKey = bapMatch?.UEI_EFTI_Combo_Key__c || null;
+    const rebateId = bapMatch?.Parent_Rebate_ID__c || null;
+    const reviewItemId = bapMatch?.CSB_Review_Item_ID__c || null;
+    const status = bapMatch?.Parent_CSB_Rebate__r?.CSB_Payment_Request_Status__c || null; // prettier-ignore
+
+    if (rebates[formioBapRebateId]) {
+      rebates[formioBapRebateId].closeOut = {
+        formio: { ...formioSubmission },
+        bap: { modified, comboKey, rebateId, reviewItemId, status },
+      };
+    }
   }
 
   return rebates;

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -14,6 +14,8 @@ type Content = {
   submittedApplicationIntro: string;
   draftPaymentRequestIntro: string;
   submittedPaymentRequestIntro: string;
+  draftCloseOutIntro: string;
+  submittedCloseOutIntro: string;
 };
 
 export type CsbData = {

--- a/app/server/app/content/draft-close-out-intro.md
+++ b/app/server/app/content/draft-close-out-intro.md
@@ -1,0 +1,1 @@
+## Edit Your Close-Out

--- a/app/server/app/content/submitted-close-out-intro.md
+++ b/app/server/app/content/submitted-close-out-intro.md
@@ -1,0 +1,3 @@
+## View Your Submitted Close-Out
+
+Your submission is under review and not editable at this time. If you wish to change your submission, [contact the helpdesk](https://www.epa.gov/cleanschoolbus/forms/contact-us-about-clean-school-bus-program-funding "external") and provide your **Rebate ID** shown below.

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -765,23 +765,44 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
   } = entity;
 
   return getBapPaymentRequestSubmission(req, reviewItemId)
-    .then((response) => {
-      const busInfo = [1, 2, 3].map((record) => ({
-        busNum: "",
-        oldBusVin: "",
-        oldBusFuelType: "",
-        oldBusNcesDistrictId: "",
-        oldBusModelYear: "",
-        oldBusEstimatedRemainingLife: "",
-        newBusDealer: "",
-        newBusFuelType: "",
-        newBusManufacturer: "",
-        newBusManufacturerOther: "",
-        newBusModel: "",
-        newBusModelYear: "",
-        newBusGvwr: "",
-        hidden_bap_prf_rebate: "",
-        newBusPurchasePrice: "",
+    .then(({ paymentRequestTableRecordQuery, busTableRecordsQuery }) => {
+      const {
+        CSB_NCES_ID__c,
+        Primary_Applicant__r,
+        Alternate_Applicant__r,
+        Applicant_Organization__r,
+        CSB_School_District__r,
+        Fleet_Name__c,
+        School_District_Prioritized__c,
+        Total_Rebate_Funds_Requested__c,
+        Total_Infrastructure_Funds__c,
+        Total_Bus_And_Infrastructure_Rebate__c,
+        Num_Of_Buses_Requested_From_Application__c,
+        Total_Price_All_Buses__c,
+        Total_Bus_Rebate_Amount__c,
+        Total_All_Eligible_Infrastructure_Costs__c,
+        Total_Infrastructure_Rebate__c,
+        Total_Level_2_Charger_Costs__c,
+        Total_DC_Fast_Charger_Costs__c,
+        Total_Other_Infrastructure_Costs__c,
+      } = paymentRequestTableRecordQuery[0];
+
+      const busInfo = busTableRecordsQuery.map((record) => ({
+        busNum: record.Rebate_Item_num__c,
+        oldBusNcesDistrictId: CSB_NCES_ID__c,
+        oldBusVin: record.CSB_VIN__c,
+        oldBusModelYear: record.CSB_Model_Year__c,
+        oldBusFuelType: record.CSB_Fuel_Type__c,
+        oldBusEstimatedRemainingLife: record.Old_Bus_Estimated_Remaining_Life__c, // prettier-ignore
+        newBusDealer: record.Vendor_Name__c,
+        newBusFuelType: record.New_Bus_Fuel_Type__c,
+        newBusManufacturer: record.New_Bus_Make__c,
+        newBusManufacturerOther: record.CSB_Manufacturer_if_Other__c,
+        newBusModel: record.New_Bus_Model__c,
+        newBusModelYear: record.New_Bus_Model_Year__c,
+        newBusGvwr: record.New_Bus_GVWR__c,
+        newBusPurchasePrice: record.New_Bus_Purchase_Price__c,
+        hidden_bap_prf_rebate: record.New_Bus_Rebate_Amount__c,
       }));
 
       const submission = {
@@ -798,30 +819,30 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
           hidden_sam_alt_elec_bus_poc_email: ALT_ELEC_BUS_POC_EMAIL__c,
           hidden_sam_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
           hidden_sam_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
-          hidden_bap_prioritized: "",
-          hidden_bap_district_id: "",
-          hidden_bap_requested_funds: "",
-          hidden_bap_primary_name: "",
-          hidden_bap_primary_title: "",
-          hidden_bap_primary_phone_number: "",
-          hidden_bap_primary_email: "",
-          hidden_bap_alternate_name: "",
-          hidden_bap_alternate_title: "",
-          hidden_bap_alternate_phone_number: "",
-          hidden_bap_alternate_email: "",
-          hidden_bap_org_name: "",
-          hidden_bap_fleet_name: "",
-          hidden_bap_district_name: "",
-          hidden_bap_prf_infra_max_rebate: "",
-          hidden_bap_received_funds: "",
-          hidden_bap_buses_requested_app: "",
-          hidden_bap_total_bus_costs_prf: "",
-          hidden_bap_total_bus_rebate_received: "",
-          hidden_bap_total_infra_costs_prf: "",
-          hidden_bap_total_infra_rebate_received: "",
-          hidden_bap_total_infra_level2_charger: "",
-          hidden_bap_total_infra_dc_fast_charger: "",
-          hidden_bap_total_infra_other_costs: "",
+          hidden_bap_district_id: CSB_NCES_ID__c,
+          hidden_bap_district_name: CSB_School_District__r?.Name, //
+          hidden_bap_primary_name: Primary_Applicant__r?.Name,
+          hidden_bap_primary_title: Primary_Applicant__r?.Title,
+          hidden_bap_primary_phone_number: Primary_Applicant__r?.Phone,
+          hidden_bap_primary_email: Primary_Applicant__r?.Email,
+          hidden_bap_alternate_name: Alternate_Applicant__r?.Name || "",
+          hidden_bap_alternate_title: Alternate_Applicant__r?.Title || "",
+          hidden_bap_alternate_phone_number: Alternate_Applicant__r?.Phone || "", // prettier-ignore
+          hidden_bap_alternate_email: Alternate_Applicant__r?.Email || "",
+          hidden_bap_org_name: Applicant_Organization__r?.Name,
+          hidden_bap_fleet_name: Fleet_Name__c,
+          hidden_bap_prioritized: School_District_Prioritized__c,
+          hidden_bap_requested_funds: Total_Rebate_Funds_Requested__c,
+          hidden_bap_prf_infra_max_rebate: Total_Infrastructure_Funds__c,
+          hidden_bap_received_funds: Total_Bus_And_Infrastructure_Rebate__c,
+          hidden_bap_buses_requested_app: Num_Of_Buses_Requested_From_Application__c, // prettier-ignore
+          hidden_bap_total_bus_costs_prf: Total_Price_All_Buses__c,
+          hidden_bap_total_bus_rebate_received: Total_Bus_Rebate_Amount__c,
+          hidden_bap_total_infra_costs_prf: Total_All_Eligible_Infrastructure_Costs__c, // prettier-ignore
+          hidden_bap_total_infra_rebate_received: Total_Infrastructure_Rebate__c, // prettier-ignore
+          hidden_bap_total_infra_level2_charger: Total_Level_2_Charger_Costs__c,
+          hidden_bap_total_infra_dc_fast_charger: Total_DC_Fast_Charger_Costs__c, // prettier-ignore
+          hidden_bap_total_infra_other_costs: Total_Other_Infrastructure_Costs__c, // prettier-ignore
           busInfo,
         },
         // add custom metadata to track formio submissions from wrapper

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -91,6 +91,8 @@ router.get("/content", (req, res) => {
     "submitted-application-intro.md",
     "draft-payment-request-intro.md",
     "submitted-payment-request-intro.md",
+    "draft-close-out-intro.md",
+    "submitted-close-out-intro.md",
   ];
 
   const s3BucketUrl = `https://${s3Bucket}.s3-${s3Region}.amazonaws.com`;
@@ -122,6 +124,8 @@ router.get("/content", (req, res) => {
         submittedApplicationIntro: data[6],
         draftPaymentRequestIntro: data[7],
         submittedPaymentRequestIntro: data[8],
+        draftCloseOutIntro: data[9],
+        submittedCloseOutIntro: data[10],
       });
     })
     .catch((error) => {

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -458,7 +458,7 @@ router.post(
     } = entity;
 
     return getBapApplicationSubmission(req, reviewItemId)
-      .then(({ formsTableRecordQuery, busTableRecordsQuery }) => {
+      .then(({ applicationTableRecordQuery, busTableRecordsQuery }) => {
         const {
           CSB_NCES_ID__c,
           Primary_Applicant__r,
@@ -469,7 +469,7 @@ router.post(
           School_District_Prioritized__c,
           Total_Rebate_Funds_Requested__c,
           Total_Infrastructure_Funds__c,
-        } = formsTableRecordQuery[0];
+        } = applicationTableRecordQuery[0];
 
         const busInfo = busTableRecordsQuery.map((record) => ({
           busNum: record.Rebate_Item_num__c,

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -293,7 +293,7 @@ async function queryForBapApplicationSubmission(req, reviewItemId) {
   //   sobjecttype = '${BAP_FORMS_TABLE}'
   // LIMIT 1`
 
-  const formsTableIdQuery = await bapConnection
+  const applicationTableIdQuery = await bapConnection
     .sobject("recordtype")
     .find(
       {
@@ -308,7 +308,7 @@ async function queryForBapApplicationSubmission(req, reviewItemId) {
     .limit(1)
     .execute(async (err, records) => ((await err) ? err : records));
 
-  const formsTableId = formsTableIdQuery["0"].Id;
+  const applicationTableId = applicationTableIdQuery["0"].Id;
 
   // `SELECT
   //   Id,
@@ -331,15 +331,15 @@ async function queryForBapApplicationSubmission(req, reviewItemId) {
   // FROM
   //   ${BAP_FORMS_TABLE}
   // WHERE
-  //   recordtypeid = '${formsTableId}' AND
+  //   recordtypeid = '${applicationTableId}' AND
   //   CSB_Review_Item_ID__c = '${reviewItemId}' AND
   //   Latest_Version__c = TRUE`
 
-  const formsTableRecordQuery = await bapConnection
+  const applicationTableRecordQuery = await bapConnection
     .sobject(BAP_FORMS_TABLE)
     .find(
       {
-        recordtypeid: formsTableId,
+        recordtypeid: applicationTableId,
         CSB_Review_Item_ID__c: reviewItemId,
         Latest_Version__c: true,
       },
@@ -366,7 +366,7 @@ async function queryForBapApplicationSubmission(req, reviewItemId) {
     )
     .execute(async (err, records) => ((await err) ? err : records));
 
-  const formsTableRecordId = formsTableRecordQuery["0"].Id;
+  const applicationTableRecordId = applicationTableRecordQuery["0"].Id;
 
   // `SELECT
   //   Id
@@ -405,7 +405,7 @@ async function queryForBapApplicationSubmission(req, reviewItemId) {
   //   ${BAP_BUS_TABLE}
   // WHERE
   //   recordtypeid = '${busTableId}' AND
-  //   Related_Order_Request__c = '${formsTableRecordId}' AND
+  //   Related_Order_Request__c = '${applicationTableRecordId}' AND
   //   CSB_Rebate_Item_Type__c = 'Old Bus'`
 
   const busTableRecordsQuery = await bapConnection
@@ -413,7 +413,7 @@ async function queryForBapApplicationSubmission(req, reviewItemId) {
     .find(
       {
         recordtypeid: busTableId,
-        Related_Order_Request__c: formsTableRecordId,
+        Related_Order_Request__c: applicationTableRecordId,
         CSB_Rebate_Item_Type__c: "Old Bus",
       },
       {
@@ -428,7 +428,7 @@ async function queryForBapApplicationSubmission(req, reviewItemId) {
     )
     .execute(async (err, records) => ((await err) ? err : records));
 
-  return { formsTableRecordQuery, busTableRecordsQuery };
+  return { applicationTableRecordQuery, busTableRecordsQuery };
 }
 
 /**

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -612,7 +612,7 @@ async function queryForBapPaymentRequestSubmission(req, reviewItemId) {
         CSB_Manufacturer_if_Other__c: 1,
         Old_Bus_NCES_District_ID__c: 1,
         Old_Bus_Estimated_Remaining_Life__c: 1,
-        "Related_Line_Item__r.Purchaser_Name__c": 1,
+        "Related_Line_Item__r.Vendor_Name__c": 1,
         New_Bus_Fuel_Type__c: 1,
         New_Bus_Make__c: 1,
         New_Bus_Model__c: 1,

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -444,8 +444,187 @@ async function queryForBapPaymentRequestSubmission(req, reviewItemId) {
   /** @type {jsforce.Connection} */
   const bapConnection = req.app.locals.bapConnection;
 
-  // TODO
-  return {};
+  // `SELECT
+  //   Id
+  // FROM
+  //   recordtype
+  // WHERE
+  //   developername = 'CSB_Payment_Request' AND
+  //   sobjecttype = '${BAP_FORMS_TABLE}'
+  // LIMIT 1`
+
+  const paymentRequestTableIdQuery = await bapConnection
+    .sobject("recordtype")
+    .find(
+      {
+        developername: "CSB_Payment_Request",
+        sobjecttype: BAP_FORMS_TABLE,
+      },
+      {
+        // "*": 1,
+        Id: 1, // Salesforce record ID
+      }
+    )
+    .limit(1)
+    .execute(async (err, records) => ((await err) ? err : records));
+
+  const paymentRequestTableId = paymentRequestTableIdQuery["0"].Id;
+
+  // `SELECT
+  //   Id,
+  //   UEI_EFTI_Combo_Key__c,
+  //   CSB_NCES_ID__c,
+  //   Primary_Applicant__r.Name,
+  //   Primary_Applicant__r.Title,
+  //   Primary_Applicant__r.Phone,
+  //   Primary_Applicant__r.Email,
+  //   Alternate_Applicant__r.Name,
+  //   Alternate_Applicant__r.Title,
+  //   Alternate_Applicant__r.Phone,
+  //   Alternate_Applicant__r.Email,
+  //   Applicant_Organization__r.Name,
+  //   CSB_School_District__r.Name,
+  //   Fleet_Name__c,
+  //   School_District_Prioritized__c,
+  //   Total_Rebate_Funds_Requested__c,
+  //   Total_Infrastructure_Funds__c,
+  //   Total_Bus_And_Infrastructure_Rebate__c,
+  //   Num_Of_Buses_Requested_From_Application__c,
+  //   Total_Price_All_Buses__c,
+  //   Total_Bus_Rebate_Amount__c,
+  //   Total_All_Eligible_Infrastructure_Costs__c,
+  //   Total_Infrastructure_Rebate__c,
+  //   Total_Level_2_Charger_Costs__c,
+  //   Total_DC_Fast_Charger_Costs__c,
+  //   Total_Other_Infrastructure_Costs__c
+  // FROM
+  //   ${BAP_FORMS_TABLE}
+  // WHERE
+  //   recordtypeid = '${paymentRequestTableId}' AND
+  //   CSB_Review_Item_ID__c = '${reviewItemId}' AND
+  //   Latest_Version__c = TRUE`
+
+  const paymentRequestTableRecordQuery = await bapConnection
+    .sobject(BAP_FORMS_TABLE)
+    .find(
+      {
+        recordtypeid: paymentRequestTableId,
+        CSB_Review_Item_ID__c: reviewItemId,
+        Latest_Version__c: true,
+      },
+      {
+        // "*": 1,
+        Id: 1, // Salesforce record ID
+        UEI_EFTI_Combo_Key__c: 1,
+        CSB_NCES_ID__c: 1,
+        "Primary_Applicant__r.Name": 1,
+        "Primary_Applicant__r.Title": 1,
+        "Primary_Applicant__r.Phone": 1,
+        "Primary_Applicant__r.Email": 1,
+        "Alternate_Applicant__r.Name": 1,
+        "Alternate_Applicant__r.Title": 1,
+        "Alternate_Applicant__r.Phone": 1,
+        "Alternate_Applicant__r.Email": 1,
+        "Applicant_Organization__r.Name": 1,
+        "CSB_School_District__r.Name": 1,
+        Fleet_Name__c: 1,
+        School_District_Prioritized__c: 1,
+        Total_Rebate_Funds_Requested__c: 1,
+        Total_Infrastructure_Funds__c: 1,
+        Total_Bus_And_Infrastructure_Rebate__c: 1,
+        Num_Of_Buses_Requested_From_Application__c: 1,
+        Total_Price_All_Buses__c: 1,
+        Total_Bus_Rebate_Amount__c: 1,
+        Total_All_Eligible_Infrastructure_Costs__c: 1,
+        Total_Infrastructure_Rebate__c: 1,
+        Total_Level_2_Charger_Costs__c: 1,
+        Total_DC_Fast_Charger_Costs__c: 1,
+        Total_Other_Infrastructure_Costs__c: 1,
+      }
+    )
+    .execute(async (err, records) => ((await err) ? err : records));
+
+  const paymentRequestTableRecordId = paymentRequestTableRecordQuery["0"].Id;
+
+  // `SELECT
+  //   Id
+  // FROM
+  //   recordtype
+  // WHERE
+  //   developername = 'CSB_Rebate_Item' AND
+  //   sobjecttype = '${BAP_BUS_TABLE}'
+  // LIMIT 1`
+
+  const busTableIdQuery = await bapConnection
+    .sobject("recordtype")
+    .find(
+      {
+        developername: "CSB_Rebate_Item",
+        sobjecttype: BAP_BUS_TABLE,
+      },
+      {
+        // "*": 1,
+        Id: 1, // Salesforce record ID
+      }
+    )
+    .limit(1)
+    .execute(async (err, records) => ((await err) ? err : records));
+
+  const busTableId = busTableIdQuery["0"].Id;
+
+  // `SELECT
+  //   Rebate_Item_num__c,
+  //   CSB_VIN__c,
+  //   CSB_Model_Year__c,
+  //   CSB_Fuel_Type__c,
+  //   CSB_Manufacturer_if_Other__c,
+  //   Old_Bus_NCES_District_ID__c,
+  //   Old_Bus_Estimated_Remaining_Life__c,
+  //   Related_Line_Item__r.Purchaser_Name__c,
+  //   New_Bus_Fuel_Type__c,
+  //   New_Bus_Make__c,
+  //   New_Bus_Model__c,
+  //   New_Bus_Model_Year__c,
+  //   New_Bus_GVWR__c,
+  //   New_Bus_Rebate_Amount__c,
+  //   New_Bus_Purchase_Price__c
+  // FROM
+  //   ${BAP_BUS_TABLE}
+  // WHERE
+  //   recordtypeid = '${busTableId}' AND
+  //   Related_Order_Request__c = '${paymentRequestTableRecordId}' AND
+  //   CSB_Rebate_Item_Type__c = 'New Bus'`
+
+  const busTableRecordsQuery = await bapConnection
+    .sobject(BAP_BUS_TABLE)
+    .find(
+      {
+        recordtypeid: busTableId,
+        Related_Order_Request__c: paymentRequestTableRecordId,
+        CSB_Rebate_Item_Type__c: "New Bus",
+      },
+      {
+        // "*": 1,
+        Rebate_Item_num__c: 1,
+        CSB_VIN__c: 1,
+        CSB_Model_Year__c: 1,
+        CSB_Fuel_Type__c: 1,
+        CSB_Manufacturer_if_Other__c: 1,
+        Old_Bus_NCES_District_ID__c: 1,
+        Old_Bus_Estimated_Remaining_Life__c: 1,
+        "Related_Line_Item__r.Purchaser_Name__c": 1,
+        New_Bus_Fuel_Type__c: 1,
+        New_Bus_Make__c: 1,
+        New_Bus_Model__c: 1,
+        New_Bus_Model_Year__c: 1,
+        New_Bus_GVWR__c: 1,
+        New_Bus_Rebate_Amount__c: 1,
+        New_Bus_Purchase_Price__c: 1,
+      }
+    )
+    .execute(async (err, records) => ((await err) ? err : records));
+
+  return { paymentRequestTableRecordQuery, busTableRecordsQuery };
 }
 
 /**


### PR DESCRIPTION
## Related Issues:
* CSBAPP-5

## Main Changes:
Continuation of #288 – integrates the initial version of the close-out form into the wrapper app, which includes fetching payment request form submission data from the BAP to inject into a brand new close-out form submission.

## Steps To Test:
1. Work with BAP team to get at least one Payment Request form submission into an "Accepted" state, so you can create a new Close-Out form submission. The flow works the same as it does with selected Application form submissions where a "New Close-Out" button is displayed in the user's dashboard in the table below any selected Payment Request form submissions.
