### PR TITLE
Feature/update no active sam message

### DIFF
--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -37,9 +37,11 @@ export const messages = {
   samlError: "Error logging in. Please try again or contact support.",
   bapSamFetchError: "Error loading SAM.gov data. Please contact support.",
   bapNoSamResults:
-    "No SAM.gov records match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
+    "No SAM.gov accounts match your email. Only Government and Electronic Business SAM.gov Points of Contacts (and alternates) may edit and submit Clean School Bus Rebate Forms.",
   bapSamEntityNotActive:
     "Your SAM.gov account is currently not active. Activate your SAM.gov account to access this submission.",
+  bapSamNoActiveEntities:
+    "There are no active SAM.gov accounts associated with your email. Ensure you have at least one active SAM.gov account to create a new application.",
   bapSamAtLeastOneEntityNotActive:
     "At least one of your SAM.gov accounts is currently not active. Any submissions associated with that SAM.gov account will be inaccessible until the account is re-activated.",
   formSubmissionError:

--- a/app/client/src/routes/frfNew.tsx
+++ b/app/client/src/routes/frfNew.tsx
@@ -213,7 +213,10 @@ export function FRFNew() {
                     </div>
                   ) : activeSamEntities.length <= 0 ? (
                     <div className={clsx("-tw-mb-4")}>
-                      <Message type="info" text={messages.bapNoSamResults} />
+                      <Message
+                        type="info"
+                        text={messages.bapSamNoActiveEntities}
+                      />
                     </div>
                   ) : (
                     <>


### PR DESCRIPTION
## Related Issues:
* CSBAPP-303

## Main Changes:
* Update message shown if a user has no active SAM.gov records, and clicks the 'New Application' button
* Update language used in the no SAM.gov results message on the welcome page to be consistent with the phrasing of SAM.gov accounts

## Steps To Test:
1. Navigate to dashboard. Ensure your user has no active SAM.gov records (easier to do when running the app locally).
2. Click the "New Application" button, and ensure the message makes sense for that context.
