### PR TITLE
Feature/apply updates around bap prf queries

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -978,60 +978,62 @@ async function queryBapFor2023PRFData(req, frfReviewItemId) {
     )
     .execute(async (err, records) => ((await err) ? err : records));
 
-  const frf2023BusRecordsContactsQueries = await Promise.all(
-    frf2023BusRecordsQuery.map(async (frf2023BusRecord) => {
-      const frf2023BusRecordId = frf2023BusRecord.Id;
+  const frf2023BusRecordsContactsQueries = (
+    await Promise.all(
+      frf2023BusRecordsQuery.map(async (frf2023BusRecord) => {
+        const frf2023BusRecordId = frf2023BusRecord.Id;
 
-      // `SELECT
-      //   Id,
-      //   Related_Line_Item__c,
-      //   Relationship_Type__c,
-      //   Contact_Organization_Name__c,
-      //   Contact__r.Id,
-      //   Contact__r.FirstName,
-      //   Contact__r.LastName
-      //   Contact__r.Title,
-      //   Contact__r.Email,
-      //   Contact__r.Phone,
-      //   Contact__r.AccountId
-      // FROM
-      //   Line_Item__c
-      // WHERE
-      //   RecordTypeId = '${rebateItemRecordTypeId}' AND
-      //   Related_Line_Item__c = '${frf2023BusRecordId}' AND
-      //   CSB_Rebate_Item_Type__c = 'COF Relationship'`
+        // `SELECT
+        //   Id,
+        //   Related_Line_Item__c,
+        //   Relationship_Type__c,
+        //   Contact_Organization_Name__c,
+        //   Contact__r.Id,
+        //   Contact__r.FirstName,
+        //   Contact__r.LastName
+        //   Contact__r.Title,
+        //   Contact__r.Email,
+        //   Contact__r.Phone,
+        //   Contact__r.AccountId
+        // FROM
+        //   Line_Item__c
+        // WHERE
+        //   RecordTypeId = '${rebateItemRecordTypeId}' AND
+        //   Related_Line_Item__c = '${frf2023BusRecordId}' AND
+        //   CSB_Rebate_Item_Type__c = 'COF Relationship'`
 
-      return await bapConnection
-        .sobject("Line_Item__c")
-        .find(
-          {
-            RecordTypeId: rebateItemRecordTypeId,
-            Related_Line_Item__c: frf2023BusRecordId,
-            CSB_Rebate_Item_Type__c: "COF Relationship",
-          },
-          {
-            // "*": 1,
-            Id: 1, // Salesforce record ID
-            Related_Line_Item__c: 1,
-            Relationship_Type__c: 1,
-            Contact_Organization_Name__c: 1,
-            "Contact__r.Id": 1,
-            "Contact__r.FirstName": 1,
-            "Contact__r.LastName": 1,
-            "Contact__r.Title": 1,
-            "Contact__r.Email": 1,
-            "Contact__r.Phone": 1,
-            "Contact__r.AccountId": 1,
-          },
-        )
-        .execute(async (err, records) => ((await err) ? err : records));
-    }),
-  );
+        return await bapConnection
+          .sobject("Line_Item__c")
+          .find(
+            {
+              RecordTypeId: rebateItemRecordTypeId,
+              Related_Line_Item__c: frf2023BusRecordId,
+              CSB_Rebate_Item_Type__c: "COF Relationship",
+            },
+            {
+              // "*": 1,
+              Id: 1, // Salesforce record ID
+              Related_Line_Item__c: 1,
+              Relationship_Type__c: 1,
+              Contact_Organization_Name__c: 1,
+              "Contact__r.Id": 1,
+              "Contact__r.FirstName": 1,
+              "Contact__r.LastName": 1,
+              "Contact__r.Title": 1,
+              "Contact__r.Email": 1,
+              "Contact__r.Phone": 1,
+              "Contact__r.AccountId": 1,
+            },
+          )
+          .execute(async (err, records) => ((await err) ? err : records));
+      }),
+    )
+  ).flat();
 
   return {
     frf2023RecordQuery,
     frf2023BusRecordsQuery,
-    frf2023BusRecordsContactsQueries: frf2023BusRecordsContactsQueries.flat(),
+    frf2023BusRecordsContactsQueries,
   };
 }
 

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -172,8 +172,13 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  Relationship_Type__c: string
  *  Contact_Organization_Name__c: string
  *  Contact__r: {
+ *    Id: string
  *    FirstName: string
  *    LastName: string
+ *    Title: string
+ *    Email: string
+ *    Phone: string
+ *    AccountId: string
  *  } | null
  * }[]} frf2023BusRecordsContactsQueries
  * @property {{
@@ -982,8 +987,13 @@ async function queryBapFor2023PRFData(req, frfReviewItemId) {
       //   Related_Line_Item__c,
       //   Relationship_Type__c,
       //   Contact_Organization_Name__c,
+      //   Contact__r.Id,
       //   Contact__r.FirstName,
       //   Contact__r.LastName
+      //   Contact__r.Title,
+      //   Contact__r.Email,
+      //   Contact__r.Phone,
+      //   Contact__r.AccountId
       // FROM
       //   Line_Item__c
       // WHERE
@@ -1005,8 +1015,13 @@ async function queryBapFor2023PRFData(req, frfReviewItemId) {
             Related_Line_Item__c: 1,
             Relationship_Type__c: 1,
             Contact_Organization_Name__c: 1,
+            "Contact__r.Id": 1,
             "Contact__r.FirstName": 1,
             "Contact__r.LastName": 1,
+            "Contact__r.Title": 1,
+            "Contact__r.Email": 1,
+            "Contact__r.Phone": 1,
+            "Contact__r.AccountId": 1,
           },
         )
         .execute(async (err, records) => ((await err) ? err : records));

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -182,6 +182,15 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  } | null
  * }[]} frf2023BusRecordsContactsQueries
  * @property {{
+ *  Id: string
+ *  Name: string
+ *  BillingStreet: string
+ *  BillingCountry: string
+ *  BillingCity: string
+ *  BillingState: string
+ *  BillingPostalCode: string
+ * }[]} frf2023BusRecordsContactsOrgsQueries
+ * @property {{
  *  type: string
  *  url: string
  * }} attributes
