### PR TITLE
Feature/prevent multiple application creation

### DIFF
--- a/app/client/src/routes/newApplicationForm.tsx
+++ b/app/client/src/routes/newApplicationForm.tsx
@@ -172,7 +172,10 @@ export function NewApplicationForm() {
 
                               return (
                                 <tr key={comboKey}>
-                                  <th scope="row" className="font-sans-2xs">
+                                  <th
+                                    scope="row"
+                                    className="width-15 font-sans-2xs"
+                                  >
                                     <button
                                       className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
                                       onClick={(ev) => {

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -26,7 +26,7 @@ export type CsbData = {
   };
 };
 
-export type BapSamEntity = {
+type BapSamEntity = {
   ENTITY_COMBO_KEY__c: string;
   UNIQUE_ENTITY_ID__c: string;
   ENTITY_EFT_INDICATOR__c: string;
@@ -81,7 +81,7 @@ type BapFormSubmission = {
   attributes: { type: string; url: string };
 };
 
-type FormioApplicationSubmission = {
+export type FormioApplicationSubmission = {
   [field: string]: unknown;
   _id: string; // MongoDB ObjectId string
   state: "submitted" | "draft";


### PR DESCRIPTION
## Related Issues:
* CSBAPP-91

## Main Changes:
Follow up to #292 that prevents users from creating multiple application form submissions by double/multiple clicking the new application button.

## Steps To Test:
1. Click the "New Application" button (or navigate to `/rebate/new`) and attempt to click one of the arrow icon buttons multiple times – a loading icon should display inside the button, and no matter how many times it's clicked, only one new submission will be created. Once the POST request succeeds, you'll be directed to the page to continue editing your newly created application form submission, as before.
