### PR TITLE
Feature/update 2023 prf bus max rebate field

### DIFF
--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -287,9 +287,9 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               orgContactFName: newOwnerRecord?.Contact__r?.FirstName,
               orgContactLName: newOwnerRecord?.Contact__r?.LastName,
             },
-            bus_rebate: New_Bus_Infra_Rebate_Requested__c,
             bus_newFuelType: New_Bus_Fuel_Type__c,
             bus_newGvwr: New_Bus_GVWR__c,
+            _bus_maxRebate: New_Bus_Infra_Rebate_Requested__c,
             _bus_newADAfromFRF: New_Bus_ADA_Compliant__c,
           };
         });


### PR DESCRIPTION
## Related Issues:
* CSBAPP-275

## Main Changes:
Update name of field used in a brand new 2023 PRF submission for storing each bus's max rebate amount

## Steps To Test:
1. Ask the BAP to change an existing 2023 FRF submission's status to "Accepted"
2. Create a new 2023 PRF submission.
3. Ensure the injected data for each bus's max rebate amount is correct (`bus_buses.[index]._bus_maxRebate`).

## TODO:
- [ ] Continue to update queries on the BAP team provides a means to get the data we still need for a new PRF submission.
