### PR TITLE
Feature/update prf org matching

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epa-csb-rebate-forms-app-client",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app-client",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "CC0-1.0",
       "dependencies": {
         "@formio/premium": "1.18.4",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app-client",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "U.S. EPA CSB Rebate Forms Application (client app)",
   "homepage": ".",
   "license": "CC0-1.0",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epa-csb-rebate-forms-app",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "CC0-1.0",
       "devDependencies": {
         "concurrently": "8.2.2",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "U.S. EPA CSB Rebate Forms Application",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -261,10 +261,14 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               County__c,
             } = Account;
 
-            const jsonOrg = frf2023RecordJson.data.organizations.find(
-              (org) =>
-                org.org_orgName === orgName && org.org_contactEmail === Email,
-            );
+            const jsonOrg = frf2023RecordJson.data.organizations.find((org) => {
+              const matchedName = org.org_orgName.trim() === orgName.trim();
+              const matchedEmail =
+                org.org_contactEmail.trim().toLowerCase() ===
+                Email.trim().toLowerCase();
+
+              return matchedName && matchedEmail;
+            });
 
             const orgAlreadyAdded = array.some((org) => org._org_id === orgId);
 

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -29,8 +29,8 @@ function getComboKeyFieldName({ rebateYear }) {
   return rebateYear === "2022"
     ? "bap_hidden_entity_combo_key"
     : rebateYear === "2023"
-    ? "_bap_entity_combo_key"
-    : "";
+      ? "_bap_entity_combo_key"
+      : "";
 }
 
 /**
@@ -41,8 +41,8 @@ function getRebateIdFieldName({ rebateYear }) {
   return rebateYear === "2022"
     ? "hidden_bap_rebate_id"
     : rebateYear === "2023"
-    ? "_bap_rebate_id"
-    : "";
+      ? "_bap_rebate_id"
+      : "";
 }
 
 /**
@@ -517,10 +517,10 @@ function uploadS3FileMetadata({ rebateYear, req, res }) {
         formType === "frf"
           ? "CSB Application"
           : formType === "prf"
-          ? "CSB Payment Request"
-          : formType === "cof"
-          ? "CSB Close Out"
-          : "CSB";
+            ? "CSB Payment Request"
+            : formType === "crf"
+              ? "CSB Close Out"
+              : "CSB";
 
       const logMessage =
         `User with email '${mail}' attempted to upload a file when the ` +

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -262,10 +262,10 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             } = Account;
 
             const jsonOrg = frf2023RecordJson.data.organizations.find((org) => {
-              const matchedName = org.org_orgName.trim() === orgName.trim();
+              const matchedName = org?.org_orgName?.trim() === orgName?.trim();
               const matchedEmail =
-                org.org_contactEmail.trim().toLowerCase() ===
-                Email.trim().toLowerCase();
+                org.org_contactEmail?.trim()?.toLowerCase() ===
+                Email?.trim()?.toLowerCase();
 
               return matchedName && matchedEmail;
             });

--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epa-csb-rebate-forms-app-server",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app-server",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "CC0-1.0",
       "dependencies": {
         "axios": "1.6.8",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app-server",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "U.S. EPA CSB Rebate Forms Application (server app)",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "epa-csb-server",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "license": {
       "name": "CC0-1.0"
     },


### PR DESCRIPTION
## Related Issues:
* CSBAPP-353

## Main Changes:
Update code that injects fetched 2023 FRF submission data into a brand new 2023 PRF submission to match org contact's email address in a case-insensitive way. Even if a user entered in an email address with capital letters (e.g., "George.Washington@test.com"), it'll be returned from the BAP in all lowercase (e.g., "george.washington@test.com"). Additionally, we should make sure we trim leading and trailing whitespace from the org name, as that's also used in the matching of organizations. After some testing, it was discovered the Formio submission can include leading or trailing spaces, but the BAP will strip that out, so we should account for that too in our matching.

**NOTE:** Unrelated to the above, this also fixes a typo in an incorrect value used for the close out form in `uploadS3FileMetadata()`

## Steps To Test:
1. Create a 2023 FRF submission where an entered organization's contact's email address includes capital letters. Also ensure there's at least one leading or trailing space in the org name.
2. Ask the BAP team to mark that submission as "Accepted"
3. Create a new related PRF submission, and ensure the injected 2023 FRF data (from the BAP query) includes the correct organization data.