### PR TITLE
Feature/apply status updates

### DIFF
--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -443,7 +443,9 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
       ? "text-italic"
       : "";
 
-  const statusIconClassNames = "usa-icon";
+  const statusIconClassNames = paymentRequestFundingApproved
+    ? "usa-icon text-primary" // blue
+    : "usa-icon";
 
   const statusIcon = paymentRequestNeedsEdits
     ? `${icons}#priority_high` // !
@@ -451,6 +453,8 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
     ? `${icons}#close` // ✕
     : paymentRequestFundingNotApproved
     ? `${icons}#cancel` // ✕ inside a circle
+    : paymentRequestFundingApproved
+    ? `${icons}#check_circle` // check inside a circle
     : paymentRequest.formio.state === "draft"
     ? `${icons}#more_horiz` // three horizontal dots
     : paymentRequest.formio.state === "submitted"
@@ -463,6 +467,8 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
     ? "Withdrawn"
     : paymentRequestFundingNotApproved
     ? "Funding Not Approved"
+    : paymentRequestFundingApproved
+    ? "Funding Approved"
     : paymentRequest.formio.state === "draft"
     ? "Draft"
     : paymentRequest.formio.state === "submitted"
@@ -502,13 +508,6 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
             <TextWithTooltip
               text="Needs Clarification"
               tooltip="Check your email for instructions on what needs clarification"
-            />
-          ) : paymentRequestFundingApproved /* TODO: check if this should change now */ ? (
-            <TextWithTooltip
-              text="Funding Approved"
-              tooltip="Check your email for more details on funding"
-              iconName="check_circle" // check inside a circle
-              iconClassNames="text-primary" // blue
             />
           ) : (
             <>

--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -109,7 +109,7 @@ function ApplicationSubmission(props: { rebate: Rebate }) {
     : applicationHasBeenWithdrawn
     ? `${icons}#close` // ✕
     : applicationNotSelected
-    ? `${icons}#check` // TODO: eventually use 'cancel' icon if we show 'Not Selected'
+    ? `${icons}#cancel` // x inside a circle
     : applicationSelected
     ? `${icons}#check_circle` // check inside a circle
     : application.formio.state === "draft"
@@ -123,7 +123,7 @@ function ApplicationSubmission(props: { rebate: Rebate }) {
     : applicationHasBeenWithdrawn
     ? "Withdrawn"
     : applicationNotSelected
-    ? "Submitted" // TODO: eventually show 'Not Selected'
+    ? "Not Selected"
     : applicationSelected
     ? "Selected"
     : application.formio.state === "draft"


### PR DESCRIPTION
## Related Issues:
* CSBAPP-5

## Main Changes:
Follow up to #321: shows the 'Not Selected' status and icon for Application form submissions that aren't selected (BAP internal status of 'Coordinator Denied'), and removes no longer necessary tooltip from Payment Request form submissions with 'Funding Approved' status.

## Steps To Test:
1. Ensure the tooltip is no longer shown for PRF submissions with the status of 'Funding Approved'
2. Work with the BAP to set an application form submission's status to 'Coordinator Denied' and ensure the status shown in the wrapper app is 'Not Selected' with an X icon inside a circle.
