### PR TITLE
Feature/prevent unnecessary form rerendering

### DIFF
--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog } from "@headlessui/react";
@@ -106,8 +106,17 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 }
 
 export function ApplicationForm() {
-  const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
+  /* ensure user verification (JWT refresh) doesn't cause form to re-render */
+  return useMemo(() => {
+    return <UserApplicationForm email={email} />;
+  }, [email]);
+}
+
+function UserApplicationForm(props: { email: string }) {
+  const { email } = props;
+
+  const navigate = useNavigate();
   const { id: mongoId } = useParams<"id">(); // MongoDB ObjectId string
 
   const content = useContentData();

--- a/app/client/src/routes/closeOutForm.tsx
+++ b/app/client/src/routes/closeOutForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog } from "@headlessui/react";
@@ -101,8 +101,17 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 }
 
 export function CloseOutForm() {
-  const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
+  /* ensure user verification (JWT refresh) doesn't cause form to re-render */
+  return useMemo(() => {
+    return <UserCloseOutForm email={email} />;
+  }, [email]);
+}
+
+function UserCloseOutForm(props: { email: string }) {
+  const { email } = props;
+
+  const navigate = useNavigate();
   const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
 
   const content = useContentData();

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog } from "@headlessui/react";
@@ -101,8 +101,17 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 }
 
 export function PaymentRequestForm() {
-  const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
+  /* ensure user verification (JWT refresh) doesn't cause form to re-render */
+  return useMemo(() => {
+    return <UserPaymentRequestForm email={email} />;
+  }, [email]);
+}
+
+function UserPaymentRequestForm(props: { email: string }) {
+  const { email } = props;
+
+  const navigate = useNavigate();
   const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
 
   const content = useContentData();


### PR DESCRIPTION
Update `applicationForm`, `paymentRequestForm`, and `closeOutForm` to use memoized email address to prevent forms from re-rendering when JWT refreshes.
