### PR TITLE
Feature/disable bap duplicates endpoint

### DIFF
--- a/app/server/app/routes/bap.js
+++ b/app/server/app/routes/bap.js
@@ -2,7 +2,7 @@ const express = require("express");
 // ---
 const { ensureAuthenticated, storeBapComboKeys } = require("../middleware");
 const {
-  checkForBapDuplicates,
+  // checkForBapDuplicates,
   getSamEntities,
   getBapFormSubmissionsStatuses,
 } = require("../utilities/bap");

--- a/app/server/app/routes/bap.js
+++ b/app/server/app/routes/bap.js
@@ -1,5 +1,4 @@
 const express = require("express");
-const cors = require("cors");
 // ---
 const { ensureAuthenticated, storeBapComboKeys } = require("../middleware");
 const {
@@ -11,26 +10,19 @@ const log = require("../utilities/logger");
 
 const router = express.Router();
 
-/**
- * TODO: remove cors() once the deduplication prototype form's functionality is
- * integrated into the other forms and move the `ensureAuthenticated` middleware
- * above the route.
- */
+router.use(ensureAuthenticated);
 
 // --- check for duplicate contacts or organizations in the BAP.
-router.options("/duplicates", cors()); // enable pre-flight request
-router.post("/duplicates", cors(), (req, res) => {
-  return checkForBapDuplicates(req)
-    .then((duplicates) => res.json(duplicates))
-    .catch((_error) => {
-      // NOTE: logged in bap verifyBapConnection
-      const errorStatus = 500;
-      const errorMessage = `Error checking duplicates from the BAP.`;
-      return res.status(errorStatus).json({ message: errorMessage });
-    });
-});
-
-router.use(ensureAuthenticated);
+// router.post("/duplicates", (req, res) => {
+//   return checkForBapDuplicates(req)
+//     .then((duplicates) => res.json(duplicates))
+//     .catch((_error) => {
+//       // NOTE: logged in bap verifyBapConnection
+//       const errorStatus = 500;
+//       const errorMessage = `Error checking duplicates from the BAP.`;
+//       return res.status(errorStatus).json({ message: errorMessage });
+//     });
+// });
 
 // --- get user's SAM.gov data from the BAP
 router.get("/sam", (req, res) => {

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -228,24 +228,6 @@
         }
       }
     },
-    "/api/bap/duplicates": {
-      "post": {
-        "summary": "Check for duplicate contacts or organizations in the BAP.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "An object containing any duplicate contacts or organizations found via the BAP's record matcher API.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/bap/sam": {
       "get": {
         "summary": "Get user's SAM.gov data from the BAP.",


### PR DESCRIPTION
## Related Issues:
* CSBAPP-332

## Main Changes:
Comment out BAP duplicates API endpoint and remove that route from the OpenAPI file docs.

## Steps To Test:
1. Ensure the BAP duplicates API endpoint is not longer in the app (to be re-integrated in a future form/release).