### PR TITLE
Feature/fix s3 upload functionality

### DIFF
--- a/app/client/src/react-app-env.d.ts
+++ b/app/client/src/react-app-env.d.ts
@@ -1,3 +1,4 @@
 /// <reference types="react-scripts" />
 
+declare module "formiojs/providers/storage/s3";
 declare module "@formio/react";

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog } from "@headlessui/react";
 import { Formio, Form } from "@formio/react";
+import s3 from "formiojs/providers/storage/s3";
 import { cloneDeep, isEqual } from "lodash";
 import icons from "uswds/img/sprite.svg";
 // ---
@@ -59,13 +60,20 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
     queryKey: ["application", { id: mongoId }],
     queryFn: () => {
       return getData<ServerResponse>(url).then((res) => {
-        // set up s3 re-route to wrapper app
-        const s3Provider = Formio.Providers.providers.storage.s3;
+        const comboKey = res.submission?.data.bap_hidden_entity_combo_key;
+
+        /**
+         * Change the formUrl the File component's `uploadFile` uses, so the s3
+         * upload PUT request is routed through the server app.
+         *
+         * https://github.com/formio/formio.js/blob/master/src/components/file/File.js#L760
+         * https://github.com/formio/formio.js/blob/master/src/providers/storage/s3.js#L5
+         * https://github.com/formio/formio.js/blob/master/src/providers/storage/xhr.js#L90
+         */
         Formio.Providers.providers.storage.s3 = function (formio: any) {
           const s3Formio = cloneDeep(formio);
-          const comboKey = res.submission?.data.bap_hidden_entity_combo_key;
           s3Formio.formUrl = `${serverUrl}/api/s3/application/${mongoId}/${comboKey}`;
-          return s3Provider(s3Formio);
+          return s3(s3Formio);
         };
 
         // remove `ncesDataSource` and `ncesDataLookup` fields

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog } from "@headlessui/react";
 import { Formio, Form } from "@formio/react";
+import s3 from "formiojs/providers/storage/s3";
 import { cloneDeep, isEqual } from "lodash";
 import icons from "uswds/img/sprite.svg";
 // ---
@@ -58,14 +59,21 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
     queryKey: ["payment-request", { id: rebateId }],
     queryFn: () => {
       return getData<ServerResponse>(url).then((res) => {
-        // set up s3 re-route to wrapper app
-        const s3Provider = Formio.Providers.providers.storage.s3;
+        const mongoId = res.submission?._id;
+        const comboKey = res.submission?.data.bap_hidden_entity_combo_key;
+
+        /**
+         * Change the formUrl the File component's `uploadFile` uses, so the s3
+         * upload PUT request is routed through the server app.
+         *
+         * https://github.com/formio/formio.js/blob/master/src/components/file/File.js#L760
+         * https://github.com/formio/formio.js/blob/master/src/providers/storage/s3.js#L5
+         * https://github.com/formio/formio.js/blob/master/src/providers/storage/xhr.js#L90
+         */
         Formio.Providers.providers.storage.s3 = function (formio: any) {
           const s3Formio = cloneDeep(formio);
-          const mongoId = res.submission?._id;
-          const comboKey = res.submission?.data.bap_hidden_entity_combo_key;
           s3Formio.formUrl = `${serverUrl}/api/s3/payment-request/${mongoId}/${comboKey}`;
-          return s3Provider(s3Formio);
+          return s3(s3Formio);
         };
 
         return Promise.resolve(res);

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -249,10 +249,10 @@ router.post(
         const formName =
           formType === "application"
             ? "CSB Application"
-              ? formType === "payment-request"
-              : "CSB Payment Request"
-              ? formType === "close-out"
-              : "CSB Close Out"
+            : formType === "payment-request"
+            ? "CSB Payment Request"
+            : formType === "close-out"
+            ? "CSB Close Out"
             : "CSB";
         const message = `${formName} form enrollment period is closed`;
         return res.status(400).json({ message });


### PR DESCRIPTION
## Related Issues:
* CSBAPP-122

## Main Changes:
Fixes an issue some users were having where the wrapper app's s3 file upload route wasn't properly being set for payment request forms in certain situations. The situation where a user would get in this error state is when a user first viewed an Application form submission, then edited a Payment Request form submission and attempted to upload a file, but was prevented from doing so.

On production, since the Application form "open enrollment" period is closed, if the s3 file upload route incorrectly had "application" as part of the Express API route path when accessed from a Payment Request form page, the request would fail (due to logic we have on the server that prevents a user from uploading a file when the enrollment period is closed for that given form).

This fixes that bug, and ensures the s3 file upload route is always properly set for each form. The issue was our "monkey patching" for the form url the File component uses would always use the value used the first time it was changed, even though we attempted to patch it in each form component. Switching from referencing the s3 storage function from the window object to importing the function from the `formiojs` library directly fixed this problem.

This also fixes the error message shown to properly display the form name (previously it said "false" in place of the form name due to a bug in the logic), when the user attempts to upload a file but the form's enrollment period is closed. In reality, they'd never see this error message in the form, as the form would render read-only and prevent them from attempting to upload a file, but this error message would be returned if they attempted to upload a file via the wrapper application's API.

## Steps To Test:
1. Navigate to any Application form submission (submission doesn't need to be editable – it can be submitted/read-only).
2. Navigate back to the dashboard, then navigate to any Payment Request form submission.
3. Advance through the form, and attempt to upload a file – it should succeed now, but would previously fail before in this given situation.
