### PR TITLE
Feature/add submission actions to helpdesk page

### DIFF
--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -52,6 +52,8 @@ export const messages = {
     "Please select the “New Application” button above to create your first rebate application.",
   helpdeskSubmissionSearchError:
     "Error loading form submission. Please confirm the form type and ID is correct and search again.",
+  helpdeskSubmissionNoActions:
+    "No actions from the last 30 days associated with this submission.",
   timeout:
     "For security reasons, you have been logged out due to 15 minutes of inactivity.",
   logout: "You have successfully logged out.",

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -75,6 +75,13 @@ type SubmissionAction = {
   modified: string; // ISO 8601 date time string
 };
 
+/**
+ * Formio action mapping (practically, just capitalizes "save" or "email").
+ */
+const formioActionMap = new Map<string, string>()
+  .set("save", "Save")
+  .set("email", "Email");
+
 function formatDate(dateTimeString: string | null) {
   return dateTimeString ? new Date(dateTimeString).toLocaleDateString() : "";
 }
@@ -513,16 +520,26 @@ export function Helpdesk() {
                 >
                   <thead>
                     <tr className="font-sans-2xs text-no-wrap">
-                      <th scope="col">TODO</th>
+                      <th scope="col">Date</th>
+                      <th scope="col">Time</th>
+                      <th scope="col">Action</th>
+                      <th scope="col">Status</th>
                     </tr>
                   </thead>
 
                   <tbody>
-                    {actionsData.map((action) => {
-                      console.log(action);
+                    {actionsData.map((data) => {
+                      const { _id, action, messages } = data;
+                      const event = messages[messages.length - 1];
+                      const { datetime, info } = event;
+                      const date = new Date(datetime).toLocaleDateString();
+                      const time = new Date(datetime).toLocaleTimeString();
                       return (
-                        <tr key={action._id}>
-                          <th scope="row">TODO</th>
+                        <tr key={_id}>
+                          <th scope="row">{date}</th>
+                          <td>{time}</td>
+                          <td>{formioActionMap.get(action) || action}</td>
+                          <td>{info}</td>
                         </tr>
                       );
                     })}

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -106,9 +106,6 @@ function ResultTableRow(props: {
     queryClient.resetQueries({ queryKey: ["helpdesk/pdf"] });
   }, [queryClient]);
 
-  const [actionsResultsPending, setActionsResultsPending] = useState(false);
-  const [pdfDownloadPending, setPDFDownloadPending] = useState(false);
-
   const actionsUrl = `${serverUrl}/api/help/formio/actions/${formId}/${mongoId}`;
   const pdfUrl = `${serverUrl}/api/help/formio/pdf/${formId}/${mongoId}`;
 
@@ -117,7 +114,6 @@ function ResultTableRow(props: {
     queryFn: () => getData<SubmissionAction[]>(actionsUrl),
     onSuccess: (res) => {
       console.log(res); // TODO
-      setActionsResultsPending(false);
     },
     enabled: false,
   });
@@ -126,7 +122,6 @@ function ResultTableRow(props: {
     queryKey: ["helpdesk/pdf"],
     queryFn: () => getData<string>(pdfUrl),
     onSuccess: (res) => {
-      setPDFDownloadPending(false);
       const link = document.createElement("a");
       link.setAttribute("href", `data:application/pdf;base64,${res}`);
       link.setAttribute("download", `${formio._id}.pdf`);
@@ -168,10 +163,9 @@ function ResultTableRow(props: {
       <td>
         <button
           className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
-          onClick={(_ev) => {
-            setActionsResultsPending(true);
-            actionsQuery.refetch();
-          }}
+          type="button"
+          disabled={actionsQuery.isFetching || actionsQuery.isSuccess}
+          onClick={(_ev) => actionsQuery.refetch()}
         >
           <span className="display-flex flex-align-center">
             <svg
@@ -183,7 +177,7 @@ function ResultTableRow(props: {
               <use href={`${icons}#history`} />
             </svg>
             <span className="margin-left-1">Actions</span>
-            {actionsResultsPending && <LoadingButtonIcon position="end" />}
+            {actionsQuery.isFetching && <LoadingButtonIcon position="end" />}
           </span>
         </button>
       </td>
@@ -191,10 +185,9 @@ function ResultTableRow(props: {
       <td className={clsx("!tw-text-right")}>
         <button
           className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
-          onClick={(_ev) => {
-            setPDFDownloadPending(true);
-            pdfQuery.refetch();
-          }}
+          type="button"
+          disabled={pdfQuery.isFetching}
+          onClick={(_ev) => pdfQuery.refetch()}
         >
           <span className="display-flex flex-align-center">
             <svg
@@ -206,7 +199,7 @@ function ResultTableRow(props: {
               <use href={`${icons}#arrow_downward`} />
             </svg>
             <span className="margin-left-1">Download</span>
-            {pdfDownloadPending && <LoadingButtonIcon position="end" />}
+            {pdfQuery.isFetching && <LoadingButtonIcon position="end" />}
           </span>
         </button>
       </td>

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -94,6 +94,36 @@ router.get("/formio/submission/:rebateYear/:formType/:id", (req, res) => {
   });
 });
 
+// --- get all actions associated with a form's submission from Formio
+router.get("/formio/actions/:formId/:mongoId", (req, res) => {
+  const { formId, mongoId } = req.params;
+
+  /** NOTE: verifyMongoObjectId */
+  if (!ObjectId.isValid(formId)) {
+    const errorStatus = 400;
+    const errorMessage = `MongoDB ObjectId validation error for: '${formId}'.`;
+    return res.status(errorStatus).json({ message: errorMessage });
+  }
+
+  /** NOTE: verifyMongoObjectId */
+  if (!ObjectId.isValid(mongoId)) {
+    const errorStatus = 400;
+    const errorMessage = `MongoDB ObjectId validation error for: '${mongoId}'.`;
+    return res.status(errorStatus).json({ message: errorMessage });
+  }
+
+  axiosFormio(req)
+    .get(`${formioProjectUrl}/action?form=${formId}&submission=${mongoId}`)
+    .then((axiosRes) => axiosRes.data)
+    .then((actions) => res.json(actions))
+    .catch((error) => {
+      // NOTE: error is logged in axiosFormio response interceptor
+      const errorStatus = error.response?.status || 500;
+      const errorMessage = `Error getting Formio submission actions.`;
+      return res.status(errorStatus).json({ message: errorMessage });
+    });
+});
+
 // --- get a PDF of an existing form's submission from Formio
 router.get("/formio/pdf/:formId/:mongoId", (req, res) => {
   const { formId, mongoId } = req.params;


### PR DESCRIPTION
## Related Issues:
* CSBAPP-323

## Main Changes:
Adds an "actions log" to the helpdesk page, to show all actions occurring for a submission (e.g., date/time stamp of each "save" and the date/time stamp of the email that goes out after the final submission). Unfortunately [Formio only retains actions logs for 30 days](https://help.form.io/userguide/form-building/actions#action-logs), so we're only able to show logs for a submission if they occurred within the last 30 days of a user viewing them on the helpdesk page.

## Steps To Test:
1. Navigate to the helpdesk page
2. Query for a submission
3. Click the "Actions" button, and either view a table of actions that occurred to that submission, or view a message indicating no actions occurred within the last 30 days.
