### PR TITLE
Feature/update status api endpoints

### DIFF
--- a/app/server/app/routes/index.js
+++ b/app/server/app/routes/index.js
@@ -11,6 +11,6 @@ router.use("/api/bap", require("./bap"));
 router.use("/api/formio/2022", require("./formio2022"));
 router.use("/api/formio/2023", require("./formio2023"));
 router.use("/api/help", require("./help"));
-router.use("/status", require("./status"));
+router.use("/api/status", require("./status"));
 
 module.exports = router;

--- a/app/server/app/routes/status.js
+++ b/app/server/app/routes/status.js
@@ -3,13 +3,21 @@ const express = require("express");
 const { axiosFormio, formUrl } = require("../config/formio");
 const { getSamEntities } = require("../utilities/bap");
 
+/**
+ * Verify that schema has type of form and a title exists
+ * (confirming Formio returned a valid schema).
+ */
+function verifySchema(schema) {
+  return schema.type === "form" && !!schema.title;
+}
+
 const router = express.Router();
 
 router.get("/app", (req, res) => {
   return res.json({ status: true });
 });
 
-router.get("/bap-sam-data", (req, res) => {
+router.get("/bap/sam", (req, res) => {
   getSamEntities(req, "bap.sam.data.status@erg.com")
     .then((bapRes) => {
       if (!Array.isArray(bapRes)) {
@@ -24,16 +32,12 @@ router.get("/bap-sam-data", (req, res) => {
     });
 });
 
-router.get("/formio-application-schema", (req, res) => {
+router.get("/formio/2022/frf", (req, res) => {
   axiosFormio(req)
     .get(formUrl["2022"].frf)
     .then((axiosRes) => axiosRes.data)
     .then((schema) => {
-      /**
-       * Verify that schema has type of form and a title exists
-       * (confirming Formio returned a valid schema).
-       */
-      return res.json({ status: schema.type === "form" && !!schema.title });
+      return res.json({ status: verifySchema(schema) });
     })
     .catch((error) => {
       // NOTE: error is logged in axiosFormio response interceptor
@@ -41,16 +45,12 @@ router.get("/formio-application-schema", (req, res) => {
     });
 });
 
-router.get("/formio-payment-request-schema", (req, res) => {
+router.get("/formio/2022/prf", (req, res) => {
   axiosFormio(req)
     .get(formUrl["2022"].prf)
     .then((axiosRes) => axiosRes.data)
     .then((schema) => {
-      /**
-       * Verify that schema has type of form and a title exists
-       * (confirming Formio returned a valid schema).
-       */
-      return res.json({ status: schema.type === "form" && !!schema.title });
+      return res.json({ status: verifySchema(schema) });
     })
     .catch((error) => {
       // NOTE: error is logged in axiosFormio response interceptor
@@ -58,16 +58,25 @@ router.get("/formio-payment-request-schema", (req, res) => {
     });
 });
 
-router.get("/formio-close-out-schema", (req, res) => {
+router.get("/formio/2022/crf", (req, res) => {
   axiosFormio(req)
     .get(formUrl["2022"].crf)
     .then((axiosRes) => axiosRes.data)
     .then((schema) => {
-      /**
-       * Verify that schema has type of form and a title exists
-       * (confirming Formio returned a valid schema).
-       */
-      return res.json({ status: schema.type === "form" && !!schema.title });
+      return res.json({ status: verifySchema(schema) });
+    })
+    .catch((error) => {
+      // NOTE: error is logged in axiosFormio response interceptor
+      return res.json({ status: false });
+    });
+});
+
+router.get("/formio/2023/frf", (req, res) => {
+  axiosFormio(req)
+    .get(formUrl["2023"].frf)
+    .then((axiosRes) => axiosRes.data)
+    .then((schema) => {
+      return res.json({ status: verifySchema(schema) });
     })
     .catch((error) => {
       // NOTE: error is logged in axiosFormio response interceptor

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -118,9 +118,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/bap-sam-data": {
+    "/status/bap/sam": {
       "get": {
-        "summary": "/status/bap-sam-data",
+        "summary": "/status/bap/sam",
         "responses": {
           "200": {
             "description": "OK"
@@ -130,9 +130,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/formio-application-schema": {
+    "/status/formio/2022/frf": {
       "get": {
-        "summary": "/status/formio-application-schema",
+        "summary": "/status/formio/2022/frf",
         "responses": {
           "200": {
             "description": "OK"
@@ -142,9 +142,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/formio-payment-request-schema": {
+    "/status/formio/2022/prf": {
       "get": {
-        "summary": "/status/formio-payment-request-schema",
+        "summary": "/status/formio/2022/prf",
         "responses": {
           "200": {
             "description": "OK"
@@ -154,9 +154,21 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/formio-close-out-schema": {
+    "/status/formio/2022/crf": {
       "get": {
-        "summary": "/status/formio-close-out-schema",
+        "summary": "/status/formio/2022/crf",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": [],
+        "parameters": [{ "$ref": "#/components/parameters/scan" }]
+      }
+    },
+    "/status/formio/2023/frf": {
+      "get": {
+        "summary": "/status/formio/2023/frf",
         "responses": {
           "200": {
             "description": "OK"

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -106,9 +106,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/app": {
+    "/api/status/app": {
       "get": {
-        "summary": "/status/app",
+        "summary": "/api/status/app",
         "responses": {
           "200": {
             "description": "OK"
@@ -118,9 +118,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/bap/sam": {
+    "/api/status/bap/sam": {
       "get": {
-        "summary": "/status/bap/sam",
+        "summary": "/api/status/bap/sam",
         "responses": {
           "200": {
             "description": "OK"
@@ -130,9 +130,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/formio/2022/frf": {
+    "/api/status/formio/2022/frf": {
       "get": {
-        "summary": "/status/formio/2022/frf",
+        "summary": "/api/status/formio/2022/frf",
         "responses": {
           "200": {
             "description": "OK"
@@ -142,9 +142,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/formio/2022/prf": {
+    "/api/status/formio/2022/prf": {
       "get": {
-        "summary": "/status/formio/2022/prf",
+        "summary": "/api/status/formio/2022/prf",
         "responses": {
           "200": {
             "description": "OK"
@@ -154,9 +154,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/formio/2022/crf": {
+    "/api/status/formio/2022/crf": {
       "get": {
-        "summary": "/status/formio/2022/crf",
+        "summary": "/api/status/formio/2022/crf",
         "responses": {
           "200": {
             "description": "OK"
@@ -166,9 +166,9 @@
         "parameters": [{ "$ref": "#/components/parameters/scan" }]
       }
     },
-    "/status/formio/2023/frf": {
+    "/api/status/formio/2023/frf": {
       "get": {
-        "summary": "/status/formio/2023/frf",
+        "summary": "/api/status/formio/2023/frf",
         "responses": {
           "200": {
             "description": "OK"


### PR DESCRIPTION
## Related Issues:
* CSBAPP-234

## Main Changes:
* Updates status API routes to reflect updated API organization used in server app (including adding a new one for the 2023 FRF)

## Steps To Test:
1. Test the new endpoints to ensure they're returning the data you'd expect:
  - `/api/status/app`
  - `/api/status/bap/sam`
  - `/api/status/formio/2022/frf`
  - `/api/status/formio/2022/prf`
  - `/api/status/formio/2022/crf`
  - `/api/status/formio/2023/frf`

## TODO:
- [ ] Update routes in StatusCake to reflect new status API routes
