### PR TITLE
Feature/add helpdesk change to draft

### DIFF
--- a/app/client/src/components/confirmationDialog.tsx
+++ b/app/client/src/components/confirmationDialog.tsx
@@ -73,10 +73,10 @@ export function ConfirmationDialog() {
               <Dialog.Panel
                 className={clsx(
                   "tw-relative tw-transform tw-overflow-hidden tw-rounded-lg tw-bg-white tw-p-4 tw-shadow-xl tw-transition-all",
-                  "sm:tw-w-full sm:tw-max-w-md sm:tw-p-6",
+                  "sm:tw-w-full sm:tw-max-w-xl sm:tw-p-6",
                 )}
               >
-                {dismissable && dismissText && (
+                {dismissable && (
                   <div className="twpf">
                     <div
                       className={clsx(

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -205,33 +205,48 @@ function ResultTableRow(props: {
                   heading: "Change Submission Status to Draft",
                   description: (
                     <>
+                      <div className="usa-alert usa-alert--info" role="alert">
+                        <div className="usa-alert__body">
+                          <p className="usa-alert__text">
+                            The BAP’s “Edits Requested” workflow is designed to
+                            give users the ability to revise their submitted
+                            form submissions.
+                          </p>
+
+                          <p>
+                            <strong>
+                              This helpdesk functionality is only intended to be
+                              used when the BAP’s status change workflow is not
+                              yet in place, and the form’s enrollment period is
+                              still open.
+                            </strong>
+                          </p>
+                        </div>
+                      </div>
+
+                      <p>Please select the button below only if:</p>
+
+                      <ul>
+                        <li>
+                          The BAP’s status change workflow is not yet in place
+                          for this form submission.
+                        </li>
+                        <li>The form’s enrollment period is still open.</li>
+                      </ul>
+
                       <div
                         className="usa-alert usa-alert--warning"
                         role="alert"
                       >
                         <div className="usa-alert__body">
                           <p className="usa-alert__text">
-                            <strong>
-                              The BAP’s “Edits Requested” workflow enables users
-                              the ability to edit their submitted form
-                              submissions.
-                            </strong>
-                          </p>
-
-                          <p className="margin-bottom-0">
-                            This functionality is only intended to be used when
-                            the BAP’s status change workflow is not yet in place
-                            for a form.
+                            <strong>Please note:</strong> Once a form’s
+                            enrollment period has been closed, only submissions
+                            with a BAP status of “Edits Requested” are editable,
+                            even if the below button is selected.
                           </p>
                         </div>
                       </div>
-
-                      <p>
-                        If you’re sure the BAP’s status change workflow is not
-                        yet in place for this form submission, and you would
-                        like to proceed with changing the submission status to
-                        “Draft,” please select the button below.
-                      </p>
                     </>
                   ),
                   confirmText: "Change Submission Status to Draft",

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -30,6 +30,7 @@ import { Loading, LoadingButtonIcon } from "@/components/loading";
 import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { TextWithTooltip } from "@/components/tooltip";
+import { useDialogActions } from "@/contexts/dialog";
 import {
   type RebateYear,
   useRebateYearState,
@@ -91,6 +92,7 @@ function formatTime(dateTimeString: string | null) {
 }
 
 function ResultTableRow(props: {
+  setFormDisplayed: Dispatch<SetStateAction<boolean>>;
   setActionsData: Dispatch<
     SetStateAction<{ fetched: boolean; results: SubmissionAction[] }>
   >;
@@ -103,7 +105,16 @@ function ResultTableRow(props: {
     | FormioFRF2023Submission;
   bap: BapSubmission;
 }) {
-  const { setActionsData, lastSearchedText, formType, formio, bap } = props;
+  const {
+    setFormDisplayed,
+    setActionsData,
+    lastSearchedText,
+    formType,
+    formio,
+    bap,
+  } = props;
+
+  const { displayDialog } = useDialogActions();
   const { rebateYear } = useRebateYearState();
 
   const formId = formio.form;
@@ -161,9 +172,93 @@ function ResultTableRow(props: {
   const email = (formio.data[emailField] as string) || "";
 
   return (
-    <>
+    <tr>
+      <th scope="row">
+        <button
+          className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+          onClick={(_ev) => setFormDisplayed(true)}
+        >
+          <span className="display-flex flex-align-center">
+            <svg
+              className="usa-icon"
+              aria-hidden="true"
+              focusable="false"
+              role="img"
+            >
+              <use href={`${icons}#visibility`} />
+            </svg>
+            <span className="margin-left-1">View</span>
+          </span>
+        </button>
+      </th>
       <td>{bapId || mongoId}</td>
-      <td>{status}</td>
+      <td>
+        {status}
+
+        {!bapId && status === "Submitted" && (
+          <span className="margin-left-2">
+            <button
+              className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+              onClick={(_ev) => {
+                displayDialog({
+                  dismissable: true,
+                  heading: "Change Submission Status to Draft",
+                  description: (
+                    <>
+                      <div
+                        className="usa-alert usa-alert--warning"
+                        role="alert"
+                      >
+                        <div className="usa-alert__body">
+                          <p className="usa-alert__text">
+                            <strong>
+                              The BAP’s “Edits Requested” workflow enables users
+                              the ability to edit their submitted form
+                              submissions.
+                            </strong>
+                          </p>
+
+                          <p className="margin-bottom-0">
+                            This functionality is only intended to be used when
+                            the BAP’s status change workflow is not yet in place
+                            for a form.
+                          </p>
+                        </div>
+                      </div>
+
+                      <p>
+                        If you’re sure the BAP’s status change workflow is not
+                        yet in place for this form submission, and you would
+                        like to proceed with changing the submission status to
+                        “Draft,” please select the button below.
+                      </p>
+                    </>
+                  ),
+                  confirmText: "Change Submission Status to Draft",
+                  confirmedAction: () => {
+                    //
+                  },
+                  dismissedAction: () => {
+                    //
+                  },
+                });
+              }}
+            >
+              <span className="display-flex flex-align-center">
+                <svg
+                  className="usa-icon"
+                  aria-hidden="true"
+                  focusable="false"
+                  role="img"
+                >
+                  <use href={`${icons}#undo`} />
+                </svg>
+                <span className="margin-left-1">Draft</span>
+              </span>
+            </button>
+          </span>
+        )}
+      </td>
       <td>{name}</td>
       <td>{email}</td>
       <td>
@@ -213,7 +308,7 @@ function ResultTableRow(props: {
           </span>
         </button>
       </td>
-    </>
+    </tr>
   );
 }
 
@@ -486,34 +581,14 @@ export function Helpdesk() {
               </thead>
 
               <tbody>
-                <tr>
-                  <th scope="row">
-                    <button
-                      className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
-                      onClick={(_ev) => setFormDisplayed(true)}
-                    >
-                      <span className="display-flex flex-align-center">
-                        <svg
-                          className="usa-icon"
-                          aria-hidden="true"
-                          focusable="false"
-                          role="img"
-                        >
-                          <use href={`${icons}#visibility`} />
-                        </svg>
-                        <span className="margin-left-1">View</span>
-                      </span>
-                    </button>
-                  </th>
-
-                  <ResultTableRow
-                    setActionsData={setActionsData}
-                    lastSearchedText={lastSearchedText}
-                    formType={formType}
-                    formio={formio}
-                    bap={bap}
-                  />
-                </tr>
+                <ResultTableRow
+                  setFormDisplayed={setFormDisplayed}
+                  setActionsData={setActionsData}
+                  lastSearchedText={lastSearchedText}
+                  formType={formType}
+                  formio={formio}
+                  bap={bap}
+                />
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Related Issues:
* CSBAPP-348

## Main Changes:
Adds the ability for the help desk page to change a submission back to draft if:
* the BAP’s status change workflow is not yet in place for the form submission and
* the form’s enrollment period is still open

## Steps To Test:
1. Navigate to the helpdesk page
2. Query for a submission that has not yet been picked up by the BAP (e.g., a submitted 2023 PRF submission)
3. Ensure the "Draft" button is displayed inside the status column. Also take note of the values shown in the "Updated By" and "Date Updated" columns.
4. Click the "Draft" button, and confirm your intention via the modal dialog.
5. Ensure the submission is changed back to draft state (see the updated "Updated By" and "Date Updated" values).
6. Navigate back to the dashboard, and ensure the "Updated By" and "Date Updated" columns reflect the changes ("cleanschoolbus@epa.gov" and the recent date and time you modified the submission).

## TODO:
- [ ] Continue to test to ensure the workflow works as expected, and also the UI of where the button is displayed is the right choice.
