### PR TITLE
Feature/update app name

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "epa-csb-client",
+  "name": "epa-csb-rebate-forms-app-client",
   "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "epa-csb-client",
+      "name": "epa-csb-rebate-forms-app-client",
       "version": "4.0.0",
       "license": "CC0-1.0",
       "dependencies": {

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "epa-csb-client",
+  "name": "epa-csb-rebate-forms-app-client",
   "version": "4.0.0",
-  "description": "U.S. EPA Clean School Bus data collection system (client app)",
+  "description": "U.S. EPA CSB Rebate Forms Application (client app)",
   "homepage": ".",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",

--- a/app/client/public/404.html
+++ b/app/client/public/404.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="U.S. EPA Clean School Bus Data Collection System"
+      content="U.S. EPA CSB Rebate Forms Application"
     />
     <meta property="DC.creator" content="US EPA" />
     <meta
       property="DC.description"
-      content="U.S. EPA Clean School Bus Data Collection System"
+      content="U.S. EPA CSB Rebate Forms Application"
     />
     <meta property="DC.date.created" content="2022-03-01" />
     <meta property="DC.date.modified" content="2022-03-01" />
@@ -22,7 +22,7 @@
     />
     <meta
       property="DC.title"
-      content="Clean School Bus Data Collection System"
+      content="CSB Rebate Forms Application"
     />
     <meta property="DC.type" content="Data and Tools" />
     <meta property="og:site_name" content="US EPA" />
@@ -30,11 +30,11 @@
     <meta property="og:url" content="%PUBLIC_URL%/" />
     <meta
       property="og:title"
-      content="Clean School Bus Data Collection System | US EPA"
+      content="CSB Rebate Forms Application | US EPA"
     />
     <meta
       property="og:description"
-      content="U.S. EPA Clean School Bus Data Collection System"
+      content="U.S. EPA CSB Rebate Forms Application"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -43,11 +43,11 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:description"
-      content="U.S. EPA Clean School Bus Data Collection System"
+      content="U.S. EPA CSB Rebate Forms Application"
     />
     <meta
       name="twitter:title"
-      content="Clean School Bus Data Collection System | US EPA"
+      content="CSB Rebate Forms Application | US EPA"
     />
     <meta name="twitter:url" content="%PUBLIC_URL%/" />
     <meta name="twitter:image:height" content="600" />
@@ -123,7 +123,7 @@
       media="all"
       href="https://www.epa.gov/themes/epa_theme/css/styles.css"
     />
-    <title>Clean School Bus Data Collection System | US EPA</title>
+    <title>CSB Rebate Forms Application | US EPA</title>
     <script>
       (function (w, d, s, l, i) {
         w[l] = w[l] || [];

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="U.S. EPA Clean School Bus Data Collection System"
+      content="U.S. EPA CSB Rebate Forms Application"
     />
     <meta property="DC.creator" content="US EPA" />
     <meta
       property="DC.description"
-      content="U.S. EPA Clean School Bus Data Collection System"
+      content="U.S. EPA CSB Rebate Forms Application"
     />
     <meta property="DC.date.created" content="2022-03-01" />
     <meta property="DC.date.modified" content="2022-03-01" />
@@ -22,7 +22,7 @@
     />
     <meta
       property="DC.title"
-      content="Clean School Bus Data Collection System"
+      content="CSB Rebate Forms Application"
     />
     <meta property="DC.type" content="Data and Tools" />
     <meta property="og:site_name" content="US EPA" />
@@ -30,11 +30,11 @@
     <meta property="og:url" content="%PUBLIC_URL%/" />
     <meta
       property="og:title"
-      content="Clean School Bus Data Collection System | US EPA"
+      content="CSB Rebate Forms Application | US EPA"
     />
     <meta
       property="og:description"
-      content="U.S. EPA Clean School Bus Data Collection System"
+      content="U.S. EPA CSB Rebate Forms Application"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -43,11 +43,11 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:description"
-      content="U.S. EPA Clean School Bus Data Collection System"
+      content="U.S. EPA CSB Rebate Forms Application"
     />
     <meta
       name="twitter:title"
-      content="Clean School Bus Data Collection System | US EPA"
+      content="CSB Rebate Forms Application | US EPA"
     />
     <meta name="twitter:url" content="%PUBLIC_URL%/" />
     <meta name="twitter:image:height" content="600" />
@@ -129,7 +129,7 @@
       media="all"
       href="https://www.epa.gov/themes/epa_theme/css/styles.css"
     />
-    <title>Clean School Bus Data Collection System | US EPA</title>
+    <title>CSB Rebate Forms Application | US EPA</title>
     <script>
       (function (w, d, s, l, i) {
         w[l] = w[l] || [];

--- a/app/client/public/manifest.json
+++ b/app/client/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "EPA CSB",
-  "name": "U.S. EPA Clean School Bus Data Collection System",
+  "name": "U.S. EPA CSB Rebate Forms Application",
   "icons": [
     {
       "src": "https://www.epa.gov/themes/epa_theme/images/favicon.ico",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "epa-csb",
+  "name": "epa-csb-rebate-forms-app",
   "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "epa-csb",
+      "name": "epa-csb-rebate-forms-app",
       "version": "4.0.0",
       "license": "CC0-1.0",
       "devDependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "epa-csb",
+  "name": "epa-csb-rebate-forms-app",
   "version": "4.0.0",
-  "description": "U.S. EPA Clean School Bus data collection system",
+  "description": "U.S. EPA CSB Rebate Forms Application",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",
   "contributors": [

--- a/app/server/app/public/index.html
+++ b/app/server/app/public/index.html
@@ -1,11 +1,21 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Clean School Bus Data Collection System | US EPA</title>
+    <title>CSB Rebate Forms Application | US EPA</title>
+    <style>
+      p {
+        font-family: sans-serif;
+        text-align: center;
+      }
+    </style>
   </head>
   <body>
-    <p>(Page to be replaced via client app build)</p>
+    <!-- NOTE: This page will be replaced via client app build -->
+    <p>
+      The CSB Rebate Forms Application is currently down for scheduled
+      maintenance. Please check back soon.
+    </p>
   </body>
 </html>

--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "epa-csb-server",
+  "name": "epa-csb-rebate-forms-app-server",
   "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "epa-csb-server",
+      "name": "epa-csb-rebate-forms-app-server",
       "version": "4.0.0",
       "license": "CC0-1.0",
       "dependencies": {

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "epa-csb-server",
+  "name": "epa-csb-rebate-forms-app-server",
   "version": "4.0.0",
-  "description": "U.S. EPA Clean School Bus data collection system (server app)",
+  "description": "U.S. EPA CSB Rebate Forms Application (server app)",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",
   "contributors": [


### PR DESCRIPTION
## Related Issues:
* CSBAPP-247

## Main Changes:
Updates app name and updates placeholder server index file's text to appear as a maintenance page (that file is replaced in client app build before deployment, so this should never actually be displayed to end users unless the build fails and/or the client app's files are not properly included in the deployment bundle).

## Steps To Test:
1. Verify HTML page titles and all metadata now display official app name
