### PR TITLE
Feature/simplify vite rollup output config

### DIFF
--- a/app/client/vite.config.ts
+++ b/app/client/vite.config.ts
@@ -21,16 +21,12 @@ export default ({ mode }) => {
         output: {
           entryFileNames: "static/js/[name]-[hash].js",
           chunkFileNames: "static/js/[name]-[hash].js",
-          assetFileNames: (chunkInfo) => {
-            const extension = [...chunkInfo.name.split(".")].pop();
-            const directory = /\.(css)$/.test(chunkInfo.name)
-              ? "static/css"
-              : /\.(woff|woff2|eot|ttf|otf)$/.test(chunkInfo.name)
-              ? "static/fonts"
-              : /\.(png|jpe?g|gif|svg|webp|webm|mp3)$/.test(chunkInfo.name)
-              ? "static/media"
-              : "static";
-            return `${directory}/[name]-[hash].${extension}`;
+          assetFileNames: ({ name }) => {
+            const css = /\.(css)$/.test(name ?? "");
+            const font = /\.(woff|woff2|eot|ttf|otf)$/.test(name ?? "");
+            const media = /\.(png|jpe?g|gif|svg|webp|webm|mp3)$/.test(name ?? ""); // prettier-ignore
+            const type = css ? "css/" : font ? "fonts/" : media ? "media/" : "/"; // prettier-ignore
+            return `static/${type}[name]-[hash][extname]`;
           },
         },
       },


### PR DESCRIPTION
## Related Issues:
* CSBAPP-276

## Main Changes:
Simplify the logic used to set the output directory and filename for each built asset in the vite rollup output config (no functional change, just more concise code).

## Steps To Test:
1. Navigate the app, and ensure everything still functions as expected – should result in no functional changes from before...just a bit of refactoring of the code. If the app works and all the assets load (CSS/JS/images), then this should be considered succesful.
