### PR TITLE
Feature/enable cors on nces endpoint

### DIFF
--- a/app/server/app/routes/formioNCES.js
+++ b/app/server/app/routes/formioNCES.js
@@ -7,8 +7,8 @@ const cors = require("cors");
 const log = require("../utilities/logger");
 const data = require("../content/nces.json");
 
-const { NODE_ENV, FORMIO_NCES_API_KEY } = process.env;
-// const { S3_PUBLIC_BUCKET, S3_PUBLIC_REGION } = process.env;
+const { FORMIO_NCES_API_KEY } = process.env;
+// const { NODE_ENV, S3_PUBLIC_BUCKET, S3_PUBLIC_REGION } = process.env;
 
 const router = express.Router();
 
@@ -20,7 +20,7 @@ const router = express.Router();
  * @param {express.NextFunction} next
  */
 function enableLocalhostCORS(req, res, next) {
-  if (NODE_ENV === "development") {
+  if (req.get("host") === "localhost:3001") {
     cors({ origin: "*" });
   }
 

--- a/app/server/app/routes/formioNCES.js
+++ b/app/server/app/routes/formioNCES.js
@@ -1,19 +1,34 @@
 // const { resolve } = require("node:path");
 // const { readFile } = require("node:fs/promises");
 const express = require("express");
+const cors = require("cors");
 // const axios = require("axios").default || require("axios"); // TODO: https://github.com/axios/axios/issues/5011
 // ---
 const log = require("../utilities/logger");
 const data = require("../content/nces.json");
 
-const { FORMIO_NCES_API_KEY } = process.env;
-
-// const { NODE_ENV, S3_PUBLIC_BUCKET, S3_PUBLIC_REGION } = process.env;
+const { NODE_ENV, FORMIO_NCES_API_KEY } = process.env;
+// const { S3_PUBLIC_BUCKET, S3_PUBLIC_REGION } = process.env;
 
 const router = express.Router();
 
+/**
+ * Enable CORS for local development
+ *
+ * @param {express.Request} req
+ * @param {express.Response} res
+ * @param {express.NextFunction} next
+ */
+function enableLocalhostCORS(req, res, next) {
+  if (NODE_ENV === "development") {
+    cors({ origin: "*" });
+  }
+
+  next();
+}
+
 // --- Search the NCES data with the provided NCES ID and return a match
-router.get("/:searchText?", async (req, res) => {
+router.get("/:searchText?", enableLocalhostCORS, (req, res) => {
   const { searchText } = req.params;
   const apiKey = req.headers["x-api-key"];
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-7

## Main Changes:
Update Formio NCES web service endpoint to allow cross origin requests if running the app locally.

## Steps To Test:
1. Run the app locally. The Formio NCES web service endpoint should now resolve correctly, as CORS is enabled for this route.
