### PR TITLE
Feature/fix 2023 frf empty efti

### DIFF
--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -951,8 +951,23 @@ function FRF2023Submission(props: { rebate: Rebate }) {
             />
           )}
           <br />
-          {Boolean(appInfo_efti) ? (
-            appInfo_efti
+          {/* NOTE:
+Similar situation with the EFTI field as in the 2022 FRF... A user's EFTI value
+from SAM.gov can be null. In a brand new 2023 FRF, we inject that value without
+modification as the `_bap_applicant_efti` field. The intention was in the 2023
+FRF schema/form definition, the `appInfo_efti` field would be set from the
+`_bap_applicant_efti` field's value, but account for a null/empty string value,
+in which case it would set the value of the field to "0000." Unfortunately, that
+logic didn't make it into the 2023 FRF schema/form definition, so we need to
+account for that situation here.
+
+Similar to the 2022 FRF, if the `appInfo_uei` field's value has been set, we
+know the user has advanced past the first screen (and therefore the form
+definition's logic has kicked in, setting values from the initially injected
+hidden fields), so we'll use the appInfo_efti value, but fall back to "0000" to
+handle when it's value is an empty string. */}
+          {Boolean(appInfo_uei) ? (
+            appInfo_efti || "0000"
           ) : (
             <TextWithTooltip
               text=" "


### PR DESCRIPTION
## Related Issues:
* CSBAPP-326

## Main Changes:
Update rendering of 2023 FRF submissions' EFTI value in dashboard table (accounting for when SAM.gov value is null)

## Steps To Test:
1. Navigate to the dashboard.
2. Create at least one 2023 FRF submission with a SAM.gov entity that has an empty/null EFTI value (assumes one of your test SAM.gov records matches this criteria).
3. Ensure the value shown in the "EFT Indicator" column for that submission displays "0000."
