### PR TITLE
Feature/update fetch data for prf submission

### DIFF
--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -260,7 +260,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               BillingState,
               BillingPostalCode,
               County__c,
-            } = Account;
+            } = Account || {};
 
             const jsonOrg = frf2023RecordJson.data.organizations.find((org) => {
               const matchedName = org?.org_orgName?.trim() === orgName?.trim();


### PR DESCRIPTION
## Related Issues:
* CSBAPP-276

## Main Changes:
Update `fetchDataForPRFSubmission()`'s handling of fetched 2023 data to account for when bus record contact data from the BAP doesn't include any Account (org) info. In practice, each bus contact returned from the BAP should have an org associated with it, but in testing on dev, one of my contacts did not have any "Account" info returned. That really should never occur in production, but this fix just ensures the app doesn't crash if that were to occur.

## Steps To Test:
1. Navigate to the dashboard
2. Click "New Payment Request" button to create a new payment request form submission from a selected FRF.
3. If the corresponding FRF data returned from the BAP (and injected as initial form data for the PRF) doesn't include any org info for one of the bus contacts (which should never actually happen), the app should function normally (there would just likely be missing organizations data injected into the new PRF submission).
