### PR TITLE
Feature/cors enable bap duplicates endpoint

### DIFF
--- a/app/server/app/routes/bap.js
+++ b/app/server/app/routes/bap.js
@@ -14,6 +14,11 @@ const router = express.Router();
 
 // --- check for duplicate contacts or organizations in the BAP.
 router.post("/duplicates", (req, res) => {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  res.setHeader("Access-Control-Allow-Credentials", true);
+
   const apiKey = req.headers["x-api-key"];
 
   if (apiKey !== FORMIO_DUPLICATES_API_KEY) {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-332

## Main Changes:
Follow-up to #407 – Add CORS headers to BAP duplicates api endpoint, so it's accessible from Formio

## Steps To Test:
1. Attempt a POST request to the BAP duplicates API endpoint from Formio.
