### PR TITLE
Feature/update nces lookup for 2023

### DIFF
--- a/app/server/app/routes/formioNCES.js
+++ b/app/server/app/routes/formioNCES.js
@@ -51,7 +51,7 @@ router.get("/:searchText?", (req, res) => {
     return res.json({});
   }
 
-  const result = data.find((item) => item["NCES District ID"] === searchText);
+  const result = data.find((item) => item["NCES ID"] === searchText);
 
   const logMessage =
     `NCES data searched with NCES ID '${searchText}' resulting in ` +


### PR DESCRIPTION
## Related Issues:
* CSBAPP-229

## Main Changes:
Update searching through NCES 2013 JSON data to use the updated key for NCES ID

## Steps To Test:
1. Navigate to a 2023 submission within the app. The 2023 FRF's NCES fields should function normally once the Formio 2023 FRF's form definition/schema has been updated to reflect the renamed and new 2023 NCES fields in the JSON data (update to #343).
