### PR TITLE
Feature/update helpdesk

### DIFF
--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -143,7 +143,7 @@ function ResultTableRow(props: {
   const date = formatDate(formio.modified);
   const time = formatTime(formio.modified);
 
-  const id = lastSearchedText.length === 6 ? bap.rebateId : bap.mongoId;
+  const bapId = lastSearchedText.length === 6 ? bap.rebateId : bap.mongoId;
 
   const bapInternalStatus = bap.status || "";
   const formioStatus = formioStatusMap.get(formio.state);
@@ -162,7 +162,7 @@ function ResultTableRow(props: {
 
   return (
     <>
-      <td>{id}</td>
+      <td>{bapId || mongoId}</td>
       <td>{status}</td>
       <td>{name}</td>
       <td>{email}</td>
@@ -573,20 +573,23 @@ export function Helpdesk() {
                     </svg>
                   </div>
                   <div className="usa-icon-list__content">
-                    <strong>MongoDB Object ID:</strong> {bap.mongoId}
+                    <strong>MongoDB Object ID:</strong>{" "}
+                    {bap.mongoId || formio._id}
                   </div>
                 </li>
 
-                <li className="usa-icon-list__item">
-                  <div className="usa-icon-list__icon text-primary">
-                    <svg className="usa-icon" aria-hidden="true" role="img">
-                      <use href={`${icons}#local_offer`} />
-                    </svg>
-                  </div>
-                  <div className="usa-icon-list__content">
-                    <strong>Rebate ID:</strong> {bap.rebateId}
-                  </div>
-                </li>
+                {bap.rebateId && (
+                  <li className="usa-icon-list__item">
+                    <div className="usa-icon-list__icon text-primary">
+                      <svg className="usa-icon" aria-hidden="true" role="img">
+                        <use href={`${icons}#local_offer`} />
+                      </svg>
+                    </div>
+                    <div className="usa-icon-list__content">
+                      <strong>Rebate ID:</strong> {bap.rebateId}
+                    </div>
+                  </li>
+                )}
               </ul>
 
               <Form

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -453,10 +453,12 @@ async function queryForBapFormSubmissionData(
   rebateId,
   mongoId,
 ) {
-  const logId = rebateId ? `rebateId: '${rebateId}'` : `mongoId: '${mongoId}'`;
+  const loggedId = rebateId
+    ? `rebateId: '${rebateId}'`
+    : `mongoId: '${mongoId}'`;
   const logMessage =
     `Querying the BAP for ${formType.toUpperCase()} submission data ` +
-    `associated with ${logId}.`;
+    `associated with ${loggedId}.`;
   log({ level: "info", message: logMessage, req });
 
   /** @type {{ bapConnection: jsforce.Connection }} */


### PR DESCRIPTION
## Related Issues:
* CSBAPP-331

## Main Changes:
Updates the helpdesk page to query Formio for submissions even when they're not yet in the BAP (e.g., draft submissions, or submissions recently submitted that haven't yet been picked up by the BAP ETL, or submissions that exist before the BAP ETL has been developed (for future forms)).

## Steps To Test:
1. Navigate to the helpdesk page.
2. Search for a submission (via it's MongoDB ObjectId) that's still in draft state
3. Ensure the submission is displayed properly in the table of results (including the MongoDB Object Id shown in the table column, and also below beside the tag icon when the "View" button is clicked).
