### PR TITLE
Feature/update sam gov inactive message

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -18,7 +18,12 @@ import "@formio/choices.js/public/assets/styles/choices.min.css";
 import "@formio/premium/dist/premium.css";
 import "formiojs/dist/formio.full.min.css";
 // ---
-import { serverBasePath, serverUrlForHrefs, cloudSpace } from "../config";
+import {
+  serverBasePath,
+  serverUrlForHrefs,
+  cloudSpace,
+  messages,
+} from "../config";
 import {
   useContentQuery,
   useContentData,
@@ -26,6 +31,7 @@ import {
   useUserData,
 } from "../utilities";
 import { Loading } from "components/loading";
+import { Message } from "components/message";
 import { MarkdownContent } from "components/markdownContent";
 import { Welcome } from "routes/welcome";
 import { UserDashboard } from "components/userDashboard";
@@ -228,18 +234,20 @@ export function App() {
   useSiteAlertBanner();
   useDisclaimerBanner();
 
-  const routes = createRoutesFromElements([
-    <Route path="/welcome" element={<Welcome />} />,
-    <Route path="/" element={<ProtectedRoute />}>
-      <Route index element={<AllRebates />} />
-      <Route path="helpdesk" element={<Helpdesk />} />
-      <Route path="rebate/new" element={<NewApplicationForm />} />
-      <Route path="rebate/:id" element={<ApplicationForm />} />
-      <Route path="payment-request/:id" element={<PaymentRequestForm />} />
-      <Route path="close-out/:id" element={<CloseOutForm />} />
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Route>,
-  ]);
+  const routes = createRoutesFromElements(
+    <Route errorElement={<Message type="error" text={messages.genericError} />}>
+      <Route path="/welcome" element={<Welcome />} />
+      <Route path="/" element={<ProtectedRoute />}>
+        <Route index element={<AllRebates />} />
+        <Route path="helpdesk" element={<Helpdesk />} />
+        <Route path="rebate/new" element={<NewApplicationForm />} />
+        <Route path="rebate/:id" element={<ApplicationForm />} />
+        <Route path="payment-request/:id" element={<PaymentRequestForm />} />
+        <Route path="close-out/:id" element={<CloseOutForm />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Route>
+    </Route>
+  );
 
   const router = createBrowserRouter(routes, { basename: serverBasePath });
 

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -55,7 +55,8 @@ export const messages = {
   bapSamFetchError: "Error loading SAM.gov data. Please contact support.",
   bapNoSamResults:
     "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
-  bapSamNotActive: "TODO", // TODO: error message for when SAM.gov entity is not active/has expired
+  bapSamNotActive:
+    "Your SAM.gov account is currently not active. Activate your SAM.gov account to access this submission.",
   formSubmissionError:
     "The requested submission does not exist, or you do not have access. Please contact support if you believe this is a mistake.",
   formSubmissionsError: "Error loading form submissions.",

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -57,6 +57,8 @@ export const messages = {
     "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
   bapSamEntityNotActive:
     "Your SAM.gov account is currently not active. Activate your SAM.gov account to access this submission.",
+  bapSamAtLeastOneEntityNotActive:
+    "At least one of your SAM.gov accounts is currently not active. Any submissions associated with that SAM.gov account will be inaccessible until the account is re-activated.",
   formSubmissionError:
     "The requested submission does not exist, or you do not have access. Please contact support if you believe this is a mistake.",
   formSubmissionsError: "Error loading form submissions.",

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -55,7 +55,7 @@ export const messages = {
   bapSamFetchError: "Error loading SAM.gov data. Please contact support.",
   bapNoSamResults:
     "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
-  bapSamNotActive:
+  bapSamEntityNotActive:
     "Your SAM.gov account is currently not active. Activate your SAM.gov account to access this submission.",
   formSubmissionError:
     "The requested submission does not exist, or you do not have access. Please contact support if you believe this is a mistake.",

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -768,8 +768,11 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
 
 export function AllRebates() {
   const content = useContentData();
+  const bapSamData = useBapSamData();
   const submissionsQueries = useSubmissionsQueries();
   const rebates = useRebates();
+
+  if (!bapSamData) return null;
 
   if (submissionsQueries.some((query) => query.isFetching)) {
     return <Loading />;
@@ -781,6 +784,13 @@ export function AllRebates() {
 
   return (
     <>
+      {bapSamData.entities.some((e) => e.ENTITY_STATUS__c !== "Active") && (
+        <Message
+          type="warning"
+          text={messages.bapSamAtLeastOneEntityNotActive}
+        />
+      )}
+
       {rebates.length === 0 ? (
         <div className="margin-top-4">
           <Message type="info" text={messages.newApplication} />

--- a/app/client/src/routes/applicationForm.tsx
+++ b/app/client/src/routes/applicationForm.tsx
@@ -339,7 +339,7 @@ function UserApplicationForm(props: { email: string }) {
   }
 
   if (entity.ENTITY_STATUS__c !== "Active") {
-    return <Message type="error" text={messages.bapSamNotActive} />;
+    return <Message type="error" text={messages.bapSamEntityNotActive} />;
   }
 
   const { title, name } = getUserInfo(email, entity);

--- a/app/client/src/routes/closeOutForm.tsx
+++ b/app/client/src/routes/closeOutForm.tsx
@@ -214,7 +214,7 @@ function UserCloseOutForm(props: { email: string }) {
   }
 
   if (entity.ENTITY_STATUS__c !== "Active") {
-    return <Message type="error" text={messages.bapSamNotActive} />;
+    return <Message type="error" text={messages.bapSamEntityNotActive} />;
   }
 
   const { title, name } = getUserInfo(email, entity);

--- a/app/client/src/routes/paymentRequestForm.tsx
+++ b/app/client/src/routes/paymentRequestForm.tsx
@@ -222,7 +222,7 @@ function UserPaymentRequestForm(props: { email: string }) {
   }
 
   if (entity.ENTITY_STATUS__c !== "Active") {
-    return <Message type="error" text={messages.bapSamNotActive} />;
+    return <Message type="error" text={messages.bapSamEntityNotActive} />;
   }
 
   const {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-5

## Main Changes:
Followup to #321. Adds a warning message to the dashboard/all rebates page if at least one of a user's SAM.gov entities is not active. Also adds an error element component (generic error message) to the routes, in case an error is thrown in a route component.

## Steps To Test:
1. The only way to really test would be for you to spoof one of your SAM.gov records' active status (which I've done when developing this locally). If one of your SAM.gov entities is inactive, you'll see a warning message on the dashboard. And if you visited a submission associated with that SAM.gov entity, the form won't load and an error message will be displayed indication it doesn't exist or you don't have access to it.
