### PR TITLE
Feature/add 2023 frf school district name field

### DIFF
--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -850,11 +850,9 @@ function FRF2023Submission(props: {
     appInfo_uei,
     appInfo_efti,
     appInfo_orgName,
-    // TODO: (school district name field)
+    _formio_schoolDistrictName,
     _user_email,
   } = frf.formio.data;
-
-  const appInfo_schoolDistrictName = null; // TODO: temporary
 
   const date = new Date(frf.formio.modified).toLocaleDateString();
   const time = new Date(frf.formio.modified).toLocaleTimeString();
@@ -1021,8 +1019,8 @@ function FRF2023Submission(props: {
             />
           )}
           <br />
-          {Boolean(appInfo_schoolDistrictName) ? (
-            appInfo_schoolDistrictName
+          {Boolean(_formio_schoolDistrictName) ? (
+            _formio_schoolDistrictName
           ) : (
             <TextWithTooltip
               text=" "

--- a/app/client/src/utilities.tsx
+++ b/app/client/src/utilities.tsx
@@ -172,6 +172,7 @@ type FormioFRF2023Data = {
   appInfo_uei: string;
   appInfo_efti: string;
   appInfo_orgName: string;
+  _formio_schoolDistrictName: string;
 };
 
 export type FormioFRF2022Submission = FormioSubmission & {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-194

## Main Changes:
Add school district name field to 2023 FRF data type and render it appropriately on the user's dashboard for their 2023 FRF submissions

## Steps To Test:
1. Navigate to the dashboard.
2. Change "Rebate Year" to 2023, and ensure the form submissions shown below reflect the new rebate year. **NOTE:** The school district name field will not be displayed until:
  a. the user has entered in that data into the form
  b. the Formio form definition has been updated to set the value appropriately in the `_formio_schoolDistrictName` field.

This change just get everything in place in the wrapping application so the school district name will correctly be displayed when the above two conditions are met.
