### PR TITLE
Feature/update formio nces cors logic

### DIFF
--- a/app/server/app/routes/formioNCES.js
+++ b/app/server/app/routes/formioNCES.js
@@ -11,18 +11,13 @@ const { FORMIO_NCES_API_KEY } = process.env;
 
 const router = express.Router();
 
-/**
- * @param {express.Request} req
- * @param {express.Response} res
- * @param {express.NextFunction} next
- */
-function enableCORS(req, res, next) {
-  res.set("Access-Control-Allow-Origin", "*");
-  next();
-}
-
 // --- Search the NCES data with the provided NCES ID and return a match
-router.get("/:searchText?", enableCORS, (req, res) => {
+router.get("/:searchText?", (req, res) => {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  res.setHeader("Access-Control-Allow-Credentials", true);
+
   const { searchText } = req.params;
   const apiKey = req.headers["x-api-key"];
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-7

## Main Changes:
Update CORS headers set in Formio NCES API endpoint (update to #341)

## Steps To Test:
1. Run the app locally. The Formio NCES web service endpoint should now resolve correctly, as CORS is enabled for this route.