@@ -1030,10 +1039,23 @@ async function queryBapFor2023PRFData(req, frfReviewItemId) {
     )
   ).flat();
 
+  const frf2023BusRecordsContactsAccountIds = [
+    ...new Set(
+      frf2023BusRecordsContactsQueries.map((item) => item.Contact__r.AccountId),
+    ),
+  ];
+
+  const frf2023BusRecordsContactsOrgsQueries = await bapConnection
+    .sobject("Account")
+    .retrieve(frf2023BusRecordsContactsAccountIds, async (err, records) =>
+      (await err) ? err : records,
+    );
+
   return {
     frf2023RecordQuery,
     frf2023BusRecordsQuery,
     frf2023BusRecordsContactsQueries,
+    frf2023BusRecordsContactsOrgsQueries,
   };
 }
 

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -191,6 +191,10 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
           Prioritized_as_Rural__c,
         } = frf2023RecordQuery[0];
 
+        const [schoolDistrictAddress1, schoolDistrictAddress2] = (
+          CSB_School_District__r?.BillingStreet ?? "\n"
+        ).split("\n");
+
         // TODO: ask BAP for the query for the fields below.
         // NOTE: the data from the 2023 FRF is in an 'organizations' field (array of objects)
         // which has the exact same fields below, except for "_org_typeCombined"
@@ -330,8 +334,8 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             _bap_alternate_phone_number: Alternate_Applicant__r?.Phone,
             _bap_district_ncesID: CSB_NCES_ID__c,
             _bap_district_name: CSB_School_District__r?.Name,
-            _bap_district_address_1: CSB_School_District__r?.BillingStreet, // TODO: once BAP returns this field with a new line character, split on it for address line 1 and 2
-            _bap_district_address_2: "", // TODO: see above
+            _bap_district_address_1: schoolDistrictAddress1 || "",
+            _bap_district_address_2: schoolDistrictAddress2 || "",
             _bap_district_city: CSB_School_District__r?.BillingCity,
             _bap_district_state: CSB_School_District__r?.BillingState,
             _bap_district_zip: CSB_School_District__r?.BillingPostalCode,

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -250,7 +250,8 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             ({ Related_Line_Item__c, Relationship_Type__c }) => {
               return (
                 Related_Line_Item__c === Id &&
-                Relationship_Type__c === "Existing Bus Owner"
+                Relationship_Type__c ===
+                  "Old Bus Private Fleet Owner (if changed)"
               );
             },
           );

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -268,7 +268,6 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
           return {
             bus_busNumber: Rebate_Item_num__c,
             bus_existingOwner: {
-              org: "", // TODO: ask BAP how to get this value
               organization: existingOwnerRecord?.Contact_Organization_Name__c,
               orgContactFName: existingOwnerRecord?.Contact__r?.FirstName,
               orgContactLName: existingOwnerRecord?.Contact__r?.LastName,
@@ -287,7 +286,6 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             bus_existingRemainingLife: Old_Bus_Estimated_Remaining_Life__c,
             bus_existingIdlingHours: Old_Bus_Annual_Idling_Hours__c,
             bus_newOwner: {
-              org: "", // TODO: ask BAP how to get this value
               organization: newOwnerRecord?.Contact_Organization_Name__c,
               orgContactFName: newOwnerRecord?.Contact__r?.FirstName,
               orgContactLName: newOwnerRecord?.Contact__r?.LastName,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-275

## Main Changes:
* Updates the BAP queries to get most of the organization data user entered into a 2023 FRF, and injects it into a brand new 2023 PRF submission (continues work begun in #377).

## Steps To Test:
1. Ask the BAP to change an existing 2023 FRF submission's status to "Accepted"
2. Create a new 2023 PRF submission.
3. Ensure the injected data for organizations is correct (excluding "Private Fleet" orgs, which we still need guidance from the BAP on if we're able to get that data)

## TODO:
- [ ] Follow up with BAP team on if we're able to get "Private Fleet" orgs and orgs added in a 2023 FRF that were not associated with a bus.
