### PR TITLE
Feature/update nces data lookup

### DIFF
--- a/app/server/app/routes/formioNCES.js
+++ b/app/server/app/routes/formioNCES.js
@@ -11,7 +11,7 @@ const data = require("../content/nces.json");
 const router = express.Router();
 
 // --- Search the NCES data with the provided NCES ID and return a match
-router.get("/:searchText", async (req, res) => {
+router.get("/:searchText?", async (req, res) => {
   const { searchText } = req.params;
 
   // const s3BucketUrl = `https://${S3_PUBLIC_BUCKET}.s3-${S3_PUBLIC_REGION}.amazonaws.com`;
@@ -22,11 +22,25 @@ router.get("/:searchText", async (req, res) => {
   //     : axios.get(`${s3BucketUrl}/content/nces.json`).then((res) => res.data))
   // );
 
+  if (!searchText) {
+    const logMessage = `No NCES ID passed to NCES data lookup.`;
+    log({ level: "info", message: logMessage, req });
+
+    return res.json({});
+  }
+
+  if (searchText.length !== 7) {
+    const logMessage = `Invalid NCES ID '${searchText}' passed to NCES data lookup.`;
+    log({ level: "info", message: logMessage, req });
+
+    return res.json({});
+  }
+
   const result = data.find((item) => item["NCES District ID"] === searchText);
 
   const logMessage =
     `NCES data searched with NCES ID '${searchText}' resulting in ` +
-    `${result ? "a match" : "no results"}.`;
+    `${result ? "a match" : "no matches"}.`;
   log({ level: "info", message: logMessage, req });
 
   return res.json({ ...result });


### PR DESCRIPTION
## Related Issues:
* CSBAPP-7

## Main Changes:
Update NCES web service endpoint to account for no NCES ID provided and only perform the search if NCES ID is exactly seven characters

## Steps To Test:
1. Access `/api/formio/nces` and ensure response is `{}`
2. Access `/api/formio/nces/123456` (or some other trailing string that's not exactly seven characters in length) and ensure response is `{}`
