### PR TITLE
Feature/update nces endpoint cors

### DIFF
--- a/app/server/app/routes/formioNCES.js
+++ b/app/server/app/routes/formioNCES.js
@@ -1,10 +1,13 @@
 const express = require("express");
 // ---
+const { ensureAuthenticated } = require("../middleware");
 const log = require("../utilities/logger");
 
 const { FORMIO_NCES_API_KEY } = process.env;
 
 const router = express.Router();
+
+router.use(ensureAuthenticated);
 
 // --- Search the NCES data with the provided NCES ID and return a match
 router.get("/:searchText?", (req, res) => {

--- a/app/server/app/routes/formioNCES.js
+++ b/app/server/app/routes/formioNCES.js
@@ -8,11 +8,6 @@ const router = express.Router();
 
 // --- Search the NCES data with the provided NCES ID and return a match
 router.get("/:searchText?", (req, res) => {
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-  res.setHeader("Access-Control-Allow-Credentials", true);
-
   const { searchText } = req.params;
   const apiKey = req.headers["x-api-key"];
 

--- a/app/server/app/routes/index.js
+++ b/app/server/app/routes/index.js
@@ -4,10 +4,10 @@ const router = express.Router();
 
 router.use("/", require("./auth"));
 router.use("/api/content", require("./content"));
-router.use("/api/formio/nces", require("./formioNCES"));
 router.use("/api/user", require("./user"));
 router.use("/api/config", require("./config"));
 router.use("/api/bap", require("./bap"));
+router.use("/api/formio/nces", require("./formioNCES"));
 router.use("/api/formio/2022", require("./formio2022"));
 router.use("/api/formio/2023", require("./formio2023"));
 router.use("/api/help", require("./help"));

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -117,35 +117,6 @@
         }
       }
     },
-    "/api/formio/nces/{searchText}": {
-      "get": {
-        "summary": "Search the NCES data with the provided NCES ID and return a match.",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "searchText",
-            "description": "The NCES ID to search for.",
-            "required": true,
-            "example": "A999999",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "An object containing the matched NCES data.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/user": {
       "get": {
         "summary": "Get user data from EPA Gateway/Login.gov.",
@@ -319,6 +290,35 @@
                   "items": {
                     "type": "object"
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/formio/nces/{searchText}": {
+      "get": {
+        "summary": "Search the NCES data with the provided NCES ID and return a match.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "searchText",
+            "description": "The NCES ID to search for.",
+            "required": true,
+            "example": "A999999",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An object containing the matched NCES data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
                 }
               }
             }


### PR DESCRIPTION
## Related Issues:
* CSBAPP-7

## Main Changes:
Follow-up to #342 – since the NCES API endpoint request is considered a complex request, due to the inclusion of the "x-api-key" header, a preflight request would need to occur to actually CORS enable this endpoint... Not including the preflight (options) request was an oversight, making this endpoint not actually CORS enabled – that ended up being a good thing though, as it didn't need to actually be CORS enabled since the request originated from the same domain when the app is deployed to Cloud.gov. That said, the NCES endpoint never worked for local development. This PR:

- Removes the CORS headers that didn't actually do anything, as there was no Preflight (OPTIONS) request before the GET request.
- For development only: Modifies the Formio "datasource" components' URL paths in the 2023 FRF to be local/relative, so the request works for local development.
- Adds the "ensureAuthenticated" middleware, as the cookie will exist in the deployed Cloud.gov app.

## Steps To Test:
1. Navigate to a new 2023 FRF on the Cloud.gov dev site
2. Ensure the NCES endpoint still functions as expected
3. Do the same above two steps locally.
