### PR TITLE
Feature/unify submissions status logic

### DIFF
--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -109,6 +109,18 @@ export const bapStatusMap = {
 };
 
 /**
+ * Status icon mapping status to USWDS icon name.
+ */
+export const statusIconMap = new Map<string, string>()
+  .set("Edits Requested", "priority_high") // !
+  .set("Withdrawn", "close") // ✕
+  .set("Not Selected", "cancel") // x inside a circle
+  .set("Selected", "check_circle") // check inside a circle
+  .set("Draft", "more_horiz") // three horizontal dots
+  .set("Submitted", "check") // check
+  .set("", "remove"); // — (fallback, not used)
+
+/**
  * Formio user name field by year and form type.
  */
 export const formioNameField = {

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -115,7 +115,11 @@ export const statusIconMap = new Map<string, string>()
   .set("Edits Requested", "priority_high") // !
   .set("Withdrawn", "close") // ✕
   .set("Not Selected", "cancel") // x inside a circle
+  .set("Funding Not Approved", "cancel")
+  .set("Close Out Not Approved", "cancel")
   .set("Selected", "check_circle") // check inside a circle
+  .set("Funding Approved", "check_circle")
+  .set("Close Out Approved", "check_circle")
   .set("Draft", "more_horiz") // three horizontal dots
   .set("Submitted", "check") // check
   .set("", "remove"); // — (fallback, not used)

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -117,6 +117,7 @@ export const statusIconMap = new Map<string, string>()
   .set("Not Selected", "cancel") // x inside a circle
   .set("Funding Not Approved", "cancel")
   .set("Close Out Not Approved", "cancel")
+  .set("Funding Denied", "cancel")
   .set("Selected", "check_circle") // check inside a circle
   .set("Funding Approved", "check_circle")
   .set("Close Out Approved", "check_circle")

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -143,14 +143,16 @@ function ResultTableRow(props: {
   const date = formatDate(formio.modified);
   const time = formatTime(formio.modified);
 
+  const id = lastSearchedText.length === 6 ? bap.rebateId : bap.mongoId;
+
   const bapInternalStatus = bap.status || "";
   const formioStatus = formioStatusMap.get(formio.state);
 
-  const id = lastSearchedText.length === 6 ? bap.rebateId : bap.mongoId;
-
   const status = submissionNeedsEdits({ formio, bap })
     ? "Edits Requested"
-    : bapStatusMap[rebateYear][formType].get(bapInternalStatus) || formioStatus;
+    : bapStatusMap[rebateYear][formType].get(bapInternalStatus) ||
+      formioStatus ||
+      "";
 
   const nameField = formioNameField[rebateYear][formType];
   const emailField = formioEmailField[rebateYear][formType];

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -272,10 +272,7 @@ function FRF2022Submission(props: { rebate: Rebate }) {
           ) : (
             <>
               <svg
-                className={clsx(
-                  "usa-icon",
-                  frfStatus === "Selected" && "text-primary",
-                )}
+                className={clsx("usa-icon", frfSelected && "text-primary")}
                 aria-hidden="true"
                 focusable="false"
                 role="img"
@@ -525,8 +522,8 @@ function PRF2022Submission(props: { rebate: Rebate }) {
       prfFormioStatus ||
       "";
 
-  const prfFundingApprovedButNoCRF =
-    prfStatus === "Funding Approved" && !Boolean(crf.formio);
+  const prfFundingApproved = prfStatus === "Funding Approved";
+  const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
 
   const statusTableCellClassNames =
     prfFormioStatus === "Submitted" || !prfSubmissionPeriodOpen
@@ -572,7 +569,7 @@ function PRF2022Submission(props: { rebate: Rebate }) {
               <svg
                 className={clsx(
                   "usa-icon",
-                  prfStatus === "Funding Approved" && "text-primary",
+                  prfFundingApproved && "text-primary",
                 )}
                 aria-hidden="true"
                 focusable="false"
@@ -737,6 +734,8 @@ function CRF2022Submission(props: { rebate: Rebate }) {
       crfFormioStatus ||
       "";
 
+  const crfCloseOutApproved = crfStatus === "Close Out Approved";
+
   const statusTableCellClassNames =
     crfFormioStatus === "Submitted" || !crfSubmissionPeriodOpen
       ? "text-italic"
@@ -785,7 +784,7 @@ function CRF2022Submission(props: { rebate: Rebate }) {
               <svg
                 className={clsx(
                   "usa-icon",
-                  crfStatus === "Close Out Approved" && "text-primary",
+                  crfCloseOutApproved && "text-primary",
                 )}
                 aria-hidden="true"
                 focusable="false"
@@ -934,10 +933,7 @@ function FRF2023Submission(props: { rebate: Rebate }) {
           ) : (
             <>
               <svg
-                className={clsx(
-                  "usa-icon",
-                  frfStatus === "Selected" && "text-primary",
-                )}
+                className={clsx("usa-icon", frfSelected && "text-primary")}
                 aria-hidden="true"
                 focusable="false"
                 role="img"
@@ -1053,7 +1049,6 @@ function PRF2023Submission(props: { rebate: Rebate }) {
   const prfSubmissionPeriodOpen = configData.submissionPeriodOpen["2023"].prf;
 
   const frfSelected = frf.bap?.status === "Accepted";
-
   const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
 
   if (frfSelectedButNoPRF) {
@@ -1154,53 +1149,22 @@ function PRF2023Submission(props: { rebate: Rebate }) {
     bap: prf.bap,
   });
 
-  const prfNeedsClarification = prf.bap?.status === "Needs Clarification";
+  const prfBapInternalStatus = prf.bap?.status || "";
+  const prfFormioStatus = formioStatusMap.get(prf.formio.state);
 
-  const prfHasBeenWithdrawn = prf.bap?.status === "Withdrawn";
+  const prfStatus = prfNeedsEdits
+    ? "Edits Requested"
+    : bapStatusMap["2023"].prf.get(prfBapInternalStatus) ||
+      prfFormioStatus ||
+      "";
 
-  const prfFundingNotApproved = prf.bap?.status === "Coordinator Denied";
-
-  const prfFundingApproved = prf.bap?.status === "Accepted";
-
+  const prfFundingApproved = prfStatus === "Funding Approved";
   const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
 
   const statusTableCellClassNames =
     prf.formio.state === "submitted" || !prfSubmissionPeriodOpen
       ? "text-italic"
       : "";
-
-  const statusIconClassNames = clsx(
-    "usa-icon",
-    prfFundingApproved && "text-primary",
-  );
-
-  const statusIcon = prfNeedsEdits
-    ? `${icons}#priority_high` // !
-    : prfHasBeenWithdrawn
-    ? `${icons}#close` // ✕
-    : prfFundingNotApproved
-    ? `${icons}#cancel` // ✕ inside a circle
-    : prfFundingApproved
-    ? `${icons}#check_circle` // check inside a circle
-    : prf.formio.state === "draft"
-    ? `${icons}#more_horiz` // three horizontal dots
-    : prf.formio.state === "submitted"
-    ? `${icons}#check` // check
-    : `${icons}#remove`; // — (fallback, not used)
-
-  const statusText = prfNeedsEdits
-    ? "Edits Requested"
-    : prfHasBeenWithdrawn
-    ? "Withdrawn"
-    : prfFundingNotApproved
-    ? "Funding Denied"
-    : prfFundingApproved
-    ? "Funding Approved"
-    : prf.formio.state === "draft"
-    ? "Draft"
-    : prf.formio.state === "submitted"
-    ? "Submitted"
-    : ""; // fallback, not used
 
   const prfUrl = `/prf/2023/${_bap_rebate_id}`;
 
@@ -1230,23 +1194,26 @@ function PRF2023Submission(props: { rebate: Rebate }) {
         <span>Payment Request</span>
         <br />
         <span className="display-flex flex-align-center font-sans-2xs">
-          {prfNeedsClarification ? (
+          {prfStatus === "Needs Clarification" ? (
             <TextWithTooltip
-              text="Needs Clarification"
+              text={prfStatus}
               tooltip="Check your email for instructions on what needs clarification"
               iconClassNames="text-base-darkest"
             />
           ) : (
             <>
               <svg
-                className={statusIconClassNames}
+                className={clsx(
+                  "usa-icon",
+                  prfFundingApproved && "text-primary",
+                )}
                 aria-hidden="true"
                 focusable="false"
                 role="img"
               >
-                <use href={statusIcon} />
+                <use href={`${icons}#${statusIconMap.get(prfStatus)}`} />
               </svg>
-              <span className="margin-left-05">{statusText}</span>
+              <span className="margin-left-05">{prfStatus}</span>
             </>
           )}
         </span>

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -204,8 +204,8 @@ function FRF2022Submission(props: { rebate: Rebate }) {
   const frfSelected = frfStatus === "Selected";
   const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
 
-  const prfFundingApproved = prf.bap?.status === "Accepted";
-  const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
+  const prfApproved = prf.bap?.status === "Accepted";
+  const prfApprovedButNoCRF = prfApproved && !Boolean(crf.formio);
 
   const statusTableCellClassNames =
     frfFormioStatus === "Submitted" || !frfSubmissionPeriodOpen
@@ -231,7 +231,7 @@ function FRF2022Submission(props: { rebate: Rebate }) {
   return (
     <tr
       className={
-        frfNeedsEdits || frfSelectedButNoPRF || prfFundingApprovedButNoCRF
+        frfNeedsEdits || frfSelectedButNoPRF || prfApprovedButNoCRF
           ? highlightedTableRowClassNames
           : defaultTableRowClassNames
       }
@@ -522,8 +522,8 @@ function PRF2022Submission(props: { rebate: Rebate }) {
       prfFormioStatus ||
       "";
 
-  const prfFundingApproved = prfStatus === "Funding Approved";
-  const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
+  const prfApproved = prfStatus === "Funding Approved";
+  const prfApprovedButNoCRF = prfApproved && !Boolean(crf.formio);
 
   const statusTableCellClassNames =
     prfFormioStatus === "Submitted" || !prfSubmissionPeriodOpen
@@ -535,7 +535,7 @@ function PRF2022Submission(props: { rebate: Rebate }) {
   return (
     <tr
       className={
-        prfNeedsEdits || prfFundingApprovedButNoCRF
+        prfNeedsEdits || prfApprovedButNoCRF
           ? highlightedTableRowClassNames
           : defaultTableRowClassNames
       }
@@ -567,10 +567,7 @@ function PRF2022Submission(props: { rebate: Rebate }) {
           ) : (
             <>
               <svg
-                className={clsx(
-                  "usa-icon",
-                  prfFundingApproved && "text-primary",
-                )}
+                className={clsx("usa-icon", prfApproved && "text-primary")}
                 aria-hidden="true"
                 focusable="false"
                 role="img"
@@ -630,10 +627,10 @@ function CRF2022Submission(props: { rebate: Rebate }) {
 
   const crfSubmissionPeriodOpen = configData.submissionPeriodOpen["2022"].crf;
 
-  const prfFundingApproved = prf.bap?.status === "Accepted";
-  const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
+  const prfApproved = prf.bap?.status === "Accepted";
+  const prfApprovedButNoCRF = prfApproved && !Boolean(crf.formio);
 
-  if (prfFundingApprovedButNoCRF) {
+  if (prfApprovedButNoCRF) {
     return (
       <tr className={highlightedTableRowClassNames}>
         <th scope="row" colSpan={6}>
@@ -734,7 +731,7 @@ function CRF2022Submission(props: { rebate: Rebate }) {
       crfFormioStatus ||
       "";
 
-  const crfCloseOutApproved = crfStatus === "Close Out Approved";
+  const crfApproved = crfStatus === "Close Out Approved";
 
   const statusTableCellClassNames =
     crfFormioStatus === "Submitted" || !crfSubmissionPeriodOpen
@@ -746,7 +743,7 @@ function CRF2022Submission(props: { rebate: Rebate }) {
   return (
     <tr
       className={
-        crfNeedsEdits || prfFundingApprovedButNoCRF
+        crfNeedsEdits || prfApprovedButNoCRF
           ? highlightedTableRowClassNames
           : defaultTableRowClassNames
       }
@@ -782,10 +779,7 @@ function CRF2022Submission(props: { rebate: Rebate }) {
           ) : (
             <>
               <svg
-                className={clsx(
-                  "usa-icon",
-                  crfCloseOutApproved && "text-primary",
-                )}
+                className={clsx("usa-icon", crfApproved && "text-primary")}
                 aria-hidden="true"
                 focusable="false"
                 role="img"
@@ -865,8 +859,8 @@ function FRF2023Submission(props: { rebate: Rebate }) {
   const frfSelected = frfStatus === "Selected";
   const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
 
-  const prfFundingApproved = prf.bap?.status === "Accepted";
-  const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
+  const prfApproved = prf.bap?.status === "Accepted";
+  const prfApprovedButNoCRF = prfApproved && !Boolean(crf.formio);
 
   const statusTableCellClassNames =
     frfFormioStatus === "Submitted" || !frfSubmissionPeriodOpen
@@ -892,7 +886,7 @@ function FRF2023Submission(props: { rebate: Rebate }) {
   return (
     <tr
       className={
-        frfNeedsEdits || frfSelectedButNoPRF || prfFundingApprovedButNoCRF
+        frfNeedsEdits || frfSelectedButNoPRF || prfApprovedButNoCRF
           ? highlightedTableRowClassNames
           : defaultTableRowClassNames
       }
@@ -1158,8 +1152,8 @@ function PRF2023Submission(props: { rebate: Rebate }) {
       prfFormioStatus ||
       "";
 
-  const prfFundingApproved = prfStatus === "Funding Approved";
-  const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
+  const prfApproved = prfStatus === "Funding Approved";
+  const prfApprovedButNoCRF = prfApproved && !Boolean(crf.formio);
 
   const statusTableCellClassNames =
     prf.formio.state === "submitted" || !prfSubmissionPeriodOpen
@@ -1171,7 +1165,7 @@ function PRF2023Submission(props: { rebate: Rebate }) {
   return (
     <tr
       className={
-        prfNeedsEdits || prfFundingApprovedButNoCRF
+        prfNeedsEdits || prfApprovedButNoCRF
           ? highlightedTableRowClassNames
           : defaultTableRowClassNames
       }
@@ -1203,10 +1197,7 @@ function PRF2023Submission(props: { rebate: Rebate }) {
           ) : (
             <>
               <svg
-                className={clsx(
-                  "usa-icon",
-                  prfFundingApproved && "text-primary",
-                )}
+                className={clsx("usa-icon", prfApproved && "text-primary")}
                 aria-hidden="true"
                 focusable="false"
                 role="img"

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -854,54 +854,25 @@ function FRF2023Submission(props: { rebate: Rebate }) {
     bap: frf.bap,
   });
 
-  const frfNeedsClarification = frf.bap?.status === "Needs Clarification";
+  const frfBapInternalStatus = frf.bap?.status || "";
+  const frfFormioStatus = formioStatusMap.get(frf.formio.state);
 
-  const frfHasBeenWithdrawn = frf.bap?.status === "Withdrawn";
+  const frfStatus = frfNeedsEdits
+    ? "Edits Requested"
+    : bapStatusMap["2023"].frf.get(frfBapInternalStatus) ||
+      frfFormioStatus ||
+      "";
 
-  const frfNotSelected = frf.bap?.status === "Coordinator Denied";
-
-  const frfSelected = frf.bap?.status === "Accepted";
-
+  const frfSelected = frfStatus === "Selected";
   const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
 
   const prfFundingApproved = prf.bap?.status === "Accepted";
-
   const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
 
   const statusTableCellClassNames =
-    frf.formio.state === "submitted" || !frfSubmissionPeriodOpen
+    frfFormioStatus === "Submitted" || !frfSubmissionPeriodOpen
       ? "text-italic"
       : "";
-
-  const statusIconClassNames = clsx("usa-icon", frfSelected && "text-primary");
-
-  const statusIcon = frfNeedsEdits
-    ? `${icons}#priority_high` // !
-    : frfHasBeenWithdrawn
-    ? `${icons}#close` // ✕
-    : frfNotSelected
-    ? `${icons}#cancel` // x inside a circle
-    : frfSelected
-    ? `${icons}#check_circle` // check inside a circle
-    : frf.formio.state === "draft"
-    ? `${icons}#more_horiz` // three horizontal dots
-    : frf.formio.state === "submitted"
-    ? `${icons}#check` // check
-    : `${icons}#remove`; // — (fallback, not used)
-
-  const statusText = frfNeedsEdits
-    ? "Edits Requested"
-    : frfHasBeenWithdrawn
-    ? "Withdrawn"
-    : frfNotSelected
-    ? "Not Selected"
-    : frfSelected
-    ? "Selected"
-    : frf.formio.state === "draft"
-    ? "Draft"
-    : frf.formio.state === "submitted"
-    ? "Submitted"
-    : ""; // fallback, not used
 
   const frfUrl = `/frf/2023/${frf.formio._id}`;
 
@@ -954,23 +925,26 @@ function FRF2023Submission(props: { rebate: Rebate }) {
         <span>Application</span>
         <br />
         <span className="display-flex flex-align-center font-sans-2xs">
-          {frfNeedsClarification ? (
+          {frfStatus === "Needs Clarification" ? (
             <TextWithTooltip
-              text="Needs Clarification"
+              text={frfStatus}
               tooltip="Check your email for instructions on what needs clarification"
               iconClassNames="text-base-darkest"
             />
           ) : (
             <>
               <svg
-                className={statusIconClassNames}
+                className={clsx(
+                  "usa-icon",
+                  frfStatus === "Selected" && "text-primary",
+                )}
                 aria-hidden="true"
                 focusable="false"
                 role="img"
               >
-                <use href={statusIcon} />
+                <use href={`${icons}#${statusIconMap.get(frfStatus)}`} />
               </svg>
-              <span className="margin-left-05">{statusText}</span>
+              <span className="margin-left-05">{frfStatus}</span>
             </>
           )}
         </span>

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -634,7 +634,6 @@ function CRF2022Submission(props: { rebate: Rebate }) {
   const crfSubmissionPeriodOpen = configData.submissionPeriodOpen["2022"].crf;
 
   const prfFundingApproved = prf.bap?.status === "Accepted";
-
   const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
 
   if (prfFundingApprovedButNoCRF) {
@@ -729,44 +728,19 @@ function CRF2022Submission(props: { rebate: Rebate }) {
     bap: crf.bap,
   });
 
-  const crfNeedsClarification = crf.bap?.status === "Needs Clarification";
+  const crfBapInternalStatus = crf.bap?.status || "";
+  const crfFormioStatus = formioStatusMap.get(crf.formio.state);
 
-  const crfReimbursementNeeded = crf.bap?.status === "Reimbursement Needed";
-
-  const crfNotApproved = crf.bap?.status === "Branch Director Denied";
-
-  const crfApproved = crf.bap?.status === "Branch Director Approved";
+  const crfStatus = crfNeedsEdits
+    ? "Edits Requested"
+    : bapStatusMap["2022"].crf.get(crfBapInternalStatus) ||
+      crfFormioStatus ||
+      "";
 
   const statusTableCellClassNames =
-    crf.formio.state === "submitted" || !crfSubmissionPeriodOpen
+    crfFormioStatus === "Submitted" || !crfSubmissionPeriodOpen
       ? "text-italic"
       : "";
-
-  const statusIconClassNames = clsx("usa-icon", crfApproved && "text-primary");
-
-  const statusIcon = crfNeedsEdits
-    ? `${icons}#priority_high` // !
-    : crfNotApproved
-    ? `${icons}#cancel` // ✕ inside a circle
-    : crfApproved
-    ? `${icons}#check_circle` // check inside a circle
-    : crf.formio.state === "draft"
-    ? `${icons}#more_horiz` // three horizontal dots
-    : crf.formio.state === "submitted"
-    ? `${icons}#check` // check
-    : `${icons}#remove`; // — (fallback, not used)
-
-  const statusText = crfNeedsEdits
-    ? "Edits Requested"
-    : crfNotApproved
-    ? "Close Out Not Approved"
-    : crfApproved
-    ? "Close Out Approved"
-    : crf.formio.state === "draft"
-    ? "Draft"
-    : crf.formio.state === "submitted"
-    ? "Submitted"
-    : ""; // fallback, not used
 
   const crfUrl = `/crf/2022/${hidden_bap_rebate_id}`;
 
@@ -794,29 +768,32 @@ function CRF2022Submission(props: { rebate: Rebate }) {
         <span>Close Out</span>
         <br />
         <span className="display-flex flex-align-center font-sans-2xs">
-          {crfNeedsClarification ? (
+          {crfStatus === "Needs Clarification" ? (
             <TextWithTooltip
-              text="Needs Clarification"
+              text={crfStatus}
               tooltip="Check your email for instructions on what needs clarification"
               iconClassNames="text-base-darkest"
             />
-          ) : crfReimbursementNeeded ? (
+          ) : crfStatus === "Reimbursement Needed" ? (
             <TextWithTooltip
-              text="Reimbursement Needed"
+              text={crfStatus}
               tooltip="Check your email for information on reimbursement needed"
               iconClassNames="text-base-darkest"
             />
           ) : (
             <>
               <svg
-                className={statusIconClassNames}
+                className={clsx(
+                  "usa-icon",
+                  crfStatus === "Close Out Approved" && "text-primary",
+                )}
                 aria-hidden="true"
                 focusable="false"
                 role="img"
               >
-                <use href={statusIcon} />
+                <use href={`${icons}#${statusIconMap.get(crfStatus)}`} />
               </svg>
-              <span className="margin-left-05">{statusText}</span>
+              <span className="margin-left-05">{crfStatus}</span>
             </>
           )}
         </span>

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -201,7 +201,9 @@ function FRF2022Submission(props: { rebate: Rebate }) {
       frfFormioStatus ||
       "";
 
-  const frfSelectedButNoPRF = frfStatus === "Selected" && !Boolean(prf.formio);
+  const frfSelected = frfStatus === "Selected";
+  const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
+
   const prfFundingApproved = prf.bap?.status === "Accepted";
   const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
 
@@ -415,7 +417,6 @@ function PRF2022Submission(props: { rebate: Rebate }) {
   const prfSubmissionPeriodOpen = configData.submissionPeriodOpen["2022"].prf;
 
   const frfSelected = frf.bap?.status === "Accepted";
-
   const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
 
   if (frfSelectedButNoPRF) {
@@ -515,53 +516,22 @@ function PRF2022Submission(props: { rebate: Rebate }) {
     bap: prf.bap,
   });
 
-  const prfNeedsClarification = prf.bap?.status === "Needs Clarification";
+  const prfBapInternalStatus = prf.bap?.status || "";
+  const prfFormioStatus = formioStatusMap.get(prf.formio.state);
 
-  const prfHasBeenWithdrawn = prf.bap?.status === "Withdrawn";
+  const prfStatus = prfNeedsEdits
+    ? "Edits Requested"
+    : bapStatusMap["2022"].prf.get(prfBapInternalStatus) ||
+      prfFormioStatus ||
+      "";
 
-  const prfFundingNotApproved = prf.bap?.status === "Coordinator Denied";
-
-  const prfFundingApproved = prf.bap?.status === "Accepted";
-
-  const prfFundingApprovedButNoCRF = prfFundingApproved && !Boolean(crf.formio);
+  const prfFundingApprovedButNoCRF =
+    prfStatus === "Funding Approved" && !Boolean(crf.formio);
 
   const statusTableCellClassNames =
-    prf.formio.state === "submitted" || !prfSubmissionPeriodOpen
+    prfFormioStatus === "Submitted" || !prfSubmissionPeriodOpen
       ? "text-italic"
       : "";
-
-  const statusIconClassNames = clsx(
-    "usa-icon",
-    prfFundingApproved && "text-primary",
-  );
-
-  const statusIcon = prfNeedsEdits
-    ? `${icons}#priority_high` // !
-    : prfHasBeenWithdrawn
-    ? `${icons}#close` // ✕
-    : prfFundingNotApproved
-    ? `${icons}#cancel` // ✕ inside a circle
-    : prfFundingApproved
-    ? `${icons}#check_circle` // check inside a circle
-    : prf.formio.state === "draft"
-    ? `${icons}#more_horiz` // three horizontal dots
-    : prf.formio.state === "submitted"
-    ? `${icons}#check` // check
-    : `${icons}#remove`; // — (fallback, not used)
-
-  const statusText = prfNeedsEdits
-    ? "Edits Requested"
-    : prfHasBeenWithdrawn
-    ? "Withdrawn"
-    : prfFundingNotApproved
-    ? "Funding Not Approved"
-    : prfFundingApproved
-    ? "Funding Approved"
-    : prf.formio.state === "draft"
-    ? "Draft"
-    : prf.formio.state === "submitted"
-    ? "Submitted"
-    : ""; // fallback, not used
 
   const prfUrl = `/prf/2022/${hidden_bap_rebate_id}`;
 
@@ -591,23 +561,26 @@ function PRF2022Submission(props: { rebate: Rebate }) {
         <span>Payment Request</span>
         <br />
         <span className="display-flex flex-align-center font-sans-2xs">
-          {prfNeedsClarification ? (
+          {prfStatus === "Needs Clarification" ? (
             <TextWithTooltip
-              text="Needs Clarification"
+              text={prfStatus}
               tooltip="Check your email for instructions on what needs clarification"
               iconClassNames="text-base-darkest"
             />
           ) : (
             <>
               <svg
-                className={statusIconClassNames}
+                className={clsx(
+                  "usa-icon",
+                  prfStatus === "Funding Approved" && "text-primary",
+                )}
                 aria-hidden="true"
                 focusable="false"
                 role="img"
               >
-                <use href={statusIcon} />
+                <use href={`${icons}#${statusIconMap.get(prfStatus)}`} />
               </svg>
-              <span className="margin-left-05">{statusText}</span>
+              <span className="margin-left-05">{prfStatus}</span>
             </>
           )}
         </span>


### PR DESCRIPTION
## Related Issues:
* CSBAPP-276

## Main Changes:
No outward facing changes to end users, but moves setting of BAP status (via BAP internal -> external status mapping) and setting of status icons into a config file, which is an improvement for several reasons:
- Makes updating the BAP internal/external status mapping much easier (adding future statuses is now easy and done in one place).
- Makes seeing all possible statuses across all forms more clear by storing them in a single place in a config file (no need to scroll through JSX/component code to see possible statuses for each form).
- Removes a lot of duplicative code (especially around defining status icons).

## Steps To Test:
1. Navigate to the user dashboard.
2. Ask the BAP team to change the status of submissions across all 5 forms (or emulate this locally).
3. Ensure the statuses and icons shown are still correct.
