### PR TITLE
Feature/update cof internal statuses

### DIFF
--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -650,12 +650,12 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
   const closeOutNeedsClarification =
     closeOut.bap?.status === "Needs Clarification";
 
-  const closeOutNotApproved = closeOut.bap?.status === "Coordinator Denied"; // TODO: confirm BAP status
+  const closeOutNotApproved = closeOut.bap?.status === "Branch Director Denied";
 
   const closeOutReimbursementNeeded =
-    closeOut.bap?.status === "Reimbursement Needed"; // TODO: confirm BAP status
+    closeOut.bap?.status === "Reimbursement Needed";
 
-  const closeOutApproved = closeOut.bap?.status === "Accepted"; // TODO: confirm BAP status
+  const closeOutApproved = closeOut.bap?.status === "Branch Director Approved";
 
   const statusTableCellClassNames =
     closeOut.formio.state === "submitted" || !closeOutFormOpen


### PR DESCRIPTION
## Related Issues:
* CSBAPP-5

## Main Changes:
Update Close Out form's internal statuses used to set external statuses, based on latest statuses in the RTM.

## Steps To Test:
1. Work with the BAP team to set internal BAP statuses of different Close Out form submissions, and confirm the wrapper app displays the external status correctly.
