### PR TITLE
Feature/update user email logic

### DIFF
--- a/app/client/src/components/userDashboard.tsx
+++ b/app/client/src/components/userDashboard.tsx
@@ -88,7 +88,7 @@ export function UserDashboard(props: { email: string }) {
     });
   }
 
-  if (!bapSamData) {
+  if (!bapSamData || !email) {
     return <Loading />;
   }
 

--- a/app/server/app/routes/bap.js
+++ b/app/server/app/routes/bap.js
@@ -18,6 +18,16 @@ router.get("/sam", (req, res) => {
   const adminOrHelpdeskUser =
     userRoles.includes("csb_admin") || userRoles.includes("csb_helpdesk");
 
+  if (!mail) {
+    const logMessage = `User with no email address attempted to fetch SAM.gov records.`;
+    log({ level: "error", message: logMessage, req });
+
+    return res.json({
+      results: false,
+      entities: [],
+    });
+  }
+
   getSamEntities(req, mail)
     .then((entities) => {
       /**
@@ -26,7 +36,7 @@ router.get("/sam", (req, res) => {
        */
       if (!adminOrHelpdeskUser && entities?.length === 0) {
         const logMessage =
-          `User with email '${mail}' tried to use app ` +
+          `User with email '${mail}' attempted to use app ` +
           `without any associated SAM.gov records.`;
         log({ level: "error", message: logMessage, req });
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-231

## Main Changes:
In testing v4, a user logged into the Dev site (using SSO) and it appeared that the Staging EPA Gateway/Login.gov didn't return an email address in the response. That caused the SAM.gov query  for this particular user in Dev to return some data for all SAM.gov entities from the BAP's web service. Ultimately they weren't able to do anything but create brand new FRF (draft) submissions for any SAM.gov entity, because all other web service requests failed (due to too many 'comboKeys' being inadvertently associated with this user). In Production, this should never occur, as all users should have an email address returned from EPA Gateway/Login.gov, but additional checks have been added to prevent the user from fetching any SAM.gov data, and logging the user out if this scenario were ever to occur on Production.

## Steps To Test:
1. Run the app locally, and login as a user with no email address. You should be logged out with the "No SAM.gov records match your email..." message displayed.