### PR TITLE
Feature/fix cof submission data

### DIFF
--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -922,7 +922,7 @@ router.post("/formio-close-out-submission", storeBapComboKeys, (req, res) => {
           oldBusEstimatedRemainingLife: record.Old_Bus_Estimated_Remaining_Life__c, // prettier-ignore
           oldBusExclude: record.Old_Bus_Exclude__c,
           hidden_prf_oldBusExclude: record.Old_Bus_Exclude__c,
-          newBusDealer: record.Related_Line_Item__r.Vendor_Name__c,
+          newBusDealer: record.Related_Line_Item__r?.Vendor_Name__c,
           newBusFuelType: record.New_Bus_Fuel_Type__c,
           hidden_prf_newBusFuelType: record.New_Bus_Fuel_Type__c,
           newBusMake: record.New_Bus_Make__c,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-5

## Main Changes:
Update BAP query field newBusDealer uses (`Related_Line_item__r.Vendor…_Name__c`) to use optional chaining operator, so `busInfo` is properly set when the `Vendor_Name__c` field doesn't exist in the `Related_Line_Item__r` object (which will happen when that value is null)

## Steps To Test:
1. Click the "New Close Out" button, and it should work (no longer will error out if there's no vendor name for one of the buses).
