### PR TITLE
Feature/resolve todos

### DIFF
--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -55,6 +55,9 @@ export const messages = {
   bapSamFetchError: "Error loading SAM.gov data. Please contact support.",
   bapNoSamResults:
     "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
+  bapSamNotActive: "TODO", // TODO: error message for when SAM.gov entity is not active/has expired
+  formSubmissionError:
+    "The requested submission does not exist, or you do not have access. Please contact support if you believe this is a mistake.",
   formSubmissionsError: "Error loading form submissions.",
   newApplication:
     "Please select the “New Application” button above to create your first rebate application.",

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -192,8 +192,7 @@ function UserApplicationForm(props: { email: string }) {
   }
 
   if (query.isError || !userAccess || !formSchema || !submission) {
-    const text = `The requested submission does not exist, or you do not have access. Please contact support if you believe this is a mistake.`;
-    return <Message type="error" text={text} />;
+    return <Message type="error" text={messages.formSubmissionError} />;
   }
 
   const rebate = rebates.find((r) => r.application.formio._id === mongoId);
@@ -331,14 +330,17 @@ function UserApplicationForm(props: { email: string }) {
 
   /** matched SAM.gov entity for the Application submission */
   const entity = bapSamData.entities.find((entity) => {
-    return (
-      entity.ENTITY_STATUS__c === "Active" &&
-      entity.ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key
-    );
+    const { ENTITY_COMBO_KEY__c } = entity;
+    return ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key;
   });
 
-  // TODO: do we need to account for when ENTITY_STATUS__c does not equal "Active" (e.g. its expired)?
-  if (!entity) return null;
+  if (!entity) {
+    return <Message type="error" text={messages.formSubmissionError} />;
+  }
+
+  if (entity.ENTITY_STATUS__c !== "Active") {
+    return <Message type="error" text={messages.bapSamNotActive} />;
+  }
 
   const { title, name } = getUserInfo(email, entity);
 

--- a/app/client/src/routes/closeOutForm.tsx
+++ b/app/client/src/routes/closeOutForm.tsx
@@ -275,20 +275,6 @@ function UserCloseOutForm(props: { email: string }) {
           options={{
             readOnly: formIsReadOnly,
             noAlerts: true,
-            hooks: {
-              beforeSubmit: (submission: any, next: any) => {
-                /** Alter the submission as needed. */
-                // submission.data.email = "changed@test.com";
-
-                /** Only call next when we're ready to submit. */
-                next();
-              },
-            },
-          }}
-          formReady={(instance: any) => {
-            instance.on("pagesChanged", () => {
-              //
-            });
           }}
           onSubmit={(onSubmitSubmission: {
             data: { [field: string]: unknown };

--- a/app/client/src/routes/closeOutForm.tsx
+++ b/app/client/src/routes/closeOutForm.tsx
@@ -185,8 +185,7 @@ function UserCloseOutForm(props: { email: string }) {
   }
 
   if (query.isError || !userAccess || !formSchema || !submission) {
-    const text = `The requested submission does not exist, or you do not have access. Please contact support if you believe this is a mistake.`;
-    return <Message type="error" text={text} />;
+    return <Message type="error" text={messages.formSubmissionError} />;
   }
 
   const rebate = rebates.find((r) => r.rebateId === rebateId);
@@ -206,14 +205,17 @@ function UserCloseOutForm(props: { email: string }) {
 
   /** matched SAM.gov entity for the Close Out submission */
   const entity = bapSamData.entities.find((entity) => {
-    return (
-      entity.ENTITY_STATUS__c === "Active" &&
-      entity.ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key
-    );
+    const { ENTITY_COMBO_KEY__c } = entity;
+    return ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key;
   });
 
-  // TODO: do we need to account for when ENTITY_STATUS__c does not equal "Active" (e.g. its expired)?
-  if (!entity) return null;
+  if (!entity) {
+    return <Message type="error" text={messages.formSubmissionError} />;
+  }
+
+  if (entity.ENTITY_STATUS__c !== "Active") {
+    return <Message type="error" text={messages.bapSamNotActive} />;
+  }
 
   const { title, name } = getUserInfo(email, entity);
 
@@ -273,6 +275,20 @@ function UserCloseOutForm(props: { email: string }) {
           options={{
             readOnly: formIsReadOnly,
             noAlerts: true,
+            hooks: {
+              beforeSubmit: (submission: any, next: any) => {
+                /** Alter the submission as needed. */
+                // submission.data.email = "changed@test.com";
+
+                /** Only call next when we're ready to submit. */
+                next();
+              },
+            },
+          }}
+          formReady={(instance: any) => {
+            instance.on("pagesChanged", () => {
+              //
+            });
           }}
           onSubmit={(onSubmitSubmission: {
             data: { [field: string]: unknown };

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -319,6 +319,11 @@ export function Helpdesk() {
                     }
                   </td>
 
+                  {/*
+                    TODO: investigate removing the changing of a submission's
+                    formio status now that the BAP team's workflow is in place
+                  */}
+
                   <td>
                     <button
                       className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -144,7 +144,6 @@ export function Helpdesk() {
                 setFormType(ev.target.value as FormType);
                 queryClient.resetQueries({ queryKey: ["helpdesk"] });
               }}
-              disabled={true} // NOTE: disabled until the Close Out form is created
             />
             <label
               className="usa-radio__label mobile-lg:margin-top-0"
@@ -276,6 +275,8 @@ export function Helpdesk() {
                     <td>{submission._id}</td>
                   ) : formType === "payment-request" ? (
                     <td>{submission.data.hidden_bap_rebate_id as string}</td>
+                  ) : formType === "close-out" ? (
+                    <td>{submission.data.hidden_bap_rebate_id as string}</td>
                   ) : (
                     <td>&nbsp;</td>
                   )}
@@ -286,6 +287,8 @@ export function Helpdesk() {
                     </td>
                   ) : formType === "payment-request" ? (
                     <td>{submission.data.applicantName as string}</td>
+                  ) : formType === "close-out" ? (
+                    <td>{submission.data.signatureName as string}</td>
                   ) : (
                     <td>&nbsp;</td>
                   )}
@@ -293,6 +296,10 @@ export function Helpdesk() {
                   {formType === "application" ? (
                     <td>{submission.data.last_updated_by as string}</td>
                   ) : formType === "payment-request" ? (
+                    <td>
+                      {submission.data.hidden_current_user_email as string}
+                    </td>
+                  ) : formType === "close-out" ? (
                     <td>
                       {submission.data.hidden_current_user_email as string}
                     </td>

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -185,8 +185,7 @@ function UserPaymentRequestForm(props: { email: string }) {
   }
 
   if (query.isError || !userAccess || !formSchema || !submission) {
-    const text = `The requested submission does not exist, or you do not have access. Please contact support if you believe this is a mistake.`;
-    return <Message type="error" text={text} />;
+    return <Message type="error" text={messages.formSubmissionError} />;
   }
 
   const rebate = rebates.find((r) => r.rebateId === rebateId);
@@ -214,14 +213,17 @@ function UserPaymentRequestForm(props: { email: string }) {
 
   /** matched SAM.gov entity for the Payment Request submission */
   const entity = bapSamData.entities.find((entity) => {
-    return (
-      entity.ENTITY_STATUS__c === "Active" &&
-      entity.ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key
-    );
+    const { ENTITY_COMBO_KEY__c } = entity;
+    return ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key;
   });
 
-  // TODO: do we need to account for when ENTITY_STATUS__c does not equal "Active" (e.g. its expired)?
-  if (!entity) return null;
+  if (!entity) {
+    return <Message type="error" text={messages.formSubmissionError} />;
+  }
+
+  if (entity.ENTITY_STATUS__c !== "Active") {
+    return <Message type="error" text={messages.bapSamNotActive} />;
+  }
 
   const {
     UNIQUE_ENTITY_ID__c,

--- a/app/server/app/routes/auth.js
+++ b/app/server/app/routes/auth.js
@@ -69,6 +69,9 @@ router.get("/login/fail", (req, res) => {
 });
 
 router.get("/logout", ensureAuthenticated, (req, res) => {
+  const { mail, memberof } = req.user;
+  const userGroups = memberof || "no";
+
   samlStrategy.logout(req, function (err, requestUrl) {
     if (err) {
       const logMessage = `SAML Error - Passport logout failed - ${err}`;
@@ -76,6 +79,9 @@ router.get("/logout", ensureAuthenticated, (req, res) => {
 
       res.redirect(`${baseUrl}/`);
     } else {
+      const logMessage = `User with email '${mail}' and member of ${userGroups} groups logged out.`;
+      log({ level: "info", message: logMessage, req });
+
       /** Send request to SAML logout url. */
       res.redirect(requestUrl);
     }

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -348,9 +348,9 @@ async function queryForBapFormSubmissionsStatuses(req, comboKeys) {
     .sort({ CreatedDate: -1 })
     .execute(async (err, records) => ((await err) ? err : records));
 
-  const parentRebateIds = parentRebateIdsQuery.map((item) => {
-    return item.Parent_Rebate_ID__c;
-  });
+  const parentRebateIds = Array.isArray(parentRebateIdsQuery)
+    ? parentRebateIdsQuery.map((item) => item.Parent_Rebate_ID__c)
+    : [];
 
   if (parentRebateIds.length === 0) return [];
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-5

## Main Changes:
Resolves a few lingering TODO items, including updating the helpdesk functionality to support the new close out form, update the logic in one of the BAP queries to not crash when a large number of combo keys are passed (unlikely to happen in practice, but happening with the app scan), show message when a user's SAM.gov entity is inactive, and log a message when a user logs out of the application.

## Steps To Test:
1. Navigate to the helpdesk page, and ensure it supports searching for a close out form submission.

## TODO:
- [ ] Update the message shown when a user's SAM.gov entity is inactive.
