### PR TITLE
Feature/update nces cors configuration

### DIFF
--- a/app/server/app/routes/formioNCES.js
+++ b/app/server/app/routes/formioNCES.js
@@ -12,23 +12,8 @@ const { FORMIO_NCES_API_KEY } = process.env;
 
 const router = express.Router();
 
-/**
- * Enable CORS for local development
- *
- * @param {express.Request} req
- * @param {express.Response} res
- * @param {express.NextFunction} next
- */
-function enableLocalhostCORS(req, res, next) {
-  if (req.get("host") === "localhost:3001") {
-    cors({ origin: "*" });
-  }
-
-  next();
-}
-
 // --- Search the NCES data with the provided NCES ID and return a match
-router.get("/:searchText?", enableLocalhostCORS, (req, res) => {
+router.get("/:searchText?", cors({ origin: "*" }), (req, res) => {
   const { searchText } = req.params;
   const apiKey = req.headers["x-api-key"];
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-7

## Main Changes:
Update Formio NCES endpoint CORS configuration to not take request host into account when enabling CORS (update to #339)

## Steps To Test:
1. Run the app locally. The Formio NCES web service endpoint should now resolve correctly, as CORS is enabled for this route.