### PR TITLE
Feature/update 2022 crf submission post api endpoint

### DIFF
--- a/app/server/app/routes/formio2022.js
+++ b/app/server/app/routes/formio2022.js
@@ -390,7 +390,6 @@ router.post("/crf-submission/:rebateId", storeBapComboKeys, (req, res) => {
   const { mail } = req.user;
   const { rebateId } = req.params; // CSB Rebate ID (6 digits)
   const { mongoId, submission } = body;
-  const comboKey = submission.data?.bap_hidden_entity_combo_key;
 
   // NOTE: included to support EPA API scan
   if (rebateId === formioExampleRebateId) {
@@ -402,6 +401,8 @@ router.post("/crf-submission/:rebateId", storeBapComboKeys, (req, res) => {
     const errorMessage = `Missing required data to update ${rebateYear} CRF submission '${rebateId}'.`;
     return res.status(errorStatus).json({ message: errorMessage });
   }
+
+  const comboKey = submission.data?.bap_hidden_entity_combo_key;
 
   checkFormSubmissionPeriodAndBapStatus({
     rebateYear,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-325

## Main Changes:
* Follow-up to #417 - Move setting of `comboKey` variable from submission data after the check that `submission` is truthy (destructured from request body), so ZAP scan doesn't throw 500 without submission found in post body.

## Steps To Test:
1. Import OpenAPI file into Zap and test against staging app. In particular, ensure "/api/formio/2022/crf-submission/000000" POST request doesn't return a 500 response.

## TODO:
- [ ] Revisit ZAP setup to determine if further improvements could be made.
