### PR TITLE
Feature/add applicant org county data

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -114,6 +114,10 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  CSB_Snapshot__r: {
  *    JSON_Snapshot__c: string
  *  }
+ *  Applicant_Organization__r: {
+ *    Id: string
+ *    County__c: string
+ *  }
  *  Primary_Applicant__r: {
  *    Id: string
  *    FirstName: string
@@ -837,6 +841,8 @@ async function queryBapFor2023PRFData(req, frfReviewItemId) {
   // `SELECT
   //   Id,
   //   CSB_Snapshot__r.JSON_Snapshot__c
+  //   Applicant_Organization__r.Id
+  //   Applicant_Organization__r.County__c
   //   Primary_Applicant__r.Id,
   //   Primary_Applicant__r.FirstName,
   //   Primary_Applicant__r.LastName,
@@ -886,6 +892,8 @@ async function queryBapFor2023PRFData(req, frfReviewItemId) {
         // "*": 1,
         Id: 1, // Salesforce record ID
         "CSB_Snapshot__r.JSON_Snapshot__c": 1,
+        "Applicant_Organization__r.Id": 1,
+        "Applicant_Organization__r.County__c": 1,
         "Primary_Applicant__r.Id": 1,
         "Primary_Applicant__r.FirstName": 1,
         "Primary_Applicant__r.LastName": 1,

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -185,6 +185,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
 
         const {
           CSB_Snapshot__r,
+          Applicant_Organization__r,
           Primary_Applicant__r,
           Alternate_Applicant__r,
           CSB_School_District__r,
@@ -374,7 +375,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             _bap_applicant_organization_name: LEGAL_BUSINESS_NAME__c,
             _bap_applicant_street_address_1: PHYSICAL_ADDRESS_LINE_1__c,
             _bap_applicant_street_address_2: PHYSICAL_ADDRESS_LINE_2__c,
-            _bap_applicant_county: "", // TODO: ask BAP how to get this value
+            _bap_applicant_county: Applicant_Organization__r?.County__c,
             _bap_applicant_city: PHYSICAL_ADDRESS_CITY__c,
             _bap_applicant_state: PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c,
             _bap_applicant_zip: PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-275

## Main Changes:
Update BAP query for 2023 PRF data to fetch the applicant organization county and inject that into a brand new 2023 PRF submission

## Steps To Test:
1. Ask the BAP to change an existing 2023 FRF submission's status to "Accepted"
2. Create a new 2023 PRF submission.
3. Ensure new PRF includes the county entered into the corresponding 2023 FRF

NOTE: because we're creating multiple submissions with the same SAM.gov entity when testing, the BAP query returns the latest county value stored in the applicant organization Salesforce record, which looks like it's being updated every time the ETL runs with whatever the last county value was used for that SAM.gov entity in a FRF submission.
