### PR TITLE
Feature/update form submission prop data

### DIFF
--- a/app/client/src/routes/change2023.tsx
+++ b/app/client/src/routes/change2023.tsx
@@ -87,9 +87,7 @@ export function Change2023() {
         <Form
           form={formSchema.json}
           url={formSchema.url} // NOTE: used for file uploads
-          submission={{
-            data: { ...submission.data },
-          }}
+          submission={submission}
           options={{
             readOnly: true,
             noAlerts: true,

--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -270,6 +270,7 @@ function CloseOutRequestForm(props: { email: string }) {
           form={formSchema.json}
           url={formSchema.url} // NOTE: used for file uploads
           submission={{
+            ...submission,
             data: {
               ...submission.data,
               last_updated_by: email,

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -418,6 +418,7 @@ function FundingRequestForm(props: { email: string }) {
           form={formSchema.json}
           url={formSchema.url} // NOTE: used for file uploads
           submission={{
+            ...submission,
             data: {
               ...submission.data,
               last_updated_by: email,

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -404,6 +404,7 @@ function FundingRequestForm(props: { email: string }) {
           form={formSchema.json}
           url={formSchema.url} // NOTE: used for file uploads
           submission={{
+            ...submission,
             data: {
               ...submission.data,
               _user_email: email,

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -291,6 +291,7 @@ function PaymentRequestForm(props: { email: string }) {
           form={formSchema.json}
           url={formSchema.url} // NOTE: used for file uploads
           submission={{
+            ...submission,
             data: {
               ...submission.data,
               last_updated_by: email,

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -289,6 +289,7 @@ function PaymentRequestForm(props: { email: string }) {
           form={formSchema.json}
           url={formSchema.url} // NOTE: used for file uploads
           submission={{
+            ...submission,
             data: {
               ...submission.data,
               _user_email: email,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-276

## Main Changes:
Update data passed to Formio Form component's submission prop to include the full submission JSON (not just the submission data object). This change should result in no functional changes for end users, but will ensure the Formio signature field's data (the user's signature) will continue to be displayed in submitted (read-only) submissions when Formio is updated to a later version.

## Steps To Test:
1. Navigate to each form (the 2022 FRF, PRF, and CRF, and the 2023 FRF, PRF, and Change Request form), and ensure they're all working as expected.
