### PR TITLE
Feature/apply bap status testing updates

### DIFF
--- a/app/client/src/routes/allRebates.tsx
+++ b/app/client/src/routes/allRebates.tsx
@@ -189,6 +189,7 @@ function ApplicationSubmission(props: { rebate: Rebate }) {
             <TextWithTooltip
               text="Needs Clarification"
               tooltip="Check your email for instructions on what needs clarification"
+              iconClassNames="text-base-darkest"
             />
           ) : (
             <>
@@ -508,6 +509,7 @@ function PaymentRequestSubmission(props: { rebate: Rebate }) {
             <TextWithTooltip
               text="Needs Clarification"
               tooltip="Check your email for instructions on what needs clarification"
+              iconClassNames="text-base-darkest"
             />
           ) : (
             <>
@@ -661,10 +663,10 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
   const closeOutNeedsClarification =
     closeOut.bap?.status === "Needs Clarification";
 
-  const closeOutNotApproved = closeOut.bap?.status === "Branch Director Denied";
-
   const closeOutReimbursementNeeded =
     closeOut.bap?.status === "Reimbursement Needed";
+
+  const closeOutNotApproved = closeOut.bap?.status === "Branch Director Denied";
 
   const closeOutApproved = closeOut.bap?.status === "Branch Director Approved";
 
@@ -681,8 +683,6 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
     ? `${icons}#priority_high` // !
     : closeOutNotApproved
     ? `${icons}#cancel` // ✕ inside a circle
-    : closeOutReimbursementNeeded
-    ? `${icons}#priority_high` // !
     : closeOutApproved
     ? `${icons}#check_circle` // check inside a circle
     : closeOut.formio.state === "draft"
@@ -695,8 +695,6 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
     ? "Edits Requested"
     : closeOutNotApproved
     ? "Close Out Not Approved"
-    : closeOutReimbursementNeeded
-    ? "Reimbursement Needed"
     : closeOutApproved
     ? "Close Out Approved"
     : closeOut.formio.state === "draft"
@@ -735,6 +733,13 @@ function CloseOutSubmission(props: { rebate: Rebate }) {
             <TextWithTooltip
               text="Needs Clarification"
               tooltip="Check your email for instructions on what needs clarification"
+              iconClassNames="text-base-darkest"
+            />
+          ) : closeOutReimbursementNeeded ? (
+            <TextWithTooltip
+              text="Reimbursement Needed"
+              tooltip="Check your email for information on reimbursement needed"
+              iconClassNames="text-base-darkest"
             />
           ) : (
             <>

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -496,11 +496,13 @@ function useCombinedRebates() {
 
 /**
  * Custom hook that sorts rebates by:
- * - most recient formio modified date, regardless of form
+ * - Most recient Formio modified date, regardless of form type
  *   (Application, Payment Request, or Close Out)
- * - Application submissions needing edits
- * - selected Applications submissions without a corresponding Payment Request
- *   submission
+ * - Submissions needing edits, regardless of form type
+ * - Selected Application form submissions without a corresponding Payment
+ *   Request form submission
+ * - Funding Approved Payment Request form submissions without a corresponding
+ *   Close Out form submission
  **/
 function useSortedRebates(rebates: { [rebateId: string]: Rebate }) {
   return Object.entries(rebates)
@@ -535,14 +537,27 @@ function useSortedRebates(rebates: { [rebateId: string]: Rebate }) {
         bap: r1.paymentRequest.bap,
       });
 
+      const r1CloseOutNeedsEdits = submissionNeedsEdits({
+        formio: r1.closeOut.formio,
+        bap: r1.closeOut.bap,
+      });
+
       const r1ApplicationSelected = r1.application.bap?.status === "Accepted";
 
       const r1ApplicationSelectedButNoPaymentRequest =
         r1ApplicationSelected && !Boolean(r1.paymentRequest.formio);
 
+      const r1PaymentRequestFundingApproved =
+        r1.paymentRequest.bap?.status === "Accepted";
+
+      const r1PaymentRequestFundingApprovedButNoCloseOut =
+        r1PaymentRequestFundingApproved && !Boolean(r1.closeOut.formio);
+
       return r1ApplicationNeedsEdits ||
         r1PaymentRequestNeedsEdits ||
-        r1ApplicationSelectedButNoPaymentRequest
+        r1CloseOutNeedsEdits ||
+        r1ApplicationSelectedButNoPaymentRequest ||
+        r1PaymentRequestFundingApprovedButNoCloseOut
         ? -1
         : 0;
     });

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -481,7 +481,7 @@ function useCombinedRebates() {
     const comboKey = bapMatch?.UEI_EFTI_Combo_Key__c || null;
     const rebateId = bapMatch?.Parent_Rebate_ID__c || null;
     const reviewItemId = bapMatch?.CSB_Review_Item_ID__c || null;
-    const status = bapMatch?.Parent_CSB_Rebate__r?.CSB_Payment_Request_Status__c || null; // prettier-ignore
+    const status = bapMatch?.Parent_CSB_Rebate__r?.CSB_Closeout_Request_Status__c || null; // prettier-ignore
 
     if (rebates[formioBapRebateId]) {
       rebates[formioBapRebateId].closeOut = {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-145

## Main Changes:
Applies edits uncovered in ERG/BAP status testing meeting:
* Fixed bug where Close Out form status was referencing the wrong field (Payment Request form status).
* Updated rebates sorting to ensure "Edits Requested" Close Out form submissions and "Funding Approved" Payment Request form submissions without a Close Out form submission are displayed at the top of the table of a user's submissions.
* Added a tooltip to the "Reimbursement Needed" Close Out form status, and darkened all "Needs Clarification" icons.

## Steps To Test:
1. Work with the BAP team to set one of your Close Out form submissions' internal statuses to "Reimbursement Needed" and ensure it's displaying a tooltip.
2. Work with the BAP team to set one of your Close Out form submissions' internal statuses to "Edits Requested" and ensure it's displayed towards the top of your submissions.
