### PR TITLE
Feature/add nces lookup

### DIFF
--- a/app/server/app/routes/formioNCES.js
+++ b/app/server/app/routes/formioNCES.js
@@ -1,12 +1,12 @@
-const { resolve } = require("node:path");
-const { readFile } = require("node:fs/promises");
+// const { resolve } = require("node:path");
+// const { readFile } = require("node:fs/promises");
 const express = require("express");
-const axios = require("axios").default || require("axios"); // TODO: https://github.com/axios/axios/issues/5011
+// const axios = require("axios").default || require("axios"); // TODO: https://github.com/axios/axios/issues/5011
 // ---
 const log = require("../utilities/logger");
 const data = require("../content/nces.json");
 
-const { NODE_ENV, S3_PUBLIC_BUCKET, S3_PUBLIC_REGION } = process.env;
+// const { NODE_ENV, S3_PUBLIC_BUCKET, S3_PUBLIC_REGION } = process.env;
 
 const router = express.Router();
 
@@ -14,7 +14,7 @@ const router = express.Router();
 router.get("/:searchText", async (req, res) => {
   const { searchText } = req.params;
 
-  const s3BucketUrl = `https://${S3_PUBLIC_BUCKET}.s3-${S3_PUBLIC_REGION}.amazonaws.com`;
+  // const s3BucketUrl = `https://${S3_PUBLIC_BUCKET}.s3-${S3_PUBLIC_REGION}.amazonaws.com`;
 
   // const data = JSON.parse(
   //   await (NODE_ENV === "development"

--- a/app/server/app/routes/formioNCES.js
+++ b/app/server/app/routes/formioNCES.js
@@ -1,0 +1,35 @@
+const { resolve } = require("node:path");
+const { readFile } = require("node:fs/promises");
+const express = require("express");
+const axios = require("axios").default || require("axios"); // TODO: https://github.com/axios/axios/issues/5011
+// ---
+const log = require("../utilities/logger");
+const data = require("../content/nces.json");
+
+const { NODE_ENV, S3_PUBLIC_BUCKET, S3_PUBLIC_REGION } = process.env;
+
+const router = express.Router();
+
+// --- Search the NCES data with the provided NCES ID and return a match
+router.get("/:searchText", async (req, res) => {
+  const { searchText } = req.params;
+
+  const s3BucketUrl = `https://${S3_PUBLIC_BUCKET}.s3-${S3_PUBLIC_REGION}.amazonaws.com`;
+
+  // const data = JSON.parse(
+  //   await (NODE_ENV === "development"
+  //     ? readFile(resolve(__dirname, "../content", "nces.json"), "utf8")
+  //     : axios.get(`${s3BucketUrl}/content/nces.json`).then((res) => res.data))
+  // );
+
+  const result = data.find((item) => item["NCES District ID"] === searchText);
+
+  const logMessage =
+    `NCES data searched with NCES ID '${searchText}' resulting in ` +
+    `${result ? "a match" : "no results"}.`;
+  log({ level: "info", message: logMessage, req });
+
+  return res.json({ ...result });
+});
+
+module.exports = router;

--- a/app/server/app/routes/index.js
+++ b/app/server/app/routes/index.js
@@ -4,6 +4,7 @@ const router = express.Router();
 
 router.use("/", require("./auth"));
 router.use("/api/content", require("./content"));
+router.use("/api/formio/nces", require("./formioNCES"));
 router.use("/api/user", require("./user"));
 router.use("/api/config", require("./config"));
 router.use("/api/bap", require("./bap"));

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -402,6 +402,35 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
+    "/api/formio/nces/{searchText}": {
+      "get": {
+        "summary": "/api/formio/nces/{searchText}",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": [],
+        "parameters": [
+          {
+            "name": "searchText",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          { "$ref": "#/components/parameters/scan" }
+        ]
+      }
+    },
     "/api/formio/2022/s3/{formType}/{mongoId}/{comboKey}/storage/s3": {
       "get": {
         "summary": "/api/formio/2022/s3/{formType}/{mongoId}/{comboKey}/storage/s3",


### PR DESCRIPTION
## Related Issues:
* CSBAPP-7

## Main Changes:
Adds a new web service API endpoint that searches the NCES.json file with a provided NCES ID and returns the resulting NCES data.

## Steps To Test:
1. Access `/api/formio/nces/{{ NCES ID HERE }}`

## TODO:
- [ ] Determine if the data should be fetched from an S3 bucket at application startup, or just hosted via the app. The data is updated so infrequently, it's more stable to host the data within the app itself, so that's the initial approach here.
