### PR TITLE
Feature/add 2023 prf status endpoint

### DIFF
--- a/app/server/app/routes/status.js
+++ b/app/server/app/routes/status.js
@@ -84,4 +84,30 @@ router.get("/formio/2023/frf", (req, res) => {
     });
 });
 
+router.get("/formio/2023/prf", (req, res) => {
+  axiosFormio(req)
+    .get(formUrl["2023"].prf)
+    .then((axiosRes) => axiosRes.data)
+    .then((schema) => {
+      return res.json({ status: verifySchema(schema) });
+    })
+    .catch((error) => {
+      // NOTE: error is logged in axiosFormio response interceptor
+      return res.json({ status: false });
+    });
+});
+
+// router.get("/formio/2023/crf", (req, res) => {
+//   axiosFormio(req)
+//     .get(formUrl["2023"].crf)
+//     .then((axiosRes) => axiosRes.data)
+//     .then((schema) => {
+//       return res.json({ status: verifySchema(schema) });
+//     })
+//     .catch((error) => {
+//       // NOTE: error is logged in axiosFormio response interceptor
+//       return res.json({ status: false });
+//     });
+// });
+
 module.exports = router;


### PR DESCRIPTION
## Related Issues:
* CSBAPP-310

## Main Changes:
* Add status web service endpoint for 2023 PRF uptime monitoring

## Steps To Test:
1. Navigate to `/api/status/formio/2023/prf` and ensure you get a JSON response of `{"status":true}`

## TODO:
- [ ] Update StatusCake uptime monitoring with new endpoint for 2023 PRF
