### PR TITLE
Feature/update bap duplicates endpoint cors

### DIFF
--- a/app/server/app/routes/bap.js
+++ b/app/server/app/routes/bap.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const cors = require("cors");
 // ---
 const { ensureAuthenticated, storeBapComboKeys } = require("../middleware");
 const {
@@ -13,12 +14,7 @@ const { FORMIO_DUPLICATES_API_KEY } = process.env;
 const router = express.Router();
 
 // --- check for duplicate contacts or organizations in the BAP.
-router.post("/duplicates", (req, res) => {
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-  res.setHeader("Access-Control-Allow-Credentials", true);
-
+router.post("/duplicates", cors(), (req, res) => {
   const apiKey = req.headers["x-api-key"];
 
   if (apiKey !== FORMIO_DUPLICATES_API_KEY) {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-332

## Main Changes:
Follow-up to #xxx - Update BAP duplicates endpoint to use cors middleware.

## Steps To Test:
1. Attempt a POST request to the BAP duplicates API endpoint from Formio.
