### PR TITLE
Feature/revert formio uswds package update

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@formio/premium": "1.18.4",
         "@formio/react": "5.2.3",
-        "@formio/uswds": "2.5.0",
+        "@formio/uswds": "2.4.8",
         "@headlessui/react": "1.7.17",
         "@heroicons/react": "2.0.18",
         "@radix-ui/react-tooltip": "1.0.6",
@@ -2163,9 +2163,9 @@
       "integrity": "sha512-RwMEVXkyz+B6RivflrrKIqvvnGR/eZDLQs74u67StcrzO6n3/5D2J8XqTQRSUzQzr5QV6Wq0eZ51z/+mGm6THw=="
     },
     "node_modules/@formio/uswds": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.5.0.tgz",
-      "integrity": "sha512-txxuS0ddD/M+/BWDT9tUEHKoJQ5y3GaQaKt/i4vBgpDcO/vKR1USEcnrUrPUSSbTv1ffH4PSHmc9vCB0YTAsvw=="
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.4.8.tgz",
+      "integrity": "sha512-sBEwGxbcs52w9yZQV2Bg8Z89e5aV4fqH1b+UxeM31KduXlqLuG7KHMbd6ZA8ifyUiR8bGwBoZXGHSlXhTIlgMQ=="
     },
     "node_modules/@formio/vanilla-text-mask": {
       "version": "5.1.1",
@@ -25035,9 +25035,9 @@
       "integrity": "sha512-RwMEVXkyz+B6RivflrrKIqvvnGR/eZDLQs74u67StcrzO6n3/5D2J8XqTQRSUzQzr5QV6Wq0eZ51z/+mGm6THw=="
     },
     "@formio/uswds": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.5.0.tgz",
-      "integrity": "sha512-txxuS0ddD/M+/BWDT9tUEHKoJQ5y3GaQaKt/i4vBgpDcO/vKR1USEcnrUrPUSSbTv1ffH4PSHmc9vCB0YTAsvw=="
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.4.8.tgz",
+      "integrity": "sha512-sBEwGxbcs52w9yZQV2Bg8Z89e5aV4fqH1b+UxeM31KduXlqLuG7KHMbd6ZA8ifyUiR8bGwBoZXGHSlXhTIlgMQ=="
     },
     "@formio/vanilla-text-mask": {
       "version": "5.1.1",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@formio/premium": "1.18.4",
     "@formio/react": "5.2.3",
-    "@formio/uswds": "2.5.0",
+    "@formio/uswds": "2.4.8",
     "@headlessui/react": "1.7.17",
     "@heroicons/react": "2.0.18",
     "@radix-ui/react-tooltip": "1.0.6",


### PR DESCRIPTION
## Related Issues:
* CSBAPP-3

## Main Changes:
* Roll back `@formio/uswds` package update to `v2.4.8` as `v2.5.0` caused the tooltips to not display properly (update to #351)

## Steps To Test:
1. View app and ensure tooltips are displayed properly

## TODO:
- [ ] Eventually revisit what's causing the tooltips to not be displayed properly in the latest `@formio/uswds` package update.
