### PR TITLE
Feature/fetch nces from s3

### DIFF
--- a/app/server/app/utilities/s3.js
+++ b/app/server/app/utilities/s3.js
@@ -1,0 +1,5 @@
+const { S3_PUBLIC_BUCKET, S3_PUBLIC_REGION } = process.env;
+
+const s3BucketUrl = `https://${S3_PUBLIC_BUCKET}.s3-${S3_PUBLIC_REGION}.amazonaws.com`;
+
+module.exports = { s3BucketUrl };


### PR DESCRIPTION
## Related Issues:
* CSBAPP-311

## Main Changes:
Switch from serving the NCES.json file directly within the app to fetching it from the public S3 bucket – will allow for updating of the NCES data at any point in the future without having to go through a new scan/release.

## Steps To Test:
1. Create (or edit) a 2022 or 2023 FRF submission.
2. Ensure the NCES data is fetched properly, and the Formio form still functions as expected (pay particular attention to any new latency due to the data now being fetched from the server).
