### PR TITLE
Feature/update error handling

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -105,7 +105,7 @@ function useInactivityDialog(callback: () => void) {
     /**
      * NOTE: setting timeout to be one minute less than the JWT's configured 15
      * minute timeout (set via the `expiresIn` option in the server app's
-     * createJwt() middleware function), so `onIdle` is called and displays a
+     * createJWT() middleware function), so `onIdle` is called and displays a
      * 1 minute countdown in a warning modal prompting user action to remain
      * logged in.
      */

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -180,11 +180,11 @@ export type Rebate = {
 async function fetchData<T = any>(url: string, options: RequestInit) {
   try {
     const response = await fetch(url, options);
-    if (!response.ok) throw new Error(response.statusText);
     const contentType = response.headers.get("content-type");
-    return contentType?.includes("application/json")
+    const data = contentType?.includes("application/json")
       ? ((await response.json()) as Promise<T>)
-      : (Promise.resolve() as Promise<T>);
+      : ((await response.text()) as unknown as Promise<T>);
+    return response.ok ? Promise.resolve(data) : Promise.reject(data);
   } catch (error) {
     return await Promise.reject(error);
   }

--- a/app/server/app/index.js
+++ b/app/server/app/index.js
@@ -18,7 +18,16 @@ const {
 } = require("./middleware");
 const routes = require("./routes");
 
-const requiredEnvVars = [
+const {
+  NODE_ENV,
+  PORT,
+  CLIENT_URL,
+  SERVER_BASE_PATH,
+  CLOUD_SPACE,
+  JSON_PAYLOAD_LIMIT,
+} = process.env;
+
+const requiredEnvironmentVariables = [
   "SERVER_URL",
   "SAML_LOGIN_URL",
   "SAML_LOGOUT_URL",
@@ -40,16 +49,17 @@ const requiredEnvVars = [
   "S3_PUBLIC_REGION",
 ];
 
-requiredEnvVars.forEach((envVar) => {
-  if (!process.env[envVar]) {
-    const message = `Required environment variable ${envVar} not found.`;
-    log({ level: "error", message });
+requiredEnvironmentVariables.forEach((variable) => {
+  if (!process.env[variable]) {
+    const logMessage = `Required environment variable ${variable} not found.`;
+    log({ level: "error", message: logMessage });
+
     process.exitCode = 1;
   }
 });
 
 const app = express();
-const port = process.env.PORT || 3001;
+const port = PORT || 3001;
 
 app.use(
   helmet({
@@ -59,13 +69,10 @@ app.use(
 );
 app.use(helmet.hsts({ maxAge: 31536000 }));
 
-// Instruct web browsers to disable caching
+/** Instruct web browsers to disable caching. */
 app.use((req, res, next) => {
   res.setHeader("Surrogate-Control", "no-store");
-  res.setHeader(
-    "Cache-Control",
-    "no-store, no-cache, must-revalidate, proxy-revalidate"
-  );
+  res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate"); // prettier-ignore
   res.setHeader("Pragma", "no-cache");
   res.setHeader("Expires", "0");
   next();
@@ -73,49 +80,59 @@ app.use((req, res, next) => {
 
 app.disable("x-powered-by");
 
-// Enable CORS and logging with morgan for local development only
-// NOTE: process.env.NODE_ENV set to "development" below to match value defined
-// in create-react-app when client app is run locally via `npm start`
-if (process.env.NODE_ENV === "development") {
-  app.use(cors({ origin: process.env.CLIENT_URL, credentials: true }));
+/**
+ * Enable CORS and logging with morgan for local development only.
+ * NOTE: process.env.NODE_ENV set to "development" below to match value defined
+ * in create-react-app when client app is run locally via `npm start`
+ */
+if (NODE_ENV === "development") {
+  app.use(cors({ origin: CLIENT_URL, credentials: true }));
   app.use(morgan("dev"));
 }
 
-// Apply global middleware on dev/staging in order for scan to receive 200 status on all endpoints
-if (
-  process.env.CLOUD_SPACE === "dev" ||
-  process.env.CLOUD_SPACE === "staging"
-) {
+/**
+ * Apply global middleware on dev/staging in order for scan to receive 200
+ * status on all endpoints
+ */
+if (CLOUD_SPACE === "dev" || CLOUD_SPACE === "staging") {
   app.use(appScan);
 }
 
-app.use(express.json({ limit: process.env.JSON_PAYLOAD_LIMIT || "5mb" }));
+app.use(express.json({ limit: JSON_PAYLOAD_LIMIT || "5mb" }));
 app.use(cookieParser());
 app.use(express.urlencoded({ extended: true }));
 
 app.use(passport.initialize());
 passport.use("saml", samlStrategy);
 
-// If SERVER_BASE_PATH is provided, serve routes and static files from there (e.g. /csb)
-const basePath = `${process.env.SERVER_BASE_PATH || ""}/`;
+/**
+ * If SERVER_BASE_PATH is provided, serve routes and static files from there
+ * (e.g. /csb).
+ */
+const basePath = `${SERVER_BASE_PATH || ""}/`;
 app.use(basePath, routes);
 
-// Use regex to add trailing slash on static requests (required when using sub path)
-const pathRegex = new RegExp(`^\\${process.env.SERVER_BASE_PATH || ""}$`);
+/**
+ * Use regex to add trailing slash on static requests
+ * (required when using sub path).
+ */
+const pathRegex = new RegExp(`^\\${SERVER_BASE_PATH || ""}$`);
 app.all(pathRegex, (req, res) => res.redirect(`${basePath}`));
 
-// Serve client app's static built files
-// NOTE: client app's `build` directory contents copied into server app's
-// `public` directory in CI/CD step
+/**
+ * Serve client app's static built files.
+ * NOTE: client app's `build` directory contents copied into server app's
+ * `public` directory in CI/CD step.
+ */
 app.use(basePath, express.static(resolve(__dirname, "public")));
 
-// Ensure that requested client route exists (otherwise send 404)
+/** Ensure that requested client route exists (otherwise send 404). */
 app.use(checkClientRouteExists);
 
-// Ensure user is authenticated on all client-side routes except / and /welcome
+/** Ensure user is authenticated on all client-side routes except / and /welcome */
 app.use(protectClientRoutes);
 
-// Serve client-side routes
+/** Serve client-side routes. */
 app.get("*", (req, res) => {
   res.sendFile(resolve(__dirname, "public/index.html"));
 });
@@ -123,5 +140,6 @@ app.get("*", (req, res) => {
 app.use(errorHandler);
 
 app.listen(port, () => {
-  log({ level: "info", message: `Server listening on port ${port}` });
+  const logMessage = `Server listening on port ${port}`;
+  log({ level: "info", message: logMessage });
 });

--- a/app/server/app/middleware.js
+++ b/app/server/app/middleware.js
@@ -7,57 +7,68 @@ const { createJwt, jwtAlgorithm } = require("./utilities/createJwt");
 const log = require("./utilities/logger");
 const { getBapComboKeys } = require("./utilities/bap");
 
+const { CLIENT_URL, SERVER_URL, SERVER_BASE_PATH, JWT_PUBLIC_KEY } =
+  process.env;
+
 const cookieName = "csb-token";
 
 /**
- * Middleware to check for JWT, add user object to request, and create new JWT to keep alive for 15 minutes from request
- * Default to rejectRequest function if jwt is invalid, but allow for a custom override function on reject
- * (required for auto-redirect to SAML)
+ * Middleware to check for JWT, add user object to request, and create new JWT
+ * to keep alive for 15 minutes from request. Default to rejectRequest function
+ * if JWT is invalid, but allow for a custom override function on reject
+ * (required for auto-redirect to SAML).
+ *
  * @param {express.Request} req
  * @param {express.Response} res
  * @param {express.NextFunction} next
  */
 function ensureAuthenticated(req, res, next, rejectCallback = rejectRequest) {
-  // If no JWT passed in token cookie, send Unauthorized response or redirect
+  /** If no JWT passed in token cookie, send Unauthorized response or redirect. */
   if (!req.cookies[cookieName]) {
-    log({ level: "warn", message: "No jwt cookie present in request", req });
+    const logMessage = `No JWT cookie present in request.`;
+    log({ level: "warn", message: logMessage, req });
+
     return rejectCallback(req, res);
   }
 
   jwt.verify(
     req.cookies[cookieName],
-    process.env.JWT_PUBLIC_KEY,
+    JWT_PUBLIC_KEY,
     { algorithms: [jwtAlgorithm] },
     function (err, user) {
       if (err) {
-        // Change log levels depending on jwt error received
-        if (err instanceof jwt.TokenExpiredError) {
-          log({ level: "warn", message: "JWT expired.", req });
+        const jwtExpired = err instanceof jwt.TokenExpiredError;
+
+        /** Change log levels depending on JWT error received. */
+        if (jwtExpired) {
+          const logMessage = `JWT expired.`;
+          log({ level: "warn", message: logMessage, req });
         } else if (err instanceof jwt.JsonWebTokenError) {
-          log({ level: "error", message: "An invalid JWT was used.", req });
+          const logMessage = `An invalid JWT was used.`;
+          log({ level: "error", message: logMessage, req });
         } else {
-          const message =
-            typeof err.toString === "function" ? err.toString() : err;
-          log({ level: "error", message, req });
+          const logMessage = typeof err.toString === "function" ? err.toString() : err; // prettier-ignore
+          log({ level: "error", message: logMessage, req });
         }
 
-        // if err is TokenExpiredError, expired will be true and user will see inactive message instead of error
-        return rejectCallback(req, res, err instanceof jwt.TokenExpiredError);
+        /** If JWT has expired, user will see inactivity message instead of error. */
+        return rejectCallback(req, res, jwtExpired);
       }
 
-      // Add user to the request object
+      /** Add user to the request object. */
       req.user = user;
 
-      // Create new token to update expiration to 15 min from now
-      const newToken = createJwt(user);
+      /** Create a new token to update expiration to 15 min from now. */
+      const token = createJwt(user);
 
-      // Add JWT in cookie and proceed with request
-      res.cookie(cookieName, newToken, {
+      /** Add JWT in cookie and proceed with request. */
+      res.cookie(cookieName, token, {
         httpOnly: true,
         overwrite: true,
         sameSite: "lax",
         secure: true,
       });
+
       next();
     }
   );
@@ -65,24 +76,24 @@ function ensureAuthenticated(req, res, next, rejectCallback = rejectRequest) {
 
 /**
  * Confirm user has either "csb_admin" or "csb_helpdesk" role.
- * Log message and send 401 Unauthorized if user does not have either role
+ * Log message and send 401 Unauthorized if user does not have either role.
+ *
  * @param {express.Request} req
  * @param {express.Response} res
  * @param {express.NextFunction} next
  */
 function ensureHelpdesk(req, res, next) {
-  const userRoles = req.user.memberof ? req.user.memberof.split(",") : [];
+  const { mail, memberof } = req.user;
+  const userRoles = memberof?.split(",") || [];
 
   if (!userRoles.includes("csb_admin") && !userRoles.includes("csb_helpdesk")) {
     if (!req.originalUrl.includes("/helpdesk-access")) {
-      log({
-        level: "error",
-        message: `User with email ${req.user.mail} attempted to perform an admin/helpdesk action without correct privileges.`,
-        req,
-      });
+      const logMessage = `User with email ${mail} attempted to perform an admin/helpdesk action without correct privileges.`;
+      log({ level: "error", message: logMessage, req });
     }
 
-    return res.status(401).json({ message: "Unauthorized" });
+    const errorMessage = `Unauthorized.`;
+    return res.status(401).json({ message: errorMessage });
   }
 
   next();
@@ -91,47 +102,52 @@ function ensureHelpdesk(req, res, next) {
 /**
  * @param {express.Request} req
  * @param {express.Response} res
- * @param {boolean} expired
+ * @param {boolean} jwtExpired
  */
-function rejectRequest(req, res, expired) {
-  // Clear token cookie if there was an error verifying (e.g. expired)
+function rejectRequest(req, res, jwtExpired) {
+  /** Clear token cookie if there was an error verifying (e.g. jwtExpired). */
   res.clearCookie(cookieName);
 
   if (req.originalUrl.includes("/api")) {
-    // Send JSON Unauthorized message if request is for an API endpoint
-    return res.status(401).json({ message: "Unauthorized" });
+    /** Send JSON Unauthorized message if request is for an API endpoint. */
+    const errorMessage = `Unauthorized.`;
+    return res.status(401).json({ message: errorMessage });
   }
-  // For non-API requests (e.g. on logout), redirect to front-end if token is non-existent or invalid
-  // If expired, display timeout info message instead of auth error
-  return res.redirect(
-    `${process.env.CLIENT_URL || process.env.SERVER_URL}/welcome?${
-      expired ? "info=timeout" : "error=auth"
-    }`
-  );
+
+  /**
+   * For non-API requests (e.g. on logout), redirect to /welcome if token is
+   * non-existent or invalid, and display the appropriate message (timeout or
+   * authentication error).
+   */
+  const param = jwtExpired ? "info=timeout" : "error=auth";
+  return res.redirect(`${CLIENT_URL || SERVER_URL}/welcome?${param}`);
 }
 
 /**
- * Auto-redirect to SAML login for any non-logged-in user on any route except base "/" or "/welcome"
+ * Auto-redirect to SAML login for any non-logged-in user on any route except
+ * base "/" or "/welcome".
+ *
  * @param {express.Request} req
  * @param {express.Response} res
  * @param {express.NextFunction} next
  */
 function protectClientRoutes(req, res, next) {
-  const subPath = process.env.SERVER_BASE_PATH || "";
+  const subPath = SERVER_BASE_PATH || "";
   const unprotectedRoutes = ["/", "/welcome", "/manifest.json"].map(
     (route) => `${subPath}${route}`
   );
+
   if (!unprotectedRoutes.includes(req.path) && !req.path.includes("/static")) {
     return ensureAuthenticated(req, res, next, (req, res) => {
-      // If ensureAuthenticated does not find valid jwt, this redirect will occur so user is auto-redirected to SAML
-      return res.redirect(
-        `${process.env.SERVER_URL}/login?RelayState=${req.originalUrl.replace(
-          subPath,
-          ""
-        )}`
-      );
+      /**
+       * If ensureAuthenticated does not find valid JWT, this redirect will
+       * occur so user is auto-redirected to SAML.
+       */
+      const url = req.originalUrl.replace(subPath, "");
+      return res.redirect(`${SERVER_URL}/login?RelayState=${url}`);
     });
   }
+
   next();
 }
 
@@ -141,10 +157,11 @@ function protectClientRoutes(req, res, next) {
  * @param {express.NextFunction} next
  */
 function checkClientRouteExists(req, res, next) {
-  const subPath = process.env.SERVER_BASE_PATH || "";
+  const subPath = SERVER_BASE_PATH || "";
   const clientRoutes = ["/", "/welcome", "/helpdesk", "/rebate/new"].map(
     (route) => `${subPath}${route}`
   );
+
   if (
     !clientRoutes.includes(req.path) &&
     !req.path.includes("/rebate/") &&
@@ -153,38 +170,46 @@ function checkClientRouteExists(req, res, next) {
   ) {
     return res.status(404).sendFile(resolve(__dirname, "public/404.html"));
   }
+
   next();
 }
 
 /**
- * Global middleware on dev/staging to send 200 status on all server endpoints (required for ZAP scan)
+ * Global middleware on dev/staging to send 200 status on all server endpoints
+ * (required for ZAP scan).
+ *
  * @param {express.Request} req
  * @param {express.Response} res
  * @param {express.NextFunction} next
  */
 function appScan(req, res, next) {
-  // OpenAPI def must use global "scan" param and enum to "true"
+  /** OpenAPI def must use global "scan" param and enum to "true". */
   if (req.query.scan === "true") {
     return res.json({ status: 200 });
   }
+
   next();
 }
 
 /**
  * Fetch user's SAM.gov unique combo keys from the BAP and add "bapComboKeys"
  * to request object if successful.
+ *
  * @param {express.Request} req
  * @param {express.Response} res
  * @param {express.NextFunction} next
  */
 function storeBapComboKeys(req, res, next) {
-  getBapComboKeys(req, req.user.mail)
+  const { mail } = req.user;
+
+  getBapComboKeys(req, mail)
     .then((bapComboKeys) => {
       req.bapComboKeys = bapComboKeys;
       next();
     })
     .catch(() => {
-      return res.status(401).json({ message: "Error getting SAM.gov data" });
+      const errorMessage = `Error getting SAM.gov data.`;
+      return res.status(401).json({ message: errorMessage });
     });
 }
 
@@ -194,11 +219,11 @@ function storeBapComboKeys(req, res, next) {
  * @param {express.NextFunction} next
  */
 function verifyMongoObjectId(req, res, next) {
-  const id = req.params.id;
+  const { id } = req.params;
 
   if (id && !ObjectId.isValid(id)) {
-    const message = `MongoDB ObjectId validation error for: ${id}`;
-    return res.status(400).json({ message });
+    const errorMessage = `MongoDB ObjectId validation error for: ${id}.`;
+    return res.status(400).json({ message: errorMessage });
   }
 
   next();

--- a/app/server/app/middleware.js
+++ b/app/server/app/middleware.js
@@ -96,8 +96,9 @@ function ensureHelpdesk(req, res, next) {
       log({ level: "error", message: logMessage, req });
     }
 
+    const errorStatus = 401;
     const errorMessage = `Unauthorized.`;
-    return res.status(401).json({ message: errorMessage });
+    return res.status(errorStatus).json({ message: errorMessage });
   }
 
   next();
@@ -114,8 +115,9 @@ function rejectRequest(req, res, jwtExpired) {
 
   if (req.originalUrl.includes("/api")) {
     /** Send JSON Unauthorized message if request is for an API endpoint. */
+    const errorStatus = 401;
     const errorMessage = `Unauthorized.`;
-    return res.status(401).json({ message: errorMessage });
+    return res.status(errorStatus).json({ message: errorMessage });
   }
 
   /**
@@ -172,7 +174,10 @@ function checkClientRouteExists(req, res, next) {
     !req.path.includes("/payment-request/") &&
     !req.path.includes("/close-out/")
   ) {
-    return res.status(404).sendFile(resolve(__dirname, "public/404.html"));
+    const errorStatus = 404;
+    return res
+      .status(errorStatus)
+      .sendFile(resolve(__dirname, "public/404.html"));
   }
 
   next();
@@ -212,8 +217,9 @@ function storeBapComboKeys(req, res, next) {
       next();
     })
     .catch(() => {
-      const errorMessage = `Error getting SAM.gov data.`;
-      return res.status(401).json({ message: errorMessage });
+      const errorStatus = 500;
+      const errorMessage = `Error getting SAM.gov data from the BAP.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     });
 }
 
@@ -226,8 +232,9 @@ function verifyMongoObjectId(req, res, next) {
   const { id } = req.params;
 
   if (id && !ObjectId.isValid(id)) {
+    const errorStatus = 400;
     const errorMessage = `MongoDB ObjectId validation error for: ${id}.`;
-    return res.status(400).json({ message: errorMessage });
+    return res.status(errorStatus).json({ message: errorMessage });
   }
 
   next();

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -872,8 +872,18 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
         paymentRequestRecordQuery,
         busRecordsQuery,
       }) => {
-        const { Fleet_Contact_Name__c, School_District_Contact__r } =
-          applicationRecordQuery[0];
+        const {
+          Fleet_Name__c,
+          Fleet_Street_Address__c,
+          Fleet_City__c,
+          Fleet_State__c,
+          Fleet_Zip__c,
+          Fleet_Contact_Name__c,
+          Fleet_Contact_Title__c,
+          Fleet_Contact_Phone__c,
+          Fleet_Contact_Email__c,
+          School_District_Contact__r,
+        } = applicationRecordQuery[0];
 
         const {
           CSB_NCES_ID__c,
@@ -881,7 +891,6 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
           Alternate_Applicant__r,
           Applicant_Organization__r,
           CSB_School_District__r,
-          Fleet_Name__c,
           School_District_Prioritized__c,
           Total_Rebate_Funds_Requested_PO__c,
           Total_Bus_And_Infrastructure_Rebate__c,
@@ -951,6 +960,14 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
             hidden_bap_alternate_email: Alternate_Applicant__r?.Email || "",
             hidden_bap_org_name: Applicant_Organization__r?.Name,
             hidden_bap_fleet_name: Fleet_Name__c,
+            hidden_bap_fleet_address: Fleet_Street_Address__c,
+            hidden_bap_fleet_city: Fleet_City__c,
+            hidden_bap_fleet_state: Fleet_State__c,
+            hidden_bap_fleet_zip: Fleet_Zip__c,
+            hidden_bap_fleet_contact_name: Fleet_Contact_Name__c,
+            hidden_bap_fleet_contact_title: Fleet_Contact_Title__c,
+            hidden_bap_fleet_phone: Fleet_Contact_Phone__c,
+            hidden_bap_fleet_email: Fleet_Contact_Email__c,
             hidden_bap_prioritized: School_District_Prioritized__c,
             hidden_bap_requested_funds: Total_Rebate_Funds_Requested_PO__c,
             hidden_bap_received_funds: Total_Bus_And_Infrastructure_Rebate__c,
@@ -963,7 +980,6 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
             hidden_bap_total_infra_level2_charger: Total_Level_2_Charger_Costs__c, // prettier-ignore
             hidden_bap_total_infra_dc_fast_charger: Total_DC_Fast_Charger_Costs__c, // prettier-ignore
             hidden_bap_total_infra_other_costs: Total_Other_Infrastructure_Costs__c, // prettier-ignore
-            hidden_bap_fleet_contact_name: Fleet_Contact_Name__c,
             hidden_bap_district_contact_fname: School_District_Contact__r?.FirstName, // prettier-ignore
             hidden_bap_district_contact_lname: School_District_Contact__r?.LastName, // prettier-ignore
             busInfo,

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -24,17 +24,27 @@ const {
 } = require("../utilities/bap");
 const log = require("../utilities/logger");
 
-const applicationFormOpen = process.env.CSB_APPLICATION_FORM_OPEN === "true";
-const paymentRequestFormOpen = process.env.CSB_PAYMENT_REQUEST_FORM_OPEN === "true"; // prettier-ignore
-const closeOutFormOpen = process.env.CSB_CLOSE_OUT_FORM_OPEN === "true";
+const {
+  NODE_ENV,
+  CSB_APPLICATION_FORM_OPEN,
+  CSB_PAYMENT_REQUEST_FORM_OPEN,
+  CSB_CLOSE_OUT_FORM_OPEN,
+  S3_PUBLIC_BUCKET,
+  S3_PUBLIC_REGION,
+} = process.env;
+
+const applicationFormOpen = CSB_APPLICATION_FORM_OPEN === "true";
+const paymentRequestFormOpen = CSB_PAYMENT_REQUEST_FORM_OPEN === "true";
+const closeOutFormOpen = CSB_CLOSE_OUT_FORM_OPEN === "true";
 
 /**
  * Returns a resolved or rejected promise, depending on if the given form's
  * submission period is open (as set via environment variables), and if the form
  * submission has the status of "Edits Requested" or not (as stored in and
  * returned from the BAP).
+ *
  * @param {Object} param
- * @param {'application'|'payment-request'|'close-out'} param.formType
+ * @param {'application' | 'payment-request' | 'close-out'} param.formType
  * @param {string} param.mongoId
  * @param {string} param.comboKey
  * @param {express.Request} param.req
@@ -45,7 +55,7 @@ function checkFormSubmissionPeriodAndBapStatus({
   comboKey,
   req,
 }) {
-  // form submission period is open, so continue
+  /** Form submission period is open, so continue. */
   if (
     (formType === "application" && applicationFormOpen) ||
     (formType === "payment-request" && paymentRequestFormOpen) ||
@@ -54,7 +64,7 @@ function checkFormSubmissionPeriodAndBapStatus({
     return Promise.resolve();
   }
 
-  // form submission period is closed, so only continue if edits are requested
+  /** Form submission period is closed, so only continue if edits are requested. */
   return getBapFormSubmissionsStatuses(req, [comboKey]).then((submissions) => {
     const submission = submissions.find((s) => s.CSB_Form_ID__c === mongoId);
 
@@ -77,10 +87,7 @@ const router = express.Router();
 
 // --- get static content from S3
 router.get("/content", (req, res) => {
-  const s3Bucket = process.env.S3_PUBLIC_BUCKET;
-  const s3Region = process.env.S3_PUBLIC_REGION;
-
-  // NOTE: static content files found in `app/server/app/content/` directory
+  /** NOTE: static content files found in `app/server/app/content/` directory. */
   const filenames = [
     "site-alert.md",
     "helpdesk-intro.md",
@@ -95,21 +102,25 @@ router.get("/content", (req, res) => {
     "submitted-close-out-intro.md",
   ];
 
-  const s3BucketUrl = `https://${s3Bucket}.s3-${s3Region}.amazonaws.com`;
+  const s3BucketUrl = `https://${S3_PUBLIC_BUCKET}.s3-${S3_PUBLIC_REGION}.amazonaws.com`;
 
   Promise.all(
     filenames.map((filename) => {
-      // local development: read files directly from disk
-      // Cloud.gov: fetch files from the public s3 bucket
-      return process.env.NODE_ENV === "development"
+      /**
+       * local development: read files directly from disk
+       * Cloud.gov: fetch files from the public s3 bucket
+       */
+      return NODE_ENV === "development"
         ? readFile(resolve(__dirname, "../content", filename), "utf8")
         : axios.get(`${s3BucketUrl}/content/${filename}`);
     })
   )
     .then((stringsOrResponses) => {
-      // local development: no further processing of strings needed
-      // Cloud.gov: get data from responses
-      return process.env.NODE_ENV === "development"
+      /**
+       * local development: no further processing of strings needed
+       * Cloud.gov: get data from responses
+       */
+      return NODE_ENV === "development"
         ? stringsOrResponses
         : stringsOrResponses.map((axiosRes) => axiosRes.data);
     })
@@ -130,18 +141,19 @@ router.get("/content", (req, res) => {
     })
     .catch((error) => {
       if (typeof error.toJSON === "function") {
-        log({ level: "debug", message: error.toJSON(), req });
+        const logMessage = error.toJSON();
+        log({ level: "debug", message: logMessage, req });
       }
 
-      const errorStatus = error.response?.status;
+      const errorStatus = error.response?.status || 500;
       const errorMethod = error.response?.config?.method?.toUpperCase();
       const errorUrl = error.response?.config?.url;
-      const message = `S3 Error: ${errorStatus} ${errorMethod} ${errorUrl}`;
-      log({ level: "error", message, req });
 
-      return res
-        .status(error?.response?.status || 500)
-        .json({ message: "Error getting static content from S3 bucket" });
+      const logMessage = `S3 Error: ${errorStatus} ${errorMethod} ${errorUrl}`;
+      log({ level: "error", message: logMessage, req });
+
+      const errorMessage = `Error getting static content from S3 bucket.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     });
 });
 
@@ -166,34 +178,49 @@ router.get("/csb-data", (req, res) => {
 
 // --- get user's SAM.gov data from EPA's Business Automation Platform (BAP)
 router.get("/bap-sam-data", (req, res) => {
-  getSamEntities(req, req.user.mail)
-    .then((entities) => {
-      // NOTE: allow admin or helpdesk users access to the app, even without SAM.gov data
-      const userRoles = req.user.memberof.split(",");
-      const helpdeskUser =
-        userRoles.includes("csb_admin") || userRoles.includes("csb_helpdesk");
+  const { mail, memberof } = req.user;
+  const userRoles = memberof.split(",");
+  const adminOrHelpdeskUser =
+    userRoles.includes("csb_admin") || userRoles.includes("csb_helpdesk");
 
-      if (!helpdeskUser && entities?.length === 0) {
-        const message = `User with email ${req.user.mail} tried to use app without any associated SAM records.`;
-        log({ level: "error", message, req });
-        return res.json({ results: false, entities: [] });
+  getSamEntities(req, mail)
+    .then((entities) => {
+      /**
+       * NOTE: allow admin or helpdesk users access to the app, even without
+       * SAM.gov data.
+       */
+      if (!adminOrHelpdeskUser && entities?.length === 0) {
+        const logMessage = `User with email '${mail}' tried to use app without any associated SAM records.`;
+        log({ level: "error", message: logMessage, req });
+
+        return res.json({
+          results: false,
+          entities: [],
+        });
       }
 
-      return res.json({ results: true, entities });
+      return res.json({
+        results: true,
+        entities,
+      });
     })
     .catch((error) => {
-      const message = `Error getting SAM.gov data from BAP`;
-      return res.status(401).json({ message });
+      const errorStatus = 500;
+      const errorMessage = `Error getting SAM.gov data from the BAP.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     });
 });
 
 // --- get user's form submissions statuses from EPA's BAP
 router.get("/bap-form-submissions", storeBapComboKeys, (req, res) => {
-  return getBapFormSubmissionsStatuses(req, req.bapComboKeys)
+  const { bapComboKeys } = req;
+
+  return getBapFormSubmissionsStatuses(req, bapComboKeys)
     .then((submissions) => res.json(submissions))
     .catch((error) => {
-      const message = `Error getting form submissions statuses from BAP`;
-      return res.status(401).json({ message });
+      const errorStatus = 500;
+      const errorMessage = `Error getting form submissions statuses from the BAP.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     });
 });
 
@@ -202,21 +229,27 @@ router.get(
   "/s3/:formType/:mongoId/:comboKey/storage/s3",
   storeBapComboKeys,
   (req, res) => {
+    const { bapComboKeys, query } = req;
+    const { mail } = req.user;
     const { comboKey } = req.params;
 
-    if (!req.bapComboKeys.includes(comboKey)) {
-      const message = `User with email ${req.user.mail} attempted to download a file without a matching BAP combo key`;
-      log({ level: "error", message, req });
-      return res.status(401).json({ message: "Unauthorized" });
+    if (!bapComboKeys.includes(comboKey)) {
+      const logMessage = `User with email '${mail}' attempted to download a file without a matching BAP combo key.`;
+      log({ level: "error", message: logMessage, req });
+
+      const errorStatus = 401;
+      const errorMessage = `Unauthorized.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     }
 
     axiosFormio(req)
-      .get(`${formioApplicationFormUrl}/storage/s3`, { params: req.query })
+      .get(`${formioApplicationFormUrl}/storage/s3`, { params: query })
       .then((axiosRes) => axiosRes.data)
       .then((fileMetadata) => res.json(fileMetadata))
       .catch((error) => {
-        const message = `Error downloading file from S3`;
-        return res.status(error?.response?.status || 500).json({ message });
+        const errorStatus = error.response?.status || 500;
+        const errorMessage = `Error downloading file from S3.`;
+        return res.status(errorStatus).json({ message: errorMessage });
       });
   }
 );
@@ -226,23 +259,29 @@ router.post(
   "/s3/:formType/:mongoId/:comboKey/storage/s3",
   storeBapComboKeys,
   (req, res) => {
+    const { bapComboKeys, body } = req;
+    const { mail } = req.user;
     const { formType, mongoId, comboKey } = req.params;
 
     checkFormSubmissionPeriodAndBapStatus({ formType, mongoId, comboKey, req })
       .then(() => {
-        if (!req.bapComboKeys.includes(comboKey)) {
-          const message = `User with email ${req.user.mail} attempted to upload a file without a matching BAP combo key`;
-          log({ level: "error", message, req });
-          return res.status(401).json({ message: "Unauthorized" });
+        if (!bapComboKeys.includes(comboKey)) {
+          const logMessage = `User with email '${mail}' attempted to upload a file without a matching BAP combo key.`;
+          log({ level: "error", message: logMessage, req });
+
+          const errorStatus = 401;
+          const errorMessage = `Unauthorized.`;
+          return res.status(errorStatus).json({ message: errorMessage });
         }
 
         axiosFormio(req)
-          .post(`${formioApplicationFormUrl}/storage/s3`, req.body)
+          .post(`${formioApplicationFormUrl}/storage/s3`, body)
           .then((axiosRes) => axiosRes.data)
           .then((fileMetadata) => res.json(fileMetadata))
           .catch((error) => {
-            const message = `Error uploading file to S3`;
-            return res.status(error?.response?.status || 500).json({ message });
+            const errorStatus = error.response?.status || 500;
+            const errorMessage = `Error uploading file to S3.`;
+            return res.status(errorStatus).json({ message: errorMessage });
           });
       })
       .catch((error) => {
@@ -254,68 +293,79 @@ router.post(
             : formType === "close-out"
             ? "CSB Close Out"
             : "CSB";
-        const message = `${formName} form enrollment period is closed`;
-        return res.status(400).json({ message });
+
+        const errorStatus = 400;
+        const errorMessage = `${formName} form enrollment period is closed.`;
+        return res.status(errorStatus).json({ message: errorMessage });
       });
   }
 );
 
 // --- get user's Application form submissions from Formio
 router.get("/formio-application-submissions", storeBapComboKeys, (req, res) => {
-  // NOTE: Helpdesk users might not have any SAM.gov records associated with
-  // their email address so we should not return any submissions to those users.
-  // The only reason we explicitly need to do this is because there could be
-  // some submissions without `bap_hidden_entity_combo_key` field values in the
-  // Formio database – that will never be the case for submissions created from
-  // this app, but there could be submissions created externally if someone is
-  // testing posting data (e.g. from a REST client, or the Formio Viewer)
-  if (req.bapComboKeys.length === 0) return res.json([]);
+  const { bapComboKeys } = req;
+
+  /**
+   * NOTE: Helpdesk users might not have any SAM.gov records associated with
+   * their email address so we should not return any submissions to those users.
+   * The only reason we explicitly need to do this is because there could be
+   * some submissions without `bap_hidden_entity_combo_key` field values in the
+   * Formio database – that will never be the case for submissions created from
+   * this app, but there could be submissions created externally if someone is
+   * testing posting data (e.g. from a REST client, or the Formio Viewer).
+   */
+  if (bapComboKeys.length === 0) return res.json([]);
 
   const userSubmissionsUrl =
     `${formioApplicationFormUrl}/submission` +
     `?sort=-modified` +
     `&limit=1000000` +
     `&data.bap_hidden_entity_combo_key=` +
-    `${req.bapComboKeys.join("&data.bap_hidden_entity_combo_key=")}`;
+    `${bapComboKeys.join("&data.bap_hidden_entity_combo_key=")}`;
 
   axiosFormio(req)
     .get(userSubmissionsUrl)
     .then((axiosRes) => axiosRes.data)
     .then((submissions) => res.json(submissions))
     .catch((error) => {
-      const message = `Error getting Formio Application form submissions`;
-      return res.status(error?.response?.status || 500).json({ message });
+      const errorStatus = error.response?.status || 500;
+      const errorMessage = `Error getting Formio Application form submissions.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     });
 });
 
 // --- post a new Application form submission to Formio
 router.post("/formio-application-submission", storeBapComboKeys, (req, res) => {
-  const comboKey = req.body.data?.bap_hidden_entity_combo_key;
+  const { bapComboKeys, body } = req;
+  const { mail } = req.user;
+  const comboKey = body.data?.bap_hidden_entity_combo_key;
 
   if (!applicationFormOpen) {
-    const message = `CSB Application form enrollment period is closed`;
-    return res.status(400).json({ message });
+    const errorStatus = 400;
+    const errorMessage = `CSB Application form enrollment period is closed.`;
+    return res.status(errorStatus).json({ message: errorMessage });
   }
 
-  // verify post data includes one of user's BAP combo keys
-  if (!req.bapComboKeys.includes(comboKey)) {
-    const message = `User with email ${req.user.mail} attempted to post a new Application form submission without a matching BAP combo key`;
-    log({ level: "error", message, req });
-    return res.status(401).json({ message: "Unauthorized" });
+  if (!bapComboKeys.includes(comboKey)) {
+    const logMessage = `User with email '${mail}' attempted to post a new Application form submission without a matching BAP combo key.`;
+    log({ level: "error", message: logMessage, req });
+
+    const errorStatus = 401;
+    const errorMessage = `Unauthorized.`;
+    return res.status(errorStatus).json({ message: errorMessage });
   }
 
-  // add custom metadata to track formio submissions from wrapper
-  req.body.metadata = {
-    ...formioCsbMetadata,
-  };
+  /** Add custom metadata to track formio submissions from wrapper. */
+  body.metadata = { ...formioCsbMetadata };
 
   axiosFormio(req)
-    .post(`${formioApplicationFormUrl}/submission`, req.body)
+    .post(`${formioApplicationFormUrl}/submission`, body)
     .then((axiosRes) => axiosRes.data)
     .then((submission) => res.json(submission))
     .catch((error) => {
-      const message = `Error posting Formio Application form submission`;
-      return res.status(error?.response?.status || 500).json({ message });
+      const errorStatus = error.response?.status || 500;
+      const errorMessage = `Error posting Formio Application form submission.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     });
 });
 
@@ -325,6 +375,8 @@ router.get(
   verifyMongoObjectId,
   storeBapComboKeys,
   (req, res) => {
+    const { bapComboKeys } = req;
+    const { mail } = req.user;
     const { mongoId } = req.params;
 
     Promise.all([
@@ -335,9 +387,10 @@ router.get(
       .then(([submission, schema]) => {
         const comboKey = submission.data.bap_hidden_entity_combo_key;
 
-        if (!req.bapComboKeys.includes(comboKey)) {
-          const message = `User with email ${req.user.mail} attempted to access Application form submission ${mongoId} that they do not have access to.`;
-          log({ level: "warn", message, req });
+        if (!bapComboKeys.includes(comboKey)) {
+          const logMessage = `User with email '${mail}' attempted to access Application form submission '${mongoId}' that they do not have access to.`;
+          log({ level: "warn", message: logMessage, req });
+
           return res.json({
             userAccess: false,
             formSchema: null,
@@ -352,8 +405,9 @@ router.get(
         });
       })
       .catch((error) => {
-        const message = `Error getting Formio Application form submission ${mongoId}`;
-        res.status(error?.response?.status || 500).json({ message });
+        const errorStatus = error.response?.status || 500;
+        const errorMessage = `Error getting Formio Application form submission ${mongoId}.`;
+        res.status(errorStatus).json({ message: errorMessage });
       });
   }
 );

--- a/app/server/app/routes/auth.js
+++ b/app/server/app/routes/auth.js
@@ -5,10 +5,14 @@ const { ensureAuthenticated } = require("../middleware");
 const { createJWT, jwtCookieName } = require("../utilities/createJwt");
 const log = require("../utilities/logger");
 
+const { CLIENT_URL, SERVER_URL, SAML_PUBLIC_KEY } = process.env;
+
 const router = express.Router();
 
-// For redirects below, set const for base url (SERVER_URL is needed as fallback when using sub path, e.g. /csb)
-const baseUrl = process.env.CLIENT_URL || process.env.SERVER_URL;
+/**
+ * NOTE: SERVER_URL is needed as fallback when using sub path, e.g. /csb
+ */
+const baseUrl = CLIENT_URL || SERVER_URL;
 
 router.get(
   "/login",
@@ -26,81 +30,82 @@ router.post(
     session: false,
   }),
   (req, res) => {
-    // Create JWT, set as cookie, then redirect to client
-    // Note: nameID and nameIDFormat are required to send with logout request
+    const { body } = req;
+    const { attributes } = req.user;
+    const userGroups = attributes.memberof || "no";
+
+    /**
+     * Create JWT, set as cookie, then redirect to client.
+     * NOTE: nameID and nameIDFormat are required to send with logout request.
+     */
+
     const token = createJWT({
       ...req.user,
-      ...req.user.attributes,
+      ...attributes,
     });
+
     res.cookie(jwtCookieName, token, {
       httpOnly: true,
       sameSite: "lax",
       secure: true,
     });
 
-    // If user has Admin or Helpdesk role, log to INFO
-    log({
-      level: "info",
-      message: `User with email ${req.user.attributes.mail} and member of ${
-        req.user.attributes.memberof || "no"
-      } groups logged in.`,
-      req,
-    });
+    const logMessage = `User with email '${attributes.mail}' and member of ${userGroups} groups logged in.`;
+    log({ level: "info", message: logMessage, req });
 
-    // "RelayState" will be the path that the user initially tried to access before being sent to /login
-    res.redirect(`${baseUrl}${req.body.RelayState || "/"}`);
+    /**
+     * "RelayState" will be the path that the user initially tried to access
+     * before being sent to /login
+     */
+    res.redirect(`${baseUrl}${body.RelayState || "/"}`);
   }
 );
 
 router.get("/login/fail", (req, res) => {
-  log({
-    level: "error",
-    message: "SAML Error - Login failed",
-    req,
-  });
+  const logMessage = `SAML Error - Login failed.`;
+  log({ level: "error", message: logMessage, req });
+
   res.redirect(`${baseUrl}/welcome?error=saml`);
 });
 
 router.get("/logout", ensureAuthenticated, (req, res) => {
   samlStrategy.logout(req, function (err, requestUrl) {
     if (err) {
-      log({
-        level: "error",
-        message: `SAML Error - Passport logout failed - ${err}`,
-        req,
-      });
+      const logMessage = `SAML Error - Passport logout failed - ${err}`;
+      log({ level: "error", message: logMessage, req });
+
       res.redirect(`${baseUrl}/`);
     } else {
-      // Send request to SAML logout url
+      /** Send request to SAML logout url. */
       res.redirect(requestUrl);
     }
   });
 });
 
 const logoutCallback = (req, res) => {
-  // Clear token cookie so client no longer passes JWT after logout
+  /** Clear token cookie so client no longer passes JWT after logout. */
   res.clearCookie(jwtCookieName);
 
-  // If "RelayState" was passed in original logout request (either querystring or post body), redirect to below
-  const RelayState = req.query?.RelayState || req.body?.RelayState;
-  res.redirect(`${baseUrl}${RelayState || "/welcome?success=logout"}`);
+  /**
+   * If "RelayState" was passed in original logout request (either querystring
+   * or post body), redirect to below.
+   */
+  const relayState = req.query?.RelayState || req.body?.RelayState;
+  res.redirect(`${baseUrl}${relayState || "/welcome?success=logout"}`);
 };
 
-// Local saml config sends GET for logout callback, while EPA config sends POST. Handle both
+/**
+ * Local SAML config sends GET for logout callback, while EPA config sends POST.
+ */
 router.get("/logout/callback", logoutCallback);
 router.post("/logout/callback", logoutCallback);
 
-// Return SAML metadata
+/** Return SAML metadata. */
 router.get("/metadata", (req, res) => {
   res.type("application/xml");
   res
     .status(200)
-    .send(
-      samlStrategy.generateServiceProviderMetadata(
-        null,
-        process.env.SAML_PUBLIC_KEY
-      )
-    );
+    .send(samlStrategy.generateServiceProviderMetadata(null, SAML_PUBLIC_KEY));
 });
 
 module.exports = router;

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -11,14 +11,19 @@ const {
 const { ensureAuthenticated, ensureHelpdesk } = require("../middleware");
 const log = require("../utilities/logger");
 
-const applicationFormOpen = process.env.CSB_APPLICATION_FORM_OPEN === "true";
-const paymentRequestFormOpen =
-  process.env.CSB_PAYMENT_REQUEST_FORM_OPEN === "true";
-const closeOutFormOpen = process.env.CSB_CLOSE_OUT_FORM_OPEN === "true";
+const {
+  CSB_APPLICATION_FORM_OPEN,
+  CSB_PAYMENT_REQUEST_FORM_OPEN,
+  CSB_CLOSE_OUT_FORM_OPEN,
+} = process.env;
+
+const applicationFormOpen = CSB_APPLICATION_FORM_OPEN === "true";
+const paymentRequestFormOpen = CSB_PAYMENT_REQUEST_FORM_OPEN === "true";
+const closeOutFormOpen = CSB_CLOSE_OUT_FORM_OPEN === "true";
 
 const router = express.Router();
 
-// confirm user is both authenticated and authorized with valid helpdesk roles
+/** Confirm user is both authenticated and authorized with valid helpdesk roles. */
 router.use(ensureAuthenticated);
 router.use(ensureHelpdesk);
 
@@ -29,10 +34,11 @@ router.get("/formio-submission/:formType/:id", (req, res) => {
   if (formType === "application") {
     const mongoId = id;
 
-    // NOTE: verifyMongoObjectId middleware content:
+    /** NOTE: verifyMongoObjectId */
     if (mongoId && !ObjectId.isValid(mongoId)) {
-      const message = `MongoDB ObjectId validation error for: ${mongoId}`;
-      return res.status(400).json({ message });
+      const errorStatus = 400;
+      const errorMessage = `MongoDB ObjectId validation error for: '${mongoId}'.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     }
 
     Promise.all([
@@ -47,8 +53,9 @@ router.get("/formio-submission/:formType/:id", (req, res) => {
         });
       })
       .catch((error) => {
-        const message = `Error getting Formio Application form submission ${mongoId}`;
-        return res.status(error?.response?.status || 500).json({ message });
+        const errorStatus = error.response?.status || 500;
+        const errorMessage = `Error getting Formio Application form submission '${mongoId}'.`;
+        return res.status(errorStatus).json({ message: errorMessage });
       });
   }
 
@@ -68,18 +75,21 @@ router.get("/formio-submission/:formType/:id", (req, res) => {
       .then(([submissions, schema]) => {
         const mongoId = submissions[0]._id;
 
-        // NOTE: verifyMongoObjectId middleware content:
+        /** NOTE: verifyMongoObjectId */
         if (mongoId && !ObjectId.isValid(mongoId)) {
-          const message = `MongoDB ObjectId validation error for: ${mongoId}`;
-          return res.status(400).json({ message });
+          const errorStatus = 400;
+          const errorMessage = `MongoDB ObjectId validation error for: '${mongoId}'.`;
+          return res.status(errorStatus).json({ message: errorMessage });
         }
 
-        // NOTE: We can't just use the returned submission data here because
-        // Formio returns the string literal 'YES' instead of a base64 encoded
-        // image string for signature fields when you query for all submissions
-        // matching on a field's value (`/submission?data.hidden_bap_rebate_id=${rebateId}`).
-        // We need to query for a specific submission (e.g. `/submission/${mongoId}`),
-        // to have Formio return the correct signature field data.
+        /**
+         * NOTE: We can't just use the returned submission data here because
+         * Formio returns the string literal 'YES' instead of a base64 encoded
+         * image string for signature fields when you query for all submissions
+         * matching on a field's value (`/submission?data.hidden_bap_rebate_id=${rebateId}`).
+         * We need to query for a specific submission (e.g. `/submission/${mongoId}`),
+         * to have Formio return the correct signature field data.
+         */
         axiosFormio(req)
           .get(`${formioPaymentRequestFormUrl}/submission/${mongoId}`)
           .then((axiosRes) => axiosRes.data)
@@ -91,8 +101,9 @@ router.get("/formio-submission/:formType/:id", (req, res) => {
           });
       })
       .catch((error) => {
-        const message = `Error getting Formio Payment Request form submission ${rebateId}`;
-        res.status(error?.response?.status || 500).json({ message });
+        const errorStatus = error.response?.status || 500;
+        const errorMessage = `Error getting Formio Payment Request form submission '${rebateId}'.`;
+        res.status(errorStatus).json({ message: errorMessage });
       });
   }
 
@@ -108,16 +119,18 @@ router.post("/formio-submission/:formType/:id", (req, res) => {
 
   if (formType === "application") {
     if (!applicationFormOpen) {
-      const message = `CSB Application form enrollment period is closed`;
-      return res.status(400).json({ message });
+      const errorStatus = 400;
+      const errorMessage = `CSB Application form enrollment period is closed.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     }
 
     const mongoId = id;
 
-    // NOTE: verifyMongoObjectId middleware content:
+    /** NOTE: verifyMongoObjectId */
     if (mongoId && !ObjectId.isValid(mongoId)) {
-      const message = `MongoDB ObjectId validation error for: ${mongoId}`;
-      return res.status(400).json({ message });
+      const errorStatus = 400;
+      const errorMessage = `MongoDB ObjectId validation error for: '${mongoId}'.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     }
 
     Promise.all([
@@ -134,8 +147,8 @@ router.post("/formio-submission/:formType/:id", (req, res) => {
           })
           .then((axiosRes) => axiosRes.data)
           .then((updatedSubmission) => {
-            const message = `User with email ${mail} updated Application form submission ${mongoId} from submitted to draft.`;
-            log({ level: "info", message, req });
+            const logMessage = `User with email '${mail}' updated Application form submission '${mongoId}' from submitted to draft.`;
+            log({ level: "info", message: logMessage, req });
 
             return res.json({
               formSchema: { url: formioApplicationFormUrl, json: schema },
@@ -144,15 +157,17 @@ router.post("/formio-submission/:formType/:id", (req, res) => {
           });
       })
       .catch((error) => {
-        const message = `Error updating Formio Application form submission ${mongoId}`;
-        res.status(error?.response?.status || 500).json({ message });
+        const errorStatus = error.response?.status || 500;
+        const errorMessage = `Error updating Formio Application form submission '${mongoId}'.`;
+        res.status(errorStatus).json({ message: errorMessage });
       });
   }
 
   if (formType === "payment-request") {
     if (!paymentRequestFormOpen) {
-      const message = `CSB Payment Request form enrollment period is closed`;
-      return res.status(400).json({ message });
+      const errorStatus = 400;
+      const errorMessage = `CSB Payment Request form enrollment period is closed.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     }
 
     const rebateId = id;
@@ -170,10 +185,11 @@ router.post("/formio-submission/:formType/:id", (req, res) => {
         const submission = submissions[0];
         const mongoId = submission._id;
 
-        // NOTE: verifyMongoObjectId middleware content:
+        /** NOTE: verifyMongoObjectId */
         if (mongoId && !ObjectId.isValid(mongoId)) {
-          const message = `MongoDB ObjectId validation error for: ${mongoId}`;
-          return res.status(400).json({ message });
+          const errorStatus = 400;
+          const errorMessage = `MongoDB ObjectId validation error for: '${mongoId}'.`;
+          return res.status(errorStatus).json({ message: errorMessage });
         }
 
         axiosFormio(req)
@@ -184,8 +200,8 @@ router.post("/formio-submission/:formType/:id", (req, res) => {
           })
           .then((axiosRes) => axiosRes.data)
           .then((updatedSubmission) => {
-            const message = `User with email ${mail} updated Payment Request form submission ${rebateId} from submitted to draft.`;
-            log({ level: "info", message, req });
+            const logMessage = `User with email '${mail}' updated Payment Request form submission '${rebateId}' from submitted to draft.`;
+            log({ level: "info", message: logMessage, req });
 
             return res.json({
               formSchema: { url: formioPaymentRequestFormUrl, json: schema },
@@ -194,15 +210,17 @@ router.post("/formio-submission/:formType/:id", (req, res) => {
           });
       })
       .catch((error) => {
-        const message = `Error getting Formio Payment Request form submission ${rebateId}`;
-        res.status(error?.response?.status || 500).json({ message });
+        const errorStatus = error.response?.status || 500;
+        const errorMessage = `Error getting Formio Payment Request form submission '${rebateId}'.`;
+        res.status(errorStatus).json({ message: errorMessage });
       });
   }
 
   if (formType === "close-out") {
     if (!closeOutFormOpen) {
-      const message = `CSB Close Out form enrollment period is closed`;
-      return res.status(400).json({ message });
+      const errorStatus = 400;
+      const errorMessage = `CSB Close Out form enrollment period is closed.`;
+      return res.status(errorStatus).json({ message: errorMessage });
     }
 
     // TODO

--- a/app/server/app/routes/status.js
+++ b/app/server/app/routes/status.js
@@ -33,7 +33,10 @@ router.get("/formio-application-schema", (req, res) => {
     .get(formioApplicationFormUrl)
     .then((axiosRes) => axiosRes.data)
     .then((schema) => {
-      // Verify that schema has type of form and a title exists (confirming formio returned a valid schema)
+      /**
+       * Verify that schema has type of form and a title exists
+       * (confirming Formio returned a valid schema).
+       */
       return res.json({ status: schema.type === "form" && !!schema.title });
     })
     .catch(() => {
@@ -46,7 +49,26 @@ router.get("/formio-payment-request-schema", (req, res) => {
     .get(formioPaymentRequestFormUrl)
     .then((axiosRes) => axiosRes.data)
     .then((schema) => {
-      // Verify that schema has type of form and a title exists (confirming formio returned a valid schema)
+      /**
+       * Verify that schema has type of form and a title exists
+       * (confirming Formio returned a valid schema).
+       */
+      return res.json({ status: schema.type === "form" && !!schema.title });
+    })
+    .catch(() => {
+      return res.json({ status: false });
+    });
+});
+
+router.get("/formio-close-out-schema", (req, res) => {
+  axiosFormio(req)
+    .get(formioCloseOutFormUrl)
+    .then((axiosRes) => axiosRes.data)
+    .then((schema) => {
+      /**
+       * Verify that schema has type of form and a title exists
+       * (confirming Formio returned a valid schema).
+       */
       return res.json({ status: schema.type === "form" && !!schema.title });
     })
     .catch(() => {

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -609,7 +609,15 @@ async function queryBapForCloseOutData(
   const applicationRecordTypeId = applicationRecordTypeIdQuery["0"].Id;
 
   // `SELECT
+  //   Fleet_Name__c,
+  //   Fleet_Street_Address__c,
+  //   Fleet_City__c,
+  //   Fleet_State__c,
+  //   Fleet_Zip__c,
   //   Fleet_Contact_Name__c,
+  //   Fleet_Contact_Title__c,
+  //   Fleet_Contact_Phone__c,
+  //   Fleet_Contact_Email__c,
   //   School_District_Contact__r.FirstName,
   //   School_District_Contact__r.LastName
   // FROM
@@ -629,7 +637,15 @@ async function queryBapForCloseOutData(
       },
       {
         // "*": 1,
+        Fleet_Name__c: 1,
+        Fleet_Street_Address__c: 1,
+        Fleet_City__c: 1,
+        Fleet_State__c: 1,
+        Fleet_Zip__c: 1,
         Fleet_Contact_Name__c: 1,
+        Fleet_Contact_Title__c: 1,
+        Fleet_Contact_Phone__c: 1,
+        Fleet_Contact_Email__c: 1,
         "School_District_Contact__r.FirstName": 1,
         "School_District_Contact__r.LastName": 1,
       }
@@ -678,7 +694,6 @@ async function queryBapForCloseOutData(
   //   Alternate_Applicant__r.Email,
   //   Applicant_Organization__r.Name,
   //   CSB_School_District__r.Name,
-  //   Fleet_Name__c,
   //   School_District_Prioritized__c,
   //   Total_Rebate_Funds_Requested_PO__c,
   //   Total_Bus_And_Infrastructure_Rebate__c,
@@ -723,7 +738,6 @@ async function queryBapForCloseOutData(
         "Alternate_Applicant__r.Email": 1,
         "Applicant_Organization__r.Name": 1,
         "CSB_School_District__r.Name": 1,
-        Fleet_Name__c: 1,
         School_District_Prioritized__c: 1,
         Total_Rebate_Funds_Requested_PO__c: 1,
         Total_Bus_And_Infrastructure_Rebate__c: 1,

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -29,9 +29,10 @@ const log = require("../utilities/logger");
  * @property {string} PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c
  * @property {string} PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c
  * @property {string} PHYSICAL_ADDRESS_ZIP_CODE_4__c
- * @property {Object} attributes
- * @property {string} attributes.type
- * @property {string} attributes.url
+ * @property {{
+ *  type: string
+ *  url: string
+ * }} attributes
  */
 
 /**
@@ -42,13 +43,131 @@ const log = require("../utilities/logger");
  * @property {string} CSB_Review_Item_ID__c
  * @property {string} Parent_Rebate_ID__c
  * @property {string} Record_Type_Name__c
- * @property {Object} Parent_CSB_Rebate__r
- * @property {string} Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c
- * @property {string} Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c
- * @property {string} Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c
- * @property {Object} attributes
- * @property {string} attributes.type
- * @property {string} attributes.url
+ * @property {{
+ *  CSB_Funding_Request_Status__c: string
+ *  CSB_Payment_Request_Status__c: string
+ *  CSB_Closeout_Request_Status__c: string
+ * }} Parent_CSB_Rebate__r
+ * @property {{
+ *  type: string
+ *  url: string
+ * }} attributes
+ */
+
+/**
+ * @typedef {Object} BapDataForPaymentRequest
+ * @property {{
+ *  Id: string
+ *  UEI_EFTI_Combo_Key__c: string
+ *  CSB_NCES_ID__c: string
+ *  Primary_Applicant__r: {
+ *    Name: string
+ *    Title: string
+ *    Phone: string
+ *    Email: string
+ *  }
+ *  Alternate_Applicant__r: {
+ *    Name: string
+ *    Title: string
+ *    Phone: string
+ *    Email: string
+ *  } | null
+ *  Applicant_Organization__r: {
+ *    Name: string
+ *  }
+ *  CSB_School_District__r: {
+ *    Name: string
+ *  }
+ *  Fleet_Name__c: string
+ *  School_District_Prioritized__c: string
+ *  Total_Rebate_Funds_Requested__c: string
+ *  Total_Infrastructure_Funds__c: string
+ * }[]} applicationRecordQuery
+ * @property {{
+ *  Rebate_Item_num__c: string
+ *  CSB_VIN__c: string
+ *  CSB_Model_Year__c: string
+ *  CSB_Fuel_Type__c: string
+ *  CSB_Replacement_Fuel_Type__c: string
+ *  CSB_Funds_Requested__c: string
+ * }[]} busRecordsQuery
+ * @property {{
+ *  type: string
+ *  url: string
+ * }} attributes
+ */
+
+/**
+ * @typedef {Object} BapDataForForCloseOut
+ * @property {{
+ *  Fleet_Contact_Name__c: string
+ *  School_District_Contact__r: {
+ *    FirstName: string
+ *    LastName: string
+ *  }
+ * }[]} applicationRecordQuery
+ * @property {{
+ *  Id: string
+ *  UEI_EFTI_Combo_Key__c: string
+ *  CSB_NCES_ID__c: string
+ *  Primary_Applicant__r: {
+ *    FirstName: string
+ *    LastName: string
+ *    Title: string
+ *    Phone: string
+ *    Email: string
+ *  }
+ *  Alternate_Applicant__r: {
+ *    FirstName: string
+ *    LastName: string
+ *    Title: string
+ *    Phone: string
+ *    Email: string
+ *  } | null
+ *  Applicant_Organization__r: {
+ *    Name: string
+ *  }
+ *  CSB_School_District__r: {
+ *    Name: string
+ *  }
+ *  Fleet_Name__c: string
+ *  School_District_Prioritized__c: string
+ *  Total_Rebate_Funds_Requested_PO__c: string
+ *  Total_Bus_And_Infrastructure_Rebate__c: string
+ *  Total_Infrastructure_Funds__c: string
+ *  Num_Of_Buses_Requested_From_Application__c: string
+ *  Total_Price_All_Buses__c: string
+ *  Total_Bus_Rebate_Amount__c: string
+ *  Total_All_Eligible_Infrastructure_Costs__c: string
+ *  Total_Infrastructure_Rebate__c: string
+ *  Total_Level_2_Charger_Costs__c: string
+ *  Total_DC_Fast_Charger_Costs__c: string
+ *  Total_Other_Infrastructure_Costs__c: string
+ * }[]} paymentRequestRecordQuery
+ * @property {{
+ *  Rebate_Item_num__c: string
+ *  CSB_VIN__c: string
+ *  CSB_Model_Year__c: string
+ *  CSB_Fuel_Type__c: string
+ *  CSB_Manufacturer_if_Other__c: string
+ *  Old_Bus_NCES_District_ID__c: string
+ *  Old_Bus_Estimated_Remaining_Life__c: string
+ *  Old_Bus_Exclude__c: string
+ *  Related_Line_Item__r: {
+ *    Purchaser_Name__c: string
+ *  }
+ *  New_Bus_Fuel_Type__c: string
+ *  New_Bus_Make__c: string
+ *  New_Bus_Model__c: string
+ *  New_Bus_Model_Year__c: string
+ *  New_Bus_GVWR__c: string
+ *  New_Bus_Rebate_Amount__c: string
+ *  New_Bus_Purchase_Price__c: string
+ * }[]} busRecordsQuery
+ * @property {{
+ *  type: string
+ *  url: string
+ * }} attributes
  */
 
 const {
@@ -280,7 +399,7 @@ async function queryForBapFormSubmissionsStatuses(req, comboKeys) {
  *
  * @param {express.Request} req
  * @param {string} applicationReviewItemId CSB Rebate ID with the form/version ID (9 digits)
- * @returns {Promise<Object>} Application form submission fields
+ * @returns {Promise<BapDataForPaymentRequest>} Application form submission fields
  */
 async function queryBapForPaymentRequestData(req, applicationReviewItemId) {
   const logMessage =
@@ -446,7 +565,7 @@ async function queryBapForPaymentRequestData(req, applicationReviewItemId) {
  * @param {express.Request} req
  * @param {string} applicationReviewItemId CSB Rebate ID with the form/version ID (9 digits)
  * @param {string} paymentRequestReviewItemId CSB Rebate ID with the form/version ID (9 digits)
- * @returns {Promise<Object>} Payment Request form submission fields
+ * @returns {Promise<BapDataForForCloseOut>} Application form and Payment Request form submission fields
  */
 async function queryBapForCloseOutData(
   req,
@@ -711,9 +830,9 @@ async function queryBapForCloseOutData(
  * function with the provided arguments.
  *
  * @param {express.Request} req
- * @param {Object} callback callback function name and arguments to call after BAP connection has been verified
- * @param {function} callback.name name of the callback function
- * @param {any[]} callback.args arguments to pass to the callback function
+ * @param {Object} fn callback function name and arguments to call after BAP connection has been verified
+ * @param {function} fn.name name of the callback function
+ * @param {any[]} fn.args arguments to pass to the callback function
  */
 function verifyBapConnection(req, { name, args }) {
   /** @type {jsforce.Connection} */
@@ -752,6 +871,7 @@ function verifyBapConnection(req, { name, args }) {
  *
  * @param {express.Request} req
  * @param {string} email
+ * @returns {ReturnType<queryForSamEntities>}
  */
 function getSamEntities(req, email) {
   return verifyBapConnection(req, {
@@ -793,6 +913,7 @@ function getBapFormSubmissionsStatuses(req, comboKeys) {
  *
  * @param {express.Request} req
  * @param {string} applicationReviewItemId
+ * @returns {ReturnType<queryBapForPaymentRequestData>}
  */
 function getBapDataForPaymentRequest(req, applicationReviewItemId) {
   return verifyBapConnection(req, {
@@ -809,6 +930,7 @@ function getBapDataForPaymentRequest(req, applicationReviewItemId) {
  * @param {express.Request} req
  * @param {string} applicationReviewItemId
  * @param {string} paymentRequestReviewItemId
+ * @returns {ReturnType<queryBapForCloseOutData>}
  */
 function getBapDataForCloseOut(
   req,

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -100,7 +100,15 @@ const log = require("../utilities/logger");
 /**
  * @typedef {Object} BapDataForForCloseOut
  * @property {{
+ *  Fleet_Name__c: string
+ *  Fleet_Street_Address__c: string
+ *  Fleet_City__c: string
+ *  Fleet_State__c: string
+ *  Fleet_Zip__c: string
  *  Fleet_Contact_Name__c: string
+ *  Fleet_Contact_Title__c: string
+ *  Fleet_Contact_Phone__c: string
+ *  Fleet_Contact_Email__c: string
  *  School_District_Contact__r: {
  *    FirstName: string
  *    LastName: string
@@ -130,7 +138,6 @@ const log = require("../utilities/logger");
  *  CSB_School_District__r: {
  *    Name: string
  *  }
- *  Fleet_Name__c: string
  *  School_District_Prioritized__c: string
  *  Total_Rebate_Funds_Requested_PO__c: string
  *  Total_Bus_And_Infrastructure_Rebate__c: string

--- a/app/server/app/utilities/createJwt.js
+++ b/app/server/app/utilities/createJwt.js
@@ -1,23 +1,25 @@
 const jwt = require("jsonwebtoken");
-const jwtAlgorithm = process.env.NODE_ENV === "development" ? "HS256" : "RS256";
 
-const createJwt = (userObject) => {
-  return jwt.sign(
-    {
-      mail: userObject.mail,
-      memberof: userObject.memberof || "",
-      nameID: userObject.nameID,
-      nameIDFormat: userObject.nameIDFormat,
-      nameQualifier: userObject.nameQualifier,
-      spNameQualifier: userObject.spNameQualifier,
-      sessionIndex: userObject.sessionIndex,
-    },
-    process.env.JWT_PRIVATE_KEY,
-    {
-      algorithm: jwtAlgorithm,
-      expiresIn: process.env.JWT_EXPIRE || "15m",
-    }
-  );
-};
+const { NODE_ENV, JWT_PRIVATE_KEY, JWT_EXPIRE } = process.env;
 
-module.exports = { createJwt, jwtAlgorithm };
+const jwtAlgorithm = NODE_ENV === "development" ? "HS256" : "RS256";
+const jwtCookieName = "csb-token";
+
+function createJWT(userData) {
+  const payload = {
+    mail: userData.mail,
+    memberof: userData.memberof || "",
+    nameID: userData.nameID,
+    nameIDFormat: userData.nameIDFormat,
+    nameQualifier: userData.nameQualifier,
+    spNameQualifier: userData.spNameQualifier,
+    sessionIndex: userData.sessionIndex,
+  };
+
+  return jwt.sign(payload, JWT_PRIVATE_KEY, {
+    algorithm: jwtAlgorithm,
+    expiresIn: JWT_EXPIRE || "15m",
+  });
+}
+
+module.exports = { createJWT, jwtAlgorithm, jwtCookieName };

--- a/app/server/app/utilities/errorHandler.js
+++ b/app/server/app/utilities/errorHandler.js
@@ -18,10 +18,9 @@ function errorHandler(err, req, res, next) {
 
   /** For API errors, return error message in JSON format */
   if (req.originalUrl.includes("/api")) {
+    const errorStatus = err?.response?.status || 500;
     const errorMessage = `An unknown server error occurred. Please try again or contact support.`;
-    return res
-      .status(err?.response?.status || 500)
-      .json({ message: errorMessage });
+    return res.status(errorStatus).json({ message: errorMessage });
   }
 
   /** For non-login non-API errors, redirect back to base route */

--- a/app/server/app/utilities/errorHandler.js
+++ b/app/server/app/utilities/errorHandler.js
@@ -1,23 +1,31 @@
 const log = require("./logger");
 
-const errorHandler = (err, req, res, next) => {
-  const message = typeof err.toString === "function" ? err.toString() : err;
-  log({ level: "error", message, req });
-  // If user was trying to log in and an error occurred, return them back to front-end login page to display a message
+const { CLIENT_URL, SERVER_URL } = process.env;
+
+function errorHandler(err, req, res, next) {
+  const logMessage = typeof err.toString === "function" ? err.toString() : err;
+  log({ level: "error", message: logMessage, req });
+
+  const url = CLIENT_URL || SERVER_URL;
+
+  /**
+   * If user was trying to log in and an error occurred, return them back to
+   * login page to display a message.
+   */
   if (req.originalUrl.includes("/login")) {
-    return res.redirect(
-      `${process.env.CLIENT_URL || process.env.SERVER_URL}/welcome?error=saml`
-    );
+    return res.redirect(`${url}/welcome?error=saml`);
   }
-  // For API errors, return error message in JSON format
+
+  /** For API errors, return error message in JSON format */
   if (req.originalUrl.includes("/api")) {
-    return res.status(err?.response?.status || 500).json({
-      message:
-        "An unknown server error occurred. Please try again or contact support.",
-    });
+    const errorMessage = `An unknown server error occurred. Please try again or contact support.`;
+    return res
+      .status(err?.response?.status || 500)
+      .json({ message: errorMessage });
   }
-  // For non-login non-API errors, redirect back to front-end base route
-  return res.redirect(`${process.env.CLIENT_URL || process.env.SERVER_URL}/`);
-};
+
+  /** For non-login non-API errors, redirect back to base route */
+  return res.redirect(`${url}/`);
+}
 
 module.exports = errorHandler;

--- a/app/server/app/utilities/logger.js
+++ b/app/server/app/utilities/logger.js
@@ -1,4 +1,7 @@
 const log4js = require("log4js");
+const express = require("express");
+
+const { LOGGER_LEVEL } = process.env;
 
 log4js.configure({
   appenders: {
@@ -24,39 +27,38 @@ log4js.configure({
 
 const logger = log4js.getLogger();
 
-if (process.env.LOGGER_LEVEL)
-  logger.level = process.env.LOGGER_LEVEL.toUpperCase();
-else logger.level = "INFO"; //default level
+logger.level = LOGGER_LEVEL ? LOGGER_LEVEL.toUpperCase() : "INFO";
+logger.info(`LOGGER_LEVEL = ${logger.level}`);
 
-logger.info("LOGGER_LEVEL = " + logger.level);
-
-const log = ({ level, message, req, otherInfo }) => {
-  if (!req) {
-    // If request is not passed, log as normal message without metadata
-    logger.log(level, message);
-  } else {
-    // Log as JSON object with message and metadata (build metadata using request object)
-    logger.log(
-      level,
-      JSON.stringify({
-        app_metadata: populateMetadataObjFromRequest(req),
+/**
+ * @param {{
+ *  level: 'debug' | 'info' | 'warn' | 'error',
+ *  message: string,
+ *  req: ?express.Request,
+ *  otherInfo: any
+ * }} options
+ */
+function log({ level, message, req, otherInfo }) {
+  /**
+   * If a request is not passed, log as normal message without metadata, else
+   * log as JSON object with message and metadata for logging/auditing purposes.
+   *
+   * See: https://docs.cloudfoundry.org/concepts/http-routing.html#http-headers
+   */
+  const data = !req
+    ? message
+    : JSON.stringify({
+        app_metadata: {
+          b3: req.headers["b3"],
+          x_b3_traceid: req.headers["x-b3-traceid"],
+          x_b3_spanid: req.headers["x-b3-spanid"],
+          x_b3_parentspanid: req.headers["x-b3-parentspanid"],
+        },
         app_message: message,
         app_otherinfo: otherInfo,
-      })
-    );
-  }
-};
+      });
 
-// We use this function to pull out important HTTP information from the
-// request for logging/auditing purposes.
-// See https://docs.cloudfoundry.org/concepts/http-routing.html#http-headers
-const populateMetadataObjFromRequest = function (request) {
-  return {
-    b3: request.headers["b3"],
-    x_b3_traceid: request.headers["x-b3-traceid"],
-    x_b3_spanid: request.headers["x-b3-spanid"],
-    x_b3_parentspanid: request.headers["x-b3-parentspanid"],
-  };
-};
+  logger.log(level, data);
+}
 
 module.exports = log;


### PR DESCRIPTION
## Related Issues:
* CSBAPP-1

## Main Changes:
* Updates client app's data fetching to returned JSON in error responses.
* Updates server app to consistently set error status codes and messages (should make updating error status codes and/or messages easier).
* Updates server app's logging messages to also be consistent (should make updates to logged messages easier).
* Adds a new `/status/formio-close-out-schema` route for checking Formio uptime for the close out form.

## Steps To Test:
1. Test app normally. If an API endpoint returns an error, you should now see JSON data being returned to the client app along with the error status code (NOTE: error JSON data is only accessible via the browser's Dev Tools Network tab – we still provide/handle error messages manually in the client app).
