### PR TITLE
Feature/rename close out form

### DIFF
--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -67,7 +67,7 @@ export const messages = {
     "The CSB Application form enrollment period is closed.",
   paymentRequestFormClosed:
     "The CSB Payment Request form enrollment period is closed.",
-  closeOutFormClosed: "The CSB Close-Out form enrollment period is closed.",
+  closeOutFormClosed: "The CSB Close Out form enrollment period is closed.",
   paymentRequestFormWillBeDeleted:
     "A request to edit the Application form associated with this draft or submitted Payment Request form has been made, so this form has been set to read-only mode. Visit your dashboard to make edits to the associated Application form submission.",
 };

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -306,7 +306,7 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
   /**
    * Stores when data is being posted to the server, so a loading indicator can
    * be rendered inside the "New Payment Request" button, and we can prevent
-   * double submits/creations of new payment request form submissions.
+   * double submits/creations of new Payment Request form submissions.
    */
   const [dataIsPosting, setDataIsPosting] = useState(false);
 
@@ -343,7 +343,7 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
 
               const { title, name } = getUserInfo(email, entity);
 
-              // create a new draft payment request submission
+              // create a new draft Payment Request form submission
               postData(`${serverUrl}/api/formio-payment-request-submission/`, {
                 email,
                 title,
@@ -541,8 +541,8 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
 
   /**
    * Stores when data is being posted to the server, so a loading indicator can
-   * be rendered inside the "New Close-Out" button, and we can prevent double
-   * submits/creations of new close-out form submissions.
+   * be rendered inside the "New Close Out" button, and we can prevent double
+   * submits/creations of new Close Out form submissions.
    */
   const [dataIsPosting, setDataIsPosting] = useState(false);
 
@@ -579,7 +579,7 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
 
               const { title, name } = getUserInfo(email, entity);
 
-              // create a new draft close-out submission
+              // create a new draft Close Out form submission
               postData(`${serverUrl}/api/formio-close-out-submission/`, {
                 email,
                 title,
@@ -600,7 +600,7 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
                     body: (
                       <>
                         <p className="tw-text-sm tw-font-medium tw-text-gray-900">
-                          Error creating Close-Out{" "}
+                          Error creating Close Out{" "}
                           <em>{paymentRequest.bap?.rebateId}</em>.
                         </p>
                         <p className="tw-mt-1 tw-text-sm tw-text-gray-500">
@@ -624,7 +624,7 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
               >
                 <use href={`${icons}#add_circle`} />
               </svg>
-              <span className="margin-left-1">New Close-Out</span>
+              <span className="margin-left-1">New Close Out</span>
               {dataIsPosting && <LoadingButtonIcon />}
             </span>
           </button>
@@ -633,7 +633,7 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
     );
   }
 
-  // return if a Close-Out submission has not been created for this rebate
+  // return if a Close Out submission has not been created for this rebate
   if (!closeOut.formio) return null;
 
   const { hidden_current_user_email, hidden_bap_rebate_id } =
@@ -683,11 +683,11 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
   const statusText = closeOutNeedsEdits
     ? "Edits Requested"
     : closeOutNotApproved
-    ? "Close-Out Not Approved"
+    ? "Close Out Not Approved"
     : closeOutReimbursementNeeded
     ? "Reimbursement Needed"
     : closeOutApproved
-    ? "Close-Out Approved"
+    ? "Close Out Approved"
     : closeOut.formio.state === "draft"
     ? "Draft"
     : closeOut.formio.state === "submitted"
@@ -717,7 +717,7 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
       <td className={statusTableCellClassNames}>&nbsp;</td>
 
       <td className={statusTableCellClassNames}>
-        <span>Close-Out</span>
+        <span>Close Out</span>
         <br />
         <span className="display-flex flex-align-center font-sans-2xs">
           {closeOutNeedsClarification ? (
@@ -803,7 +803,7 @@ export function AllRebates() {
                   <th scope="col">
                     <TextWithTooltip
                       text="Form Type"
-                      tooltip="Application, Payment Request, or Close-Out form"
+                      tooltip="Application, Payment Request, or Close Out form"
                     />
                     <br />
                     <TextWithTooltip

--- a/app/client/src/routes/closeOutForm.tsx
+++ b/app/client/src/routes/closeOutForm.tsx
@@ -196,7 +196,7 @@ function UserCloseOutForm(props: { email: string }) {
     (submission.state === "submitted" || !closeOutFormOpen) &&
     !closeOutNeedsEdits;
 
-  /** matched SAM.gov entity for the Close-Out submission */
+  /** matched SAM.gov entity for the Close Out submission */
   const entity = bapSamData.entities.find((entity) => {
     return (
       entity.ENTITY_STATUS__c === "Active" &&
@@ -307,7 +307,7 @@ function UserCloseOutForm(props: { email: string }) {
                     <p className="tw-text-sm tw-font-medium tw-text-gray-900">
                       {onSubmitSubmission.state === "submitted" ? (
                         <>
-                          Close-Out <em>{rebateId}</em> submitted successfully.
+                          Close Out <em>{rebateId}</em> submitted successfully.
                         </>
                       ) : (
                         <>Draft saved successfully.</>
@@ -334,7 +334,7 @@ function UserCloseOutForm(props: { email: string }) {
                   body: (
                     <p className="tw-text-sm tw-font-medium tw-text-gray-900">
                       {onSubmitSubmission.state === "submitted" ? (
-                        <>Error submitting Close-Out form.</>
+                        <>Error submitting Close Out form.</>
                       ) : (
                         <>Error saving draft.</>
                       )}

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -144,13 +144,13 @@ export function Helpdesk() {
                 setFormType(ev.target.value as FormType);
                 queryClient.resetQueries({ queryKey: ["helpdesk"] });
               }}
-              disabled={true} // NOTE: disabled until the close-out form is created
+              disabled={true} // NOTE: disabled until the Close Out form is created
             />
             <label
               className="usa-radio__label mobile-lg:margin-top-0"
               htmlFor="form-type-close-out"
             >
-              Close-Out
+              Close Out
             </label>
           </div>
         </fieldset>

--- a/app/client/src/routes/newApplicationForm.tsx
+++ b/app/client/src/routes/newApplicationForm.tsx
@@ -37,7 +37,7 @@ export function NewApplicationForm() {
   /**
    * Stores when data is being posted to the server, so a loading indicator can
    * be rendered inside the new application button, and we can prevent double
-   * submits/creations of new application form submissions.
+   * submits/creations of new Application form submissions.
    */
   const [postingDataId, setPostingDataId] = useState("0");
 

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -349,7 +349,7 @@ export function useSubmissionsQueries() {
 
 /**
  * Custom hook to combine Application form submissions data, Payment Request
- * form submissions data, and Close-Out form submissions data from both the BAP
+ * form submissions data, and Close Out form submissions data from both the BAP
  * and Formio into a single `submissions` object, with the BAP assigned
  * `rebateId` as the keys.
  **/
@@ -466,8 +466,8 @@ function useCombinedRebates() {
   }
 
   /**
-   * Iterate over Formio Close-Out form submissions, matching them with
-   * submissions returned from the BAP, so we can set the Close-Out form
+   * Iterate over Formio Close Out form submissions, matching them with
+   * submissions returned from the BAP, so we can set the Close Out form
    * submission data.
    */
   for (const formioSubmission of formioCloseOutSubmissions) {
@@ -497,7 +497,7 @@ function useCombinedRebates() {
 /**
  * Custom hook that sorts rebates by:
  * - most recient formio modified date, regardless of form
- *   (Application, Payment Request, or Close-Out)
+ *   (Application, Payment Request, or Close Out)
  * - Application submissions needing edits
  * - selected Applications submissions without a corresponding Payment Request
  *   submission

--- a/app/server/app/content/draft-close-out-intro.md
+++ b/app/server/app/content/draft-close-out-intro.md
@@ -1,1 +1,1 @@
-## Edit Your Close-Out
+## Edit Your Close Out

--- a/app/server/app/content/submitted-close-out-intro.md
+++ b/app/server/app/content/submitted-close-out-intro.md
@@ -1,3 +1,3 @@
-## View Your Submitted Close-Out
+## View Your Submitted Close Out
 
 Your submission is under review and not editable at this time. If you wish to change your submission, [contact the helpdesk](https://www.epa.gov/cleanschoolbus/forms/contact-us-about-clean-school-bus-program-funding "external") and provide your **Rebate ID** shown below.

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -252,7 +252,7 @@ router.post(
               ? formType === "payment-request"
               : "CSB Payment Request"
               ? formType === "close-out"
-              : "CSB Close-Out"
+              : "CSB Close Out"
             : "CSB";
         const message = `${formName} form enrollment period is closed`;
         return res.status(400).json({ message });
@@ -714,7 +714,7 @@ router.post(
   }
 );
 
-// --- get user's Close-Out form submissions from Formio
+// --- get user's Close Out form submissions from Formio
 router.get("/formio-close-out-submissions", storeBapComboKeys, (req, res) => {
   const userSubmissionsUrl =
     `${formioCloseOutFormUrl}/submission` +
@@ -729,12 +729,12 @@ router.get("/formio-close-out-submissions", storeBapComboKeys, (req, res) => {
     .then((axiosRes) => axiosRes.data)
     .then((submissions) => res.json(submissions))
     .catch((error) => {
-      const message = `Error getting Formio Close-Out form submissions`;
+      const message = `Error getting Formio Close Out form submissions`;
       return res.status(error?.response?.status || 500).json({ message });
     });
 });
 
-// --- post a new Close-Out form submission to Formio
+// --- post a new Close Out form submission to Formio
 router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
   const {
     email,
@@ -749,13 +749,13 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
   } = req.body;
 
   if (!closeOutFormOpen) {
-    const message = `CSB Close-Out form enrollment period is closed`;
+    const message = `CSB Close Out form enrollment period is closed`;
     return res.status(400).json({ message });
   }
 
   // verify post data includes one of user's BAP combo keys
   if (!req.bapComboKeys.includes(comboKey)) {
-    const message = `User with email ${req.user.mail} attempted to post a new Close-Out form submission without a matching BAP combo key`;
+    const message = `User with email ${req.user.mail} attempted to post a new Close Out form submission without a matching BAP combo key`;
     log({ level: "error", message, req });
     return res.status(401).json({ message: "Unauthorized" });
   }
@@ -888,7 +888,7 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
           .then((axiosRes) => axiosRes.data)
           .then((submission) => res.json(submission))
           .catch((error) => {
-            const message = `Error posting Formio Close-Out form submission`;
+            const message = `Error posting Formio Close Out form submission`;
             return res.status(error?.response?.status || 500).json({ message });
           });
       }
@@ -899,7 +899,7 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
     });
 });
 
-// --- get an existing Close-Out form's schema and submission data from Formio
+// --- get an existing Close Out form's schema and submission data from Formio
 router.get(
   "/formio-close-out-submission/:rebateId",
   storeBapComboKeys,
@@ -922,7 +922,7 @@ router.get(
         const comboKey = submission.data.bap_hidden_entity_combo_key;
 
         if (!req.bapComboKeys.includes(comboKey)) {
-          const message = `User with email ${req.user.mail} attempted to access Close-Out form submission ${rebateId} that they do not have access to.`;
+          const message = `User with email ${req.user.mail} attempted to access Close Out form submission ${rebateId} that they do not have access to.`;
           log({ level: "warn", message, req });
           return res.json({
             userAccess: false,
@@ -957,13 +957,13 @@ router.get(
           });
       })
       .catch((error) => {
-        const message = `Error getting Formio Close-Out form submission ${rebateId}`;
+        const message = `Error getting Formio Close Out form submission ${rebateId}`;
         res.status(error?.response?.status || 500).json({ message });
       });
   }
 );
 
-// --- post an update to an existing draft Close-Out form submission to Formio
+// --- post an update to an existing draft Close Out form submission to Formio
 router.post(
   "/formio-close-out-submission/:rebateId",
   storeBapComboKeys,
@@ -977,7 +977,7 @@ router.post(
       .then(() => {
         // verify post data includes one of user's BAP combo keys
         if (!req.bapComboKeys.includes(comboKey)) {
-          const message = `User with email ${req.user.mail} attempted to update Close-Out form submission ${rebateId} without a matching BAP combo key`;
+          const message = `User with email ${req.user.mail} attempted to update Close Out form submission ${rebateId} without a matching BAP combo key`;
           log({ level: "error", message, req });
           return res.status(401).json({ message: "Unauthorized" });
         }
@@ -999,12 +999,12 @@ router.post(
           .then((axiosRes) => axiosRes.data)
           .then((submission) => res.json(submission))
           .catch((error) => {
-            const message = `Error updating Formio Close-Out form submission ${rebateId}`;
+            const message = `Error updating Formio Close Out form submission ${rebateId}`;
             return res.status(error?.response?.status || 500).json({ message });
           });
       })
       .catch((error) => {
-        const message = `CSB Close-Out form enrollment period is closed`;
+        const message = `CSB Close Out form enrollment period is closed`;
         return res.status(400).json({ message });
       });
   }

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -201,7 +201,7 @@ router.post("/formio-submission/:formType/:id", (req, res) => {
 
   if (formType === "close-out") {
     if (!closeOutFormOpen) {
-      const message = `CSB Close-Out form enrollment period is closed`;
+      const message = `CSB Close Out form enrollment period is closed`;
       return res.status(400).json({ message });
     }
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-119

## Main Changes:
Renames all instances of "Close-Out" to "Close Out"

## Steps To Test:
1. Ensure there are no longer any instances of "Close-Out" in the wrapper application's UI (NOTE: text within the close out form itself is managed in Formio via the form's definition, so that will need to be updated independently).
