### PR TITLE
Feature/update web services and openapi docs

### DIFF
--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -1,6 +1,11 @@
 const express = require("express");
 // ---
 const {
+  formioExampleMongoId,
+  formioExampleRebateId,
+  formioNoUserAccess,
+} = require("../config/formio");
+const {
   ensureAuthenticated,
   storeBapComboKeys,
   verifyMongoObjectId,
@@ -81,31 +86,77 @@ router.post(
 
 // --- get user's 2023 PRF submissions from Formio
 router.get("/prf-submissions", storeBapComboKeys, (req, res) => {
-  res.json([]); // TODO: temporary until the PRF is live on prod
+  // TODO: temporary until the PRF is live on prod
+  res.json([]);
+
   // fetchPRFSubmissions({ rebateYear, req, res });
 });
 
 // --- post a new 2023 PRF submission to Formio
 router.post("/prf-submission", storeBapComboKeys, (req, res) => {
-  res.json({}); // TODO: temporary until the PRF is live on prod
+  // TODO: temporary until the PRF is live on prod
+  const { body } = req;
+
+  // NOTE: included to support EPA API scan
+  if (Object.keys(body).length === 0) {
+    return res.json({});
+  }
+
+  const errorStatus = 400;
+  const errorMessage = `Formio ${rebateYear} PRF is not yet live.`;
+  return res.status(errorStatus).json({ message: errorMessage });
+
   // createPRFSubmission({ rebateYear, req, res });
 });
 
 // --- get an existing 2023 PRF's schema and submission data from Formio
 router.get("/prf-submission/:rebateId", storeBapComboKeys, async (req, res) => {
-  res.json({}); // TODO: temporary until the PRF is live on prod
+  // TODO: temporary until the PRF is live on prod
+  const { rebateId } = req.params; // CSB Rebate ID (6 digits)
+
+  // NOTE: included to support EPA API scan
+  if (rebateId === formioExampleRebateId) {
+    return res.json(formioNoUserAccess);
+  }
+
+  const errorStatus = 400;
+  const errorMessage = `Formio ${rebateYear} PRF is not yet live.`;
+  return res.status(errorStatus).json({ message: errorMessage });
+
   // fetchPRFSubmission({ rebateYear, req, res });
 });
 
 // --- post an update to an existing draft 2023 PRF submission to Formio
 router.post("/prf-submission/:rebateId", storeBapComboKeys, (req, res) => {
-  res.json({}); // TODO: temporary until the PRF is live on prod
+  // TODO: temporary until the PRF is live on prod
+  const { rebateId } = req.params; // CSB Rebate ID (6 digits)
+
+  // NOTE: included to support EPA API scan
+  if (rebateId === formioExampleRebateId) {
+    return res.json({});
+  }
+
+  const errorStatus = 400;
+  const errorMessage = `Formio ${rebateYear} PRF is not yet live.`;
+  return res.status(errorStatus).json({ message: errorMessage });
+
   // updatePRFSubmission({ rebateYear, req, res });
 });
 
 // --- delete an existing 2023 PRF submission from Formio
 router.post("/delete-prf-submission", storeBapComboKeys, (req, res) => {
-  res.json({}); // TODO: temporary until the PRF is live on prod
+  // TODO: temporary until the PRF is live on prod
+  const { body } = req;
+
+  // NOTE: included to support EPA API scan
+  if (Object.keys(body).length === 0) {
+    return res.json({});
+  }
+
+  const errorStatus = 400;
+  const errorMessage = `Formio ${rebateYear} PRF is not yet live.`;
+  return res.status(errorStatus).json({ message: errorMessage });
+
   // deletePRFSubmission({ rebateYear, req, res });
 });
 
@@ -123,25 +174,51 @@ router.get("/crf-submissions", storeBapComboKeys, (req, res) => {
 
 // --- get user's 2023 Change Request form submissions from Formio
 router.get("/changes", storeBapComboKeys, (req, res) => {
-  res.json([]); // TODO: temporary until the change request form is live on prod
+  // TODO: temporary until the change request form is live on prod
+  res.json([]);
+
   // fetchChangeRequests({ rebateYear, req, res });
 });
 
 // --- get the 2023 Change Request form's schema from Formio
 router.get("/change", storeBapComboKeys, (req, res) => {
-  res.json({}); // TODO: temporary until the change request form is live on prod
+  // TODO: temporary until the change request form is live on prod
+  res.json({});
+
   // fetchChangeRequestSchema({ rebateYear, req, res });
 });
 
 // --- post a new 2023 Change Request form submission to Formio
 router.post("/change", storeBapComboKeys, (req, res) => {
-  res.json({}); // TODO: temporary until the change request form is live on prod
+  // TODO: temporary until the change request form is live on prod
+  const { body } = req;
+
+  // NOTE: included to support EPA API scan
+  if (Object.keys(body).length === 0) {
+    return res.json({});
+  }
+
+  const errorStatus = 400;
+  const errorMessage = `Formio ${rebateYear} Change Request Form is not yet live.`;
+  return res.status(errorStatus).json({ message: errorMessage });
+
   // createChangeRequest({ rebateYear, req, res });
 });
 
 // --- get an existing 2023 Change Request form's schema and submission data from Formio
 router.get("/change/:mongoId", storeBapComboKeys, async (req, res) => {
-  res.json({}); // TODO: temporary until the change request form is live on prod
+  // TODO: temporary until the change request form is live on prod
+  const { mongoId } = req.params; // CSB Rebate ID (6 digits)
+
+  // NOTE: included to support EPA API scan
+  if (mongoId === formioExampleMongoId) {
+    return res.json(formioNoUserAccess);
+  }
+
+  const errorStatus = 400;
+  const errorMessage = `Formio ${rebateYear} Change Request Form is not yet live.`;
+  return res.status(errorStatus).json({ message: errorMessage });
+
   // fetchChangeRequest({ rebateYear, req, res });
 });
 

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -673,10 +673,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  }
+                  "type": "object"
                 }
               }
             }
@@ -814,6 +811,83 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/formio/2023/changes": {
+      "get": {
+        "summary": "Get user's 2023 Change Request form submissions from Formio.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "An array of 2023 Change Request form submissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/formio/2023/change": {
+      "get": {
+        "summary": "Get the 2023 Change Request form's schema from Formio.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The 2023 Change Request form's schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Post a new 2023 Change Request form submission to Formio.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The newly created 2023 Change Request form submission.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/formio/2023/change/{mongoId}": {
+      "get": {
+        "summary": "Get an existing 2023 Change Request form's schema and submission data from Formio.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/mongoId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The 2023 Change Request form's schema, form submission, and user access status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormioSchemaAndSubmission"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Related Issues:
* CSBAPP-325

## Main Changes:
* Follow-up to #419 – update 2023 Formio PRF routes to return better results for v4.1 release (no always an empty object, but an error message until the PRF is deployed), and update OpenAPI docs with 2023 Change Request Form routes.

## Steps To Test:
1. Import OpenAPI file into Zap and test against staging app.

## TODO:
- [ ] Revisit ZAP setup to determine if further improvements could be made.
