### PR TITLE
Remove no longer used BAP env variables in GitHub Workflow actions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -64,9 +64,6 @@ jobs:
       BAP_URL: ${{ secrets.BAP_URL }}
       BAP_USER: ${{ secrets.BAP_USER }}
       BAP_PASSWORD: ${{ secrets.BAP_PASSWORD }}
-      BAP_SAM_TABLE: ${{ secrets.BAP_SAM_TABLE }}
-      BAP_FORMS_TABLE: ${{ secrets.BAP_FORMS_TABLE }}
-      BAP_BUS_TABLE: ${{ secrets.BAP_BUS_TABLE }}
       AWS_ACCESS_KEY_ID: ${{ secrets.S3_PUBLIC_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_PUBLIC_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ${{ secrets.S3_PUBLIC_REGION }}
@@ -153,9 +150,6 @@ jobs:
           cf set-env $APP_NAME "BAP_URL" "$BAP_URL" > /dev/null
           cf set-env $APP_NAME "BAP_USER" "$BAP_USER" > /dev/null
           cf set-env $APP_NAME "BAP_PASSWORD" "$BAP_PASSWORD" > /dev/null
-          cf set-env $APP_NAME "BAP_SAM_TABLE" "$BAP_SAM_TABLE" > /dev/null
-          cf set-env $APP_NAME "BAP_FORMS_TABLE" "$BAP_FORMS_TABLE" > /dev/null
-          cf set-env $APP_NAME "BAP_BUS_TABLE" "$BAP_BUS_TABLE" > /dev/null
           cf set-env $APP_NAME "S3_PUBLIC_BUCKET" "$S3_PUBLIC_BUCKET" > /dev/null
           cf set-env $APP_NAME "S3_PUBLIC_REGION" "$AWS_DEFAULT_REGION" > /dev/null
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -64,9 +64,6 @@ jobs:
       BAP_URL: ${{ secrets.BAP_URL }}
       BAP_USER: ${{ secrets.BAP_USER }}
       BAP_PASSWORD: ${{ secrets.BAP_PASSWORD }}
-      BAP_SAM_TABLE: ${{ secrets.BAP_SAM_TABLE }}
-      BAP_FORMS_TABLE: ${{ secrets.BAP_FORMS_TABLE }}
-      BAP_BUS_TABLE: ${{ secrets.BAP_BUS_TABLE }}
       AWS_ACCESS_KEY_ID: ${{ secrets.S3_PUBLIC_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_PUBLIC_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ${{ secrets.S3_PUBLIC_REGION }}
@@ -153,9 +150,6 @@ jobs:
           cf set-env $APP_NAME "BAP_URL" "$BAP_URL" > /dev/null
           cf set-env $APP_NAME "BAP_USER" "$BAP_USER" > /dev/null
           cf set-env $APP_NAME "BAP_PASSWORD" "$BAP_PASSWORD" > /dev/null
-          cf set-env $APP_NAME "BAP_SAM_TABLE" "$BAP_SAM_TABLE" > /dev/null
-          cf set-env $APP_NAME "BAP_FORMS_TABLE" "$BAP_FORMS_TABLE" > /dev/null
-          cf set-env $APP_NAME "BAP_BUS_TABLE" "$BAP_BUS_TABLE" > /dev/null
           cf set-env $APP_NAME "S3_PUBLIC_BUCKET" "$S3_PUBLIC_BUCKET" > /dev/null
           cf set-env $APP_NAME "S3_PUBLIC_REGION" "$AWS_DEFAULT_REGION" > /dev/null
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-275

## Main Changes:
* Remove no longer used BAP env variables in GitHub Workflow actions

## Steps To Test:
N/A – everything should still work, as the env variables are no longer used in the app.
