### PR TITLE
Feature/update new 2023 prf orgs logic

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -110,6 +110,9 @@ const { submissionPeriodOpen } = require("../config/formio");
  * @typedef {Object} BapDataFor2023PRF
  * @property {{
  *  Id: string
+ *  CSB_Snapshot__r: {
+ *    JSON_Snapshot__c: string
+ *  }
  *  Primary_Applicant__r: {
  *    FirstName: string
  *    LastName: string
@@ -825,6 +828,7 @@ async function queryBapFor2023PRFData(req, frfReviewItemId) {
 
   // `SELECT
   //   Id,
+  //   CSB_Snapshot__r.JSON_Snapshot__c
   //   Primary_Applicant__r.FirstName,
   //   Primary_Applicant__r.LastName,
   //   Primary_Applicant__r.Title,
@@ -869,6 +873,7 @@ async function queryBapFor2023PRFData(req, frfReviewItemId) {
       {
         // "*": 1,
         Id: 1, // Salesforce record ID
+        "CSB_Snapshot__r.JSON_Snapshot__c": 1,
         "Primary_Applicant__r.FirstName": 1,
         "Primary_Applicant__r.LastName": 1,
         "Primary_Applicant__r.Title": 1,

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -197,7 +197,6 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
         } = frf2023RecordQuery[0];
 
         const frf2023RecordJson = JSON.parse(CSB_Snapshot__r.JSON_Snapshot__c);
-        const frf2023RecordJsonOrgs = frf2023RecordJson.data.organizations;
 
         const [schoolDistrictStreetAddress1, schoolDistrictStreetAddress2] = (
           CSB_School_District__r?.BillingStreet ?? "\n"
@@ -215,7 +214,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               BillingPostalCode,
             } = frf2023BusRecordsContactsOrgs;
 
-            const jsonOrg = frf2023RecordJsonOrgs.find(
+            const jsonOrg = frf2023RecordJson.data.organizations.find(
               (item) => item.org_orgName === Name,
             );
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-275

## Main Changes:
* Update to #399 – uses the "JSON snapshot" returned from the BAP (which is the Formio submission data the BAP fetched and stores for each submission) to compare against when building up the "org_organizations" array that's included in a new 2023 PRF submission. This is important, as it ensures we're not inadvertently including the primary applicant or school district's org info in that array, as it wasn't in the 2023 FRF's "organizations" array.

## Steps To Test:
1. Ask the BAP to change an existing 2023 FRF submission's status to "Accepted" – the FRF submission should be one where no "organizations" were created. Any buses in that FRF should use the applicant's primary org or the school district org as "existing bus contact" and "new bus contact" assigned to the bus. This means the "organizations" array should be empty.
2. Create a new 2023 PRF submission.
3. Ensure the injected data for organizations matches the organizations data from the corresponding 2023 FRF (an empty array).
