### PR TITLE
Feature/further integrate close out form

### DIFF
--- a/app/server/app/middleware.js
+++ b/app/server/app/middleware.js
@@ -148,7 +148,8 @@ function checkClientRouteExists(req, res, next) {
   if (
     !clientRoutes.includes(req.path) &&
     !req.path.includes("/rebate/") &&
-    !req.path.includes("/payment-request/")
+    !req.path.includes("/payment-request/") &&
+    !req.path.includes("/close-out/")
   ) {
     return res.status(404).sendFile(resolve(__dirname, "public/404.html"));
   }

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -800,13 +800,20 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
         oldBusEstimatedRemainingLife: record.Old_Bus_Estimated_Remaining_Life__c, // prettier-ignore
         newBusDealer: record.Vendor_Name__c,
         newBusFuelType: record.New_Bus_Fuel_Type__c,
-        newBusManufacturer: record.New_Bus_Make__c,
-        newBusManufacturerOther: record.CSB_Manufacturer_if_Other__c,
+        hidden_prf_newBusFuelType: record.New_Bus_Fuel_Type__c,
+        newBusMake: record.New_Bus_Make__c,
+        hidden_prf_newBusMake: record.New_Bus_Make__c,
+        newBusMakeOther: record.CSB_Manufacturer_if_Other__c,
+        hidden_prf_newBusMakeOther: record.CSB_Manufacturer_if_Other__c,
         newBusModel: record.New_Bus_Model__c,
+        hidden_prf_newBusModel: record.New_Bus_Model__c,
         newBusModelYear: record.New_Bus_Model_Year__c,
+        hidden_prf_newBusModelYear: record.New_Bus_Model_Year__c,
         newBusGvwr: record.New_Bus_GVWR__c,
+        hidden_prf_newBusGvwr: record.New_Bus_GVWR__c,
         newBusPurchasePrice: record.New_Bus_Purchase_Price__c,
-        hidden_bap_prf_rebate: record.New_Bus_Rebate_Amount__c,
+        hidden_prf_newBusPurchasePrice: record.New_Bus_Purchase_Price__c,
+        hidden_prf_rebate: record.New_Bus_Rebate_Amount__c,
       }));
 
       const submission = {
@@ -824,7 +831,7 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
           hidden_sam_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
           hidden_sam_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
           hidden_bap_district_id: CSB_NCES_ID__c,
-          hidden_bap_district_name: CSB_School_District__r?.Name, //
+          hidden_bap_district_name: CSB_School_District__r?.Name,
           hidden_bap_primary_name: Primary_Applicant__r?.Name,
           hidden_bap_primary_title: Primary_Applicant__r?.Title,
           hidden_bap_primary_phone_number: Primary_Applicant__r?.Phone,

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -798,6 +798,7 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
         oldBusModelYear: record.CSB_Model_Year__c,
         oldBusFuelType: record.CSB_Fuel_Type__c,
         oldBusEstimatedRemainingLife: record.Old_Bus_Estimated_Remaining_Life__c, // prettier-ignore
+        hidden_prf_oldBusExclude: record.Old_Bus_Exclude__c,
         newBusDealer: record.Vendor_Name__c,
         newBusFuelType: record.New_Bus_Fuel_Type__c,
         hidden_prf_newBusFuelType: record.New_Bus_Fuel_Type__c,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-5

## Main Changes:
Iterative changes to support the new close-out form:
* Updates the data injected into a new close-out form submission
* Updates the server app's allowable routes so /close-out pages correctly resolve

## Steps To Test:
1. Same as #293:    
Work with BAP team to get at least one Payment Request form submission into an "Accepted" state, so you can create a new Close-Out form submission.

## TODO:
- [ ] Further test/make changes based on the close-out form's needs
