### PR TITLE
Feature/add bap query for 2023 submissions

### DIFF
--- a/app/client/src/components/errorBoundary.tsx
+++ b/app/client/src/components/errorBoundary.tsx
@@ -1,4 +1,5 @@
-import { Component, ErrorInfo, ReactNode } from "react";
+import type { ReactNode } from "react";
+import { Component, ErrorInfo } from "react";
 // ---
 import { messages } from "@/config";
 import { Message } from "@/components/message";

--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -9,7 +9,6 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import { serverUrl, messages } from "@/config";
 import {
-  FormioCRF2022Submission,
   getData,
   postData,
   useContentData,
@@ -25,6 +24,7 @@ import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useNotificationsActions } from "@/contexts/notifications";
 import { useRebateYearState } from "@/contexts/rebateYear";
+import type { FormioCRF2022Submission } from "@/utilities";
 
 type ServerResponse =
   | {

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -9,7 +9,6 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import { serverUrl, messages } from "@/config";
 import {
-  FormioFRF2022Submission,
   getData,
   postData,
   useContentData,
@@ -26,6 +25,7 @@ import { MarkdownContent } from "@/components/markdownContent";
 import { useDialogActions } from "@/contexts/dialog";
 import { useNotificationsActions } from "@/contexts/notifications";
 import { useRebateYearState } from "@/contexts/rebateYear";
+import type { FormioFRF2022Submission } from "@/utilities";
 
 type ServerResponse =
   | {

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -16,13 +16,14 @@ import {
   useConfigData,
   useBapSamData,
   useSubmissionsQueries,
-  // useSubmissions,
-  // submissionNeedsEdits,
+  useSubmissions,
+  submissionNeedsEdits,
   getUserInfo,
 } from "@/utilities";
 import { Loading } from "@/components/loading";
 import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
+import { useDialogActions } from "@/contexts/dialog";
 import { useNotificationsActions } from "@/contexts/notifications";
 import { useRebateYearState } from "@/contexts/rebateYear";
 
@@ -117,7 +118,9 @@ function FundingRequestForm(props: { email: string }) {
   const content = useContentData();
   const configData = useConfigData();
   const bapSamData = useBapSamData();
+  const { displayDialog } = useDialogActions();
   const {
+    displayInfoNotification,
     displaySuccessNotification,
     displayErrorNotification,
     dismissNotification,
@@ -125,7 +128,7 @@ function FundingRequestForm(props: { email: string }) {
   const { rebateYear } = useRebateYearState();
 
   const submissionsQueries = useSubmissionsQueries("2023");
-  // const submissions = useSubmissions("2023");
+  const submissions = useSubmissions("2023");
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { userAccess, formSchema, submission } = query.data ?? {};
@@ -181,16 +184,130 @@ function FundingRequestForm(props: { email: string }) {
     return <Message type="error" text={messages.formSubmissionError} />;
   }
 
-  // const rebate = submissions.find((r) => r.frf.formio._id === mongoId);
+  const rebate = submissions.find((r) => r.frf.formio._id === mongoId);
 
-  // const frfNeedsEdits = !rebate
-  //   ? false
-  //   : submissionNeedsEdits({
-  //       formio: rebate.frf.formio,
-  //       bap: rebate.frf.bap,
-  //     });
+  const frfNeedsEdits = !rebate
+    ? false
+    : submissionNeedsEdits({
+        formio: rebate.frf.formio,
+        bap: rebate.frf.bap,
+      });
 
-  const frfNeedsEdits = false; // TODO: update when BAP FRF work is completed
+  const frfNeedsEditsAndPRFExists = frfNeedsEdits && !!rebate?.prf.formio;
+
+  /**
+   * NOTE: If the FRF submission needs edits and there's a corresponding PRF
+   * submission, display a confirmation dialog prompting the user to delete the
+   * PRF submission, as it's data will no longer valid when the FRF submission's
+   * data is changed.
+   */
+  if (frfNeedsEditsAndPRFExists) {
+    displayDialog({
+      dismissable: true,
+      heading: "Submission Edits Requested",
+      description: (
+        <>
+          <p>
+            This Application form submission has been opened at the request of
+            the applicant to make edits, but before you can make edits, the
+            associated Payment Request form submission needs to be deleted. If
+            the request to make edits to your Application form submission was
+            made in error, contact the Clean School Bus Program helpline at{" "}
+            <a href="mailto:cleanschoolbus@epa.gov">cleanschoolbus@epa.gov</a>.
+          </p>
+
+          <p>
+            If you’d like to view the Payment Request form submission before
+            deletion, please close this dialog box, and you will be re-directed
+            to the associated Payment Request form.
+          </p>
+
+          <p>
+            To proceed with deleting the associated Payment Request form
+            submission, please select the{" "}
+            <strong>Delete Payment Request Form Submission</strong> button
+            below, and the Payment Request form submission will be deleted. The
+            Application form will then be open for editing.
+          </p>
+
+          <div className="usa-alert usa-alert--error" role="alert">
+            <div className="usa-alert__body">
+              <p className="usa-alert__text">
+                <strong>Please note:</strong> Once deleted, the Payment Request
+                form submission will be removed from your dashboard and cannot
+                be recovered.
+              </p>
+            </div>
+          </div>
+        </>
+      ),
+      confirmText: "Delete Payment Request Form Submission",
+      confirmedAction: () => {
+        const prf = rebate.prf.formio;
+
+        if (!prf) {
+          displayErrorNotification({
+            id: Date.now(),
+            body: (
+              <>
+                <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                  Error deleting Payment Request <em>{rebate.rebateId}</em>.
+                </p>
+                <p className="tw-mt-1 tw-text-sm tw-text-gray-500">
+                  Please notify the helpdesk that a problem exists preventing
+                  the deletion of Payment Request form submission{" "}
+                  <em>{rebate.rebateId}</em>.
+                </p>
+              </>
+            ),
+          });
+
+          // NOTE: logging rebate for helpdesk debugging purposes
+          console.log(rebate);
+          return;
+        }
+
+        displayInfoNotification({
+          id: Date.now(),
+          body: (
+            <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+              Deleting Payment Request <em>{rebate.rebateId}</em>...
+            </p>
+          ),
+        });
+
+        const url = `${serverUrl}/api/formio/2023/delete-prf-submission`;
+
+        postData(url, {
+          mongoId: prf._id,
+          rebateId: prf.data.hidden_bap_rebate_id,
+          comboKey: prf.data.bap_hidden_entity_combo_key,
+        })
+          .then((_res) => {
+            window.location.reload();
+          })
+          .catch((_err) => {
+            displayErrorNotification({
+              id: Date.now(),
+              body: (
+                <>
+                  <p className="tw-text-sm tw-font-medium tw-text-gray-900">
+                    Error deleting Payment Request <em>{rebate.rebateId}</em>.
+                  </p>
+                  <p className="tw-mt-1 tw-text-sm tw-text-gray-500">
+                    Please reload the page to attempt the deletion again, or
+                    contact the helpdesk if the problem persists.
+                  </p>
+                </>
+              ),
+            });
+          });
+      },
+      dismissedAction: () => navigate(`/prf/2023/${rebate.rebateId}`),
+    });
+
+    return null;
+  }
 
   const frfSubmissionPeriodOpen =
     configData.submissionPeriodOpen[rebateYear].frf;
@@ -241,6 +358,19 @@ function FundingRequestForm(props: { email: string }) {
             <strong>Application ID:</strong> {submission._id}
           </div>
         </li>
+
+        {rebate?.frf.bap?.rebateId && (
+          <li className="usa-icon-list__item">
+            <div className="usa-icon-list__icon text-primary">
+              <svg className="usa-icon" aria-hidden="true" role="img">
+                <use href={`${icons}#local_offer`} />
+              </svg>
+            </div>
+            <div className="usa-icon-list__content">
+              <strong>Rebate ID:</strong> {rebate.frf.bap.rebateId}
+            </div>
+          </li>
+        )}
       </ul>
 
       <Dialog as="div" open={dataIsPosting.current} onClose={(_value) => {}}>

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -9,7 +9,6 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import { serverUrl, messages } from "@/config";
 import {
-  FormioFRF2023Submission,
   getData,
   postData,
   useContentData,
@@ -26,6 +25,7 @@ import { MarkdownContent } from "@/components/markdownContent";
 import { useDialogActions } from "@/contexts/dialog";
 import { useNotificationsActions } from "@/contexts/notifications";
 import { useRebateYearState } from "@/contexts/rebateYear";
+import type { FormioFRF2023Submission } from "@/utilities";
 
 type ServerResponse =
   | {

--- a/app/client/src/routes/frfNew.tsx
+++ b/app/client/src/routes/frfNew.tsx
@@ -6,9 +6,6 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import { serverUrl, messages } from "@/config";
 import {
-  BapSamEntity,
-  FormioFRF2022Submission,
-  FormioFRF2023Submission,
   postData,
   useContentData,
   useConfigData,
@@ -20,6 +17,11 @@ import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { TextWithTooltip } from "@/components/tooltip";
 import { useRebateYearState } from "@/contexts/rebateYear";
+import type {
+  BapSamEntity,
+  FormioFRF2022Submission,
+  FormioFRF2023Submission,
+} from "@/utilities";
 
 /**
  * Creates the initial FRF submission data for a given rebate year

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -14,11 +14,6 @@ import {
   bapCRFStatusMap,
 } from "@/config";
 import {
-  FormioFRF2022Submission,
-  FormioPRF2022Submission,
-  FormioCRF2022Submission,
-  FormioFRF2023Submission,
-  BapSubmission,
   getData,
   postData,
   useContentData,
@@ -30,10 +25,17 @@ import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { TextWithTooltip } from "@/components/tooltip";
 import {
-  RebateYear,
   useRebateYearState,
   useRebateYearActions,
 } from "@/contexts/rebateYear";
+import type { RebateYear } from "@/contexts/rebateYear";
+import type {
+  FormioFRF2022Submission,
+  FormioPRF2022Submission,
+  FormioCRF2022Submission,
+  FormioFRF2023Submission,
+  BapSubmission,
+} from "@/utilities";
 
 type FormType = "frf" | "prf" | "crf";
 

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -9,7 +9,6 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import { serverUrl, messages } from "@/config";
 import {
-  FormioPRF2022Submission,
   getData,
   postData,
   useContentData,
@@ -25,6 +24,7 @@ import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useNotificationsActions } from "@/contexts/notifications";
 import { useRebateYearState } from "@/contexts/rebateYear";
+import type { FormioPRF2022Submission } from "@/utilities";
 
 type ServerResponse =
   | {

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -842,7 +842,7 @@ function FRF2023Submission(props: {
   rebate: Extract<Rebate, { rebateYear: "2023" }>;
 }) {
   const { rebate } = props;
-  const { frf } = rebate;
+  const { frf, prf, crf } = rebate;
 
   const configData = useConfigData();
 
@@ -866,21 +866,15 @@ function FRF2023Submission(props: {
     bap: frf.bap,
   });
 
-  /**
-   * NOTE:
-   * Setting of the statuses below will occur once the BAP's 2023 FRF work has
-   * been completed, so the code below will be updated in the future.
-   */
+  const frfNeedsClarification = frf.bap?.status === "Needs Clarification";
 
-  const frfNeedsClarification = false; // frf.bap?.status === "Needs Clarification";
+  const frfHasBeenWithdrawn = frf.bap?.status === "Withdrawn";
 
-  const frfHasBeenWithdrawn = false; // frf.bap?.status === "Withdrawn";
+  const frfNotSelected = frf.bap?.status === "Coordinator Denied";
 
-  const frfNotSelected = false; // frf.bap?.status === "Coordinator Denied";
+  const frfSelected = frf.bap?.status === "Accepted";
 
-  const frfSelected = false; // frf.bap?.status === "Accepted";
-
-  const frfSelectedButNoPRF = false; // frfSelected && !Boolean(prf.formio);
+  const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
 
   const prfFundingApproved = false; // prf.bap?.status === "Accepted";
 
@@ -958,10 +952,16 @@ function FRF2023Submission(props: {
       </th>
 
       <td className={statusTableCellClassNames}>
-        <TextWithTooltip
-          text=" "
-          tooltip="Rebate ID will be displayed at a later date"
-        />
+        {frf.bap?.rebateId ? (
+          <span title={`Application ID: ${frf.formio._id}`}>
+            {frf.bap.rebateId}
+          </span>
+        ) : (
+          <TextWithTooltip
+            text=" "
+            tooltip="Rebate ID should be displayed within 24hrs. after submitting a rebate form application"
+          />
+        )}
       </td>
 
       <td className={statusTableCellClassNames}>

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -5,7 +5,6 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import { serverUrl, messages } from "@/config";
 import {
-  Rebate,
   postData,
   useContentData,
   useConfigData,
@@ -21,10 +20,19 @@ import { MarkdownContent } from "@/components/markdownContent";
 import { TextWithTooltip } from "@/components/tooltip";
 import { useNotificationsActions } from "@/contexts/notifications";
 import {
-  RebateYear,
   useRebateYearState,
   useRebateYearActions,
 } from "@/contexts/rebateYear";
+import type { RebateYear } from "@/contexts/rebateYear";
+import type {
+  FormioFRF2022Submission,
+  FormioPRF2022Submission,
+  FormioCRF2022Submission,
+  FormioFRF2023Submission,
+  // FormioPRF2023Submission,
+  // FormioCRF2023Submission,
+  Rebate,
+} from "@/utilities";
 
 const defaultTableRowClassNames = "bg-gray-5";
 const highlightedTableRowClassNames = "bg-primary-lighter";
@@ -129,9 +137,7 @@ function SubmissionsTableHeader() {
   );
 }
 
-function FRF2022Submission(props: {
-  rebate: Extract<Rebate, { rebateYear: "2022" }>;
-}) {
+function FRF2022Submission(props: { rebate: Rebate }) {
   const { rebate } = props;
   const { frf, prf, crf } = rebate;
 
@@ -148,7 +154,7 @@ function FRF2022Submission(props: {
     applicantOrganizationName,
     schoolDistrictName,
     last_updated_by,
-  } = frf.formio.data;
+  } = (frf.formio as FormioFRF2022Submission).data;
 
   const date = new Date(frf.formio.modified).toLocaleDateString();
   const time = new Date(frf.formio.modified).toLocaleTimeString();
@@ -376,9 +382,7 @@ save the form for the EFT indicator to be displayed. */
   );
 }
 
-function PRF2022Submission(props: {
-  rebate: Extract<Rebate, { rebateYear: "2022" }>;
-}) {
+function PRF2022Submission(props: { rebate: Rebate }) {
   const { rebate } = props;
   const { frf, prf, crf } = rebate;
 
@@ -406,10 +410,10 @@ function PRF2022Submission(props: {
 
   /** matched SAM.gov entity for the FRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    return (
-      entity.ENTITY_STATUS__c === "Active" &&
-      entity.ENTITY_COMBO_KEY__c === frf.formio.data.bap_hidden_entity_combo_key
-    );
+    const { ENTITY_STATUS__c, ENTITY_COMBO_KEY__c } = entity;
+    const comboKey = (frf.formio as FormioFRF2022Submission).data
+      .bap_hidden_entity_combo_key;
+    return ENTITY_STATUS__c === "Active" && ENTITY_COMBO_KEY__c === comboKey;
   });
 
   if (frfSelectedButNoPRF) {
@@ -485,7 +489,10 @@ function PRF2022Submission(props: {
   // return if a Payment Request submission has not been created for this rebate
   if (!prf.formio) return null;
 
-  const { hidden_current_user_email, hidden_bap_rebate_id } = prf.formio.data;
+  const {
+    hidden_current_user_email,
+    hidden_bap_rebate_id, //
+  } = (prf.formio as FormioPRF2022Submission).data;
 
   const date = new Date(prf.formio.modified).toLocaleDateString();
   const time = new Date(prf.formio.modified).toLocaleTimeString();
@@ -610,9 +617,7 @@ function PRF2022Submission(props: {
   );
 }
 
-function CRF2022Submission(props: {
-  rebate: Extract<Rebate, { rebateYear: "2022" }>;
-}) {
+function CRF2022Submission(props: { rebate: Rebate }) {
   const { rebate } = props;
   const { frf, prf, crf } = rebate;
 
@@ -640,11 +645,10 @@ function CRF2022Submission(props: {
 
   /** matched SAM.gov entity for the PRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    return (
-      entity.ENTITY_STATUS__c === "Active" &&
-      entity.ENTITY_COMBO_KEY__c ===
-        prf.formio?.data.bap_hidden_entity_combo_key
-    );
+    const { ENTITY_STATUS__c, ENTITY_COMBO_KEY__c } = entity;
+    const comboKey = (prf.formio as FormioPRF2022Submission | null)?.data
+      .bap_hidden_entity_combo_key;
+    return ENTITY_STATUS__c === "Active" && ENTITY_COMBO_KEY__c === comboKey;
   });
 
   if (prfFundingApprovedButNoCRF) {
@@ -720,7 +724,10 @@ function CRF2022Submission(props: {
   // return if a Close Out submission has not been created for this rebate
   if (!crf.formio) return null;
 
-  const { hidden_current_user_email, hidden_bap_rebate_id } = crf.formio.data;
+  const {
+    hidden_current_user_email,
+    hidden_bap_rebate_id, //
+  } = (crf.formio as FormioCRF2022Submission).data;
 
   const date = new Date(crf.formio.modified).toLocaleDateString();
   const time = new Date(crf.formio.modified).toLocaleTimeString();
@@ -838,9 +845,7 @@ function CRF2022Submission(props: {
   );
 }
 
-function FRF2023Submission(props: {
-  rebate: Extract<Rebate, { rebateYear: "2023" }>;
-}) {
+function FRF2023Submission(props: { rebate: Rebate }) {
   const { rebate } = props;
   const { frf, prf, crf } = rebate;
 
@@ -856,7 +861,7 @@ function FRF2023Submission(props: {
     appInfo_orgName,
     _formio_schoolDistrictName,
     _user_email,
-  } = frf.formio.data;
+  } = (frf.formio as FormioFRF2023Submission).data;
 
   const date = new Date(frf.formio.modified).toLocaleDateString();
   const time = new Date(frf.formio.modified).toLocaleTimeString();
@@ -876,9 +881,9 @@ function FRF2023Submission(props: {
 
   const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
 
-  const prfFundingApproved = false; // prf.bap?.status === "Accepted";
+  const prfFundingApproved = prf.bap?.status === "Accepted";
 
-  const prfFundingApprovedButNoCRF = prfFundingApproved; // prfFundingApproved && !Boolean(crf.formio);
+  const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
 
   const statusTableCellClassNames =
     frf.formio.state === "submitted" || !frfSubmissionPeriodOpen

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -199,6 +199,16 @@ type FormioFRF2023Data = {
   _formio_schoolDistrictName: string;
 };
 
+type FormioPRF2023Data = {
+  [field: string]: unknown;
+  // TODO: add PRF fields
+};
+
+type FormioCRF2023Data = {
+  [field: string]: unknown;
+  // TODO: add CRF fields
+};
+
 export type FormioFRF2022Submission = FormioSubmission & {
   data: FormioFRF2022Data;
 };
@@ -213,6 +223,14 @@ export type FormioCRF2022Submission = FormioSubmission & {
 
 export type FormioFRF2023Submission = FormioSubmission & {
   data: FormioFRF2023Data;
+};
+
+export type FormioPRF2023Submission = FormioSubmission & {
+  data: FormioPRF2023Data;
+};
+
+export type FormioCRF2023Submission = FormioSubmission & {
+  data: FormioCRF2023Data;
 };
 
 export type BapSubmission = {
@@ -474,6 +492,24 @@ export function useSubmissionsQueries(rebateYear: RebateYear) {
     refetchOnWindowFocus: false,
   };
 
+  const formioPRF2023Query = {
+    queryKey: ["formio/2023/prf-submissions"],
+    queryFn: () => {
+      const url = `${serverUrl}/api/formio/2023/prf-submissions`;
+      return getData<FormioPRF2023Submission[]>(url);
+    },
+    refetchOnWindowFocus: false,
+  };
+
+  const formioCRF2023Query = {
+    queryKey: ["formio/2023/crf-submissions"],
+    queryFn: () => {
+      const url = `${serverUrl}/api/formio/2023/crf-submissions`;
+      return getData<FormioCRF2023Submission[]>(url);
+    },
+    refetchOnWindowFocus: false,
+  };
+
   type Query = {
     queryKey: string[];
     queryFn: () =>
@@ -481,7 +517,9 @@ export function useSubmissionsQueries(rebateYear: RebateYear) {
       | Promise<FormioFRF2022Submission[]>
       | Promise<FormioPRF2022Submission[]>
       | Promise<FormioCRF2022Submission[]>
-      | Promise<FormioFRF2023Submission[]>;
+      | Promise<FormioFRF2023Submission[]>
+      | Promise<FormioPRF2023Submission[]>
+      | Promise<FormioCRF2023Submission[]>;
     refetchOnWindowFocus: boolean;
   };
 
@@ -489,7 +527,7 @@ export function useSubmissionsQueries(rebateYear: RebateYear) {
     rebateYear === "2022"
       ? [bapQuery, formioFRF2022Query, formioPRF2022Query, formioCRF2022Query]
       : rebateYear === "2023"
-      ? [bapQuery, formioFRF2023Query]
+      ? [bapQuery, formioFRF2023Query, formioPRF2023Query, formioCRF2023Query]
       : [];
 
   return useQueries({ queries });
@@ -713,6 +751,8 @@ function useCombinedSubmissions(rebateYear: RebateYear) {
   const formioFRF2023Submissions = queryClient.getQueryData<
     FormioFRF2023Submission[]
   >(["formio/2023/frf-submissions"]);
+
+  // TODO: add formioPRF2023Submissions and formioCRF2023Submissions
 
   const submissions =
     rebateYear === "2022"

--- a/app/server/app/routes/formio2022.js
+++ b/app/server/app/routes/formio2022.js
@@ -41,7 +41,7 @@ router.get(
   storeBapComboKeys,
   (req, res) => {
     downloadS3FileMetadata({ rebateYear: "2022", req, res });
-  }
+  },
 );
 
 // --- upload Formio S3 file metadata
@@ -50,7 +50,7 @@ router.post(
   storeBapComboKeys,
   (req, res) => {
     uploadS3FileMetadata({ rebateYear: "2022", req, res });
-  }
+  },
 );
 
 // --- get user's 2022 FRF submissions from Formio
@@ -70,7 +70,7 @@ router.get(
   storeBapComboKeys,
   (req, res) => {
     fetchFRFSubmission({ rebateYear: "2022", req, res });
-  }
+  },
 );
 
 // --- post an update to an existing draft 2022 FRF submission to Formio
@@ -80,7 +80,7 @@ router.post(
   storeBapComboKeys,
   (req, res) => {
     updateFRFSubmission({ rebateYear: "2022", req, res });
-  }
+  },
 );
 
 // --- get user's 2022 PRF submissions from Formio
@@ -92,7 +92,7 @@ router.get("/prf-submissions", storeBapComboKeys, (req, res) => {
     `?sort=-modified` +
     `&limit=1000000` +
     `&data.bap_hidden_entity_combo_key=${bapComboKeys.join(
-      "&data.bap_hidden_entity_combo_key="
+      "&data.bap_hidden_entity_combo_key=",
     )}`;
 
   axiosFormio(req)
@@ -439,7 +439,7 @@ router.get("/crf-submissions", storeBapComboKeys, (req, res) => {
     `?sort=-modified` +
     `&limit=1000000` +
     `&data.bap_hidden_entity_combo_key=${bapComboKeys.join(
-      "&data.bap_hidden_entity_combo_key="
+      "&data.bap_hidden_entity_combo_key=",
     )}`;
 
   axiosFormio(req)

--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -38,7 +38,7 @@ router.get(
   storeBapComboKeys,
   (req, res) => {
     downloadS3FileMetadata({ rebateYear: "2023", req, res });
-  }
+  },
 );
 
 // --- upload Formio S3 file metadata
@@ -47,7 +47,7 @@ router.post(
   storeBapComboKeys,
   (req, res) => {
     uploadS3FileMetadata({ rebateYear: "2023", req, res });
-  }
+  },
 );
 
 // --- get user's 2023 FRF submissions from Formio
@@ -67,7 +67,7 @@ router.get(
   storeBapComboKeys,
   (req, res) => {
     fetchFRFSubmission({ rebateYear: "2023", req, res });
-  }
+  },
 );
 
 // --- post an update to an existing draft 2023 FRF submission to Formio
@@ -77,7 +77,20 @@ router.post(
   storeBapComboKeys,
   (req, res) => {
     updateFRFSubmission({ rebateYear: "2023", req, res });
-  }
+  },
 );
+
+// --- get user's 2023 PRF submissions from Formio
+
+// --- post a new 2023 PRF submission to Formio
+
+// --- get an existing 2023 PRF's schema and submission data from Formio
+
+// --- post an update to an existing draft 2023 PRF submission to Formio
+
+// --- delete an existing 2023 PRF submission from Formio
+router.post("/delete-prf-submission", storeBapComboKeys, (req, res) => {
+  // TODO
+});
 
 module.exports = router;

--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -81,6 +81,10 @@ router.post(
 );
 
 // --- get user's 2023 PRF submissions from Formio
+router.get("/prf-submissions", storeBapComboKeys, (req, res) => {
+  // TODO
+  res.json([]);
+});
 
 // --- post a new 2023 PRF submission to Formio
 
@@ -92,5 +96,17 @@ router.post(
 router.post("/delete-prf-submission", storeBapComboKeys, (req, res) => {
   // TODO
 });
+
+// --- get user's 2022 CRF submissions from Formio
+router.get("/crf-submissions", storeBapComboKeys, (req, res) => {
+  // TODO
+  res.json([]);
+});
+
+// --- post a new 2022 CRF submission to Formio
+
+// --- get an existing 2022 CRF's schema and submission data from Formio
+
+// --- post an update to an existing draft 2022 CRF submission to Formio
 
 module.exports = router;

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -495,7 +495,7 @@ async function queryForBapFormSubmissionsStatuses(req, comboKeys) {
         CSB_Modified_Full_String__c: 1, // ISO 8601 date time string
         CSB_Review_Item_ID__c: 1, // CSB Rebate ID with form/version ID (9 digits)
         Parent_Rebate_ID__c: 1, // CSB Rebate ID (6 digits)
-        Record_Type_Name__c: 1, // 'CSB Funding Request' | 'CSB Payment Request' | 'CSB Close Out Request' // TODO: update with new names
+        Record_Type_Name__c: 1, // 'CSB Funding Request' | 'CSB Payment Request' | 'CSB Close Out Request' | 'CSB Funding Request 2023' | 'CSB Payment Request 2023' | 'CSB Close Out Request 2023'
         Rebate_Program_Year__c: 1, // '2022' | '2023'
         "Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c": 1,

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -45,6 +45,7 @@ const { submissionPeriodOpen } = require("../config/formio");
  * @property {string} CSB_Review_Item_ID__c
  * @property {string} Parent_Rebate_ID__c
  * @property {string} Record_Type_Name__c
+ * @property {string | null} Rebate_Program_Year__c
  * @property {{
  *  CSB_Funding_Request_Status__c: string
  *  CSB_Payment_Request_Status__c: string
@@ -466,6 +467,7 @@ async function queryForBapFormSubmissionsStatuses(req, comboKeys) {
   //   CSB_Review_Item_ID__c,
   //   Parent_Rebate_ID__c,
   //   Record_Type_Name__c,
+  //   Rebate_Program_Year__c,
   //   Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c,
   //   Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c,
   //   Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c
@@ -493,7 +495,8 @@ async function queryForBapFormSubmissionsStatuses(req, comboKeys) {
         CSB_Modified_Full_String__c: 1, // ISO 8601 date time string
         CSB_Review_Item_ID__c: 1, // CSB Rebate ID with form/version ID (9 digits)
         Parent_Rebate_ID__c: 1, // CSB Rebate ID (6 digits)
-        Record_Type_Name__c: 1, // 'CSB Funding Request' | 'CSB Payment Request' | 'CSB Close Out Request'
+        Record_Type_Name__c: 1, // 'CSB Funding Request' | 'CSB Payment Request' | 'CSB Close Out Request' // TODO: update with new names
+        Rebate_Program_Year__c: 1, // '2022' | '2023'
         "Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c": 1,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-252

## Main Changes:
* Fetches submission data from the BAP for 2023 submissions to support showing BAP submission statuses on the user's dashboard for 2023 submissions.
* Reduces a bit of duplicated code for combining submission data from the BAP and Formio that's now used for both 2022 and 2023 submissions.

## Steps To Test:
1. Create some FRF submissions for 2023
2. Request the BAP team to change the status of a few submissions
3. Ensure statuses are reflected as expected on the dashboard, along with all functionality related to statuses (e.g. "Edits Requested").
