### PR TITLE
Feature/update 2023 prf org type data

### DIFF
--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -205,8 +205,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
 
         const org_organizations = frf2023BusRecordsContactsQueries.reduce(
           (array, frf2023BusRecordsContact) => {
-            const { Relationship_Type__c, Contact__r } =
-              frf2023BusRecordsContact;
+            const { Contact__r } = frf2023BusRecordsContact;
 
             const {
               Id: contactId,
@@ -232,38 +231,20 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               (item) => item.org_orgName === orgName,
             );
 
-            const existingBusOwner = Relationship_Type__c === existingBusOwnerType; // prettier-ignore
-            const newBusOwner = Relationship_Type__c === newBusOwnerType;
+            const orgAlreadyAdded = array.some((org) => org._org_id === orgId);
 
             /**
              * Ensure the org exists in the 2023 FRF submission's
-             * "organizations" array.
+             * "organizations" array, and it hasn't already been added.
              */
-            if (jsonOrg) {
-              /**
-               * If the org has already been added, update org_type as needed
-               * and and advance to the next org in the loop.
-               */
-              if (array.some((item) => item._org_id === orgId)) {
-                const org = array.find((item) => item._org_id === orgId);
-
-                if (existingBusOwner) org.org_type.existingBusOwner = true;
-                if (newBusOwner) org.org_type.newBusOwner = true;
-
-                return array;
-              }
-
+            if (jsonOrg && !orgAlreadyAdded) {
               const [orgStreetAddress1, orgStreetAddress2] = (
                 BillingStreet ?? "\n"
               ).split("\n");
 
               array.push({
                 org_number: jsonOrg.org_number,
-                org_type: {
-                  existingBusOwner,
-                  newBusOwner,
-                  // privateFleet: false,
-                },
+                org_type: jsonOrg.org_type,
                 // _org_typeCombined: "", // NOTE: 'Existing Bus Owner, New Bus Owner'
                 _org_id: orgId,
                 org_name: orgName,

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -228,7 +228,8 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             } = Account;
 
             const jsonOrg = frf2023RecordJson.data.organizations.find(
-              (item) => item.org_orgName === orgName,
+              (org) =>
+                org.org_orgName === orgName && org.org_contactEmail === Email,
             );
 
             const orgAlreadyAdded = array.some((org) => org._org_id === orgId);


### PR DESCRIPTION
## Related Issues:
* CSBAPP-275

## Main Changes:
* Continuation of #405, getting the remaining 2023 FRF data from the BAP for a new 2023 PRF submission: since the BAP doesn't currently support storing more than one user-created org tagged as a "Private Fleet", it was determined that we should use the Formio submitted data's org type.

## Steps To Test:
1. Ask the BAP to change an existing 2023 FRF submission's status to "Accepted"
2. Create a new 2023 PRF submission.
3. Ensure each injected organization data's "org type" fields match the values (checkboxes) used in the corresponding 2023 FRF submission.