### PR TITLE
Feature/add sam entity status checks

### DIFF
--- a/app/client/src/routes/frfNew.tsx
+++ b/app/client/src/routes/frfNew.tsx
@@ -137,7 +137,7 @@ export function FRFNew() {
       } = entity;
 
       const isActive = ENTITY_STATUS__c === "Active";
-      const hasExclusionStatus = EXCLUSION_STATUS_FLAG__c !== null;
+      const hasExclusionStatus = EXCLUSION_STATUS_FLAG__c === "D";
       const hasDebtSubjectToOffset = DEBT_SUBJECT_TO_OFFSET_FLAG__c === "Y";
 
       const isEligible = !hasExclusionStatus && !hasDebtSubjectToOffset;

--- a/app/client/src/routes/frfNew.tsx
+++ b/app/client/src/routes/frfNew.tsx
@@ -137,8 +137,10 @@ export function FRFNew() {
       } = entity;
 
       const isActive = ENTITY_STATUS__c === "Active";
-      const isEligible =
-        !EXCLUSION_STATUS_FLAG__c && !DEBT_SUBJECT_TO_OFFSET_FLAG__c;
+      const hasExclusionStatus = EXCLUSION_STATUS_FLAG__c !== null;
+      const hasDebtSubjectToOffset = DEBT_SUBJECT_TO_OFFSET_FLAG__c === "Y";
+
+      const isEligible = !hasExclusionStatus && !hasDebtSubjectToOffset;
 
       if (isActive && isEligible) object.eligible.push(entity);
       if (isActive && !isEligible) object.ineligible.push(entity);
@@ -397,51 +399,57 @@ export function FRFNew() {
                               );
                             })}
 
-                            <tr>
-                              <td
-                                colSpan={4}
-                                className="font-sans-2xs !tw-whitespace-normal"
-                              >
-                                <strong>Ineligible SAM.gov Entities:</strong>
-                                <br />
-                                The following SAM.gov entities are ineligible
-                                due to their exclusion status or a debt subject
-                                to offset. Please visit SAM.gov to resolve these
-                                issues.
-                              </td>
-                            </tr>
-
-                            {samEntities.ineligible.map((entity) => {
-                              const {
-                                ENTITY_COMBO_KEY__c,
-                                UNIQUE_ENTITY_ID__c,
-                                ENTITY_EFT_INDICATOR__c,
-                                LEGAL_BUSINESS_NAME__c,
-                              } = entity;
-
-                              return (
-                                <tr key={ENTITY_COMBO_KEY__c}>
-                                  <th
-                                    scope="row"
-                                    className="width-15 font-sans-2xs"
+                            {samEntities.ineligible.length > 0 && (
+                              <>
+                                <tr>
+                                  <td
+                                    colSpan={4}
+                                    className="font-sans-2xs !tw-whitespace-normal"
                                   >
-                                    <TextWithTooltip
-                                      text=" "
-                                      tooltip="Ineligible SAM.gov entity"
-                                    />
-                                  </th>
-                                  <td className="font-sans-2xs">
-                                    {UNIQUE_ENTITY_ID__c}
-                                  </td>
-                                  <td className="font-sans-2xs">
-                                    {ENTITY_EFT_INDICATOR__c || "0000"}
-                                  </td>
-                                  <td className="font-sans-2xs">
-                                    {LEGAL_BUSINESS_NAME__c}
+                                    <strong>
+                                      Ineligible SAM.gov Entities:
+                                    </strong>
+                                    <br />
+                                    The following SAM.gov entities are
+                                    ineligible due to their exclusion status or
+                                    a debt subject to offset. Please visit
+                                    SAM.gov to resolve these issues.
                                   </td>
                                 </tr>
-                              );
-                            })}
+
+                                {samEntities.ineligible.map((entity) => {
+                                  const {
+                                    ENTITY_COMBO_KEY__c,
+                                    UNIQUE_ENTITY_ID__c,
+                                    ENTITY_EFT_INDICATOR__c,
+                                    LEGAL_BUSINESS_NAME__c,
+                                  } = entity;
+
+                                  return (
+                                    <tr key={ENTITY_COMBO_KEY__c}>
+                                      <th
+                                        scope="row"
+                                        className="width-15 font-sans-2xs"
+                                      >
+                                        <TextWithTooltip
+                                          text=" "
+                                          tooltip="Ineligible SAM.gov entity"
+                                        />
+                                      </th>
+                                      <td className="font-sans-2xs">
+                                        {UNIQUE_ENTITY_ID__c}
+                                      </td>
+                                      <td className="font-sans-2xs">
+                                        {ENTITY_EFT_INDICATOR__c || "0000"}
+                                      </td>
+                                      <td className="font-sans-2xs">
+                                        {LEGAL_BUSINESS_NAME__c}
+                                      </td>
+                                    </tr>
+                                  );
+                                })}
+                              </>
+                            )}
                           </tbody>
                         </table>
                       </div>

--- a/app/client/src/routes/frfNew.tsx
+++ b/app/client/src/routes/frfNew.tsx
@@ -282,13 +282,15 @@ export function FRFNew() {
                           </thead>
                           <tbody>
                             {activeSamEntities.map((entity) => {
-                              const comboKey = entity.ENTITY_COMBO_KEY__c;
-                              const uei = entity.UNIQUE_ENTITY_ID__c;
-                              const efti = entity.ENTITY_EFT_INDICATOR__c;
-                              const orgName = entity.LEGAL_BUSINESS_NAME__c;
+                              const {
+                                ENTITY_COMBO_KEY__c,
+                                UNIQUE_ENTITY_ID__c,
+                                ENTITY_EFT_INDICATOR__c,
+                                LEGAL_BUSINESS_NAME__c,
+                              } = entity;
 
                               return (
-                                <tr key={comboKey}>
+                                <tr key={ENTITY_COMBO_KEY__c}>
                                   <th
                                     scope="row"
                                     className="width-15 font-sans-2xs"
@@ -303,7 +305,7 @@ export function FRFNew() {
 
                                         // account for when data is posting to prevent double submits
                                         if (postingDataId !== "0") return;
-                                        setPostingDataId(comboKey);
+                                        setPostingDataId(ENTITY_COMBO_KEY__c);
 
                                         const data =
                                           createInitialSubmissionData({
@@ -335,8 +337,9 @@ export function FRFNew() {
                                       }}
                                     >
                                       <span className="usa-sr-only">
-                                        New Application with UEI: {uei} and
-                                        EFTI: {efti}
+                                        New Application with UEI:{" "}
+                                        {UNIQUE_ENTITY_ID__c} and EFTI:{" "}
+                                        {ENTITY_EFT_INDICATOR__c}
                                       </span>
                                       <span className="display-flex flex-align-center">
                                         <svg
@@ -352,17 +355,22 @@ export function FRFNew() {
                                         <span className="mobile-lg:display-none margin-left-1">
                                           New Application
                                         </span>
-                                        {postingDataId === comboKey && (
+                                        {postingDataId ===
+                                          ENTITY_COMBO_KEY__c && (
                                           <LoadingButtonIcon position="end" />
                                         )}
                                       </span>
                                     </button>
                                   </th>
-                                  <td className="font-sans-2xs">{uei}</td>
                                   <td className="font-sans-2xs">
-                                    {efti || "0000"}
+                                    {UNIQUE_ENTITY_ID__c}
                                   </td>
-                                  <td className="font-sans-2xs">{orgName}</td>
+                                  <td className="font-sans-2xs">
+                                    {ENTITY_EFT_INDICATOR__c || "0000"}
+                                  </td>
+                                  <td className="font-sans-2xs">
+                                    {LEGAL_BUSINESS_NAME__c}
+                                  </td>
                                 </tr>
                               );
                             })}

--- a/app/client/src/routes/frfNew.tsx
+++ b/app/client/src/routes/frfNew.tsx
@@ -396,6 +396,52 @@ export function FRFNew() {
                                 </tr>
                               );
                             })}
+
+                            <tr>
+                              <td
+                                colSpan={4}
+                                className="font-sans-2xs !tw-whitespace-normal"
+                              >
+                                <strong>Ineligible SAM.gov Entities:</strong>
+                                <br />
+                                The following SAM.gov entities are ineligible
+                                due to their exclusion status or a debt subject
+                                to offset. Please visit SAM.gov to resolve these
+                                issues.
+                              </td>
+                            </tr>
+
+                            {samEntities.ineligible.map((entity) => {
+                              const {
+                                ENTITY_COMBO_KEY__c,
+                                UNIQUE_ENTITY_ID__c,
+                                ENTITY_EFT_INDICATOR__c,
+                                LEGAL_BUSINESS_NAME__c,
+                              } = entity;
+
+                              return (
+                                <tr key={ENTITY_COMBO_KEY__c}>
+                                  <th
+                                    scope="row"
+                                    className="width-15 font-sans-2xs"
+                                  >
+                                    <TextWithTooltip
+                                      text=" "
+                                      tooltip="Ineligible SAM.gov entity"
+                                    />
+                                  </th>
+                                  <td className="font-sans-2xs">
+                                    {UNIQUE_ENTITY_ID__c}
+                                  </td>
+                                  <td className="font-sans-2xs">
+                                    {ENTITY_EFT_INDICATOR__c || "0000"}
+                                  </td>
+                                  <td className="font-sans-2xs">
+                                    {LEGAL_BUSINESS_NAME__c}
+                                  </td>
+                                </tr>
+                              );
+                            })}
                           </tbody>
                         </table>
                       </div>

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -36,8 +36,10 @@ export type BapSamEntity = {
   Id: string;
   ENTITY_COMBO_KEY__c: string;
   UNIQUE_ENTITY_ID__c: string;
-  ENTITY_EFT_INDICATOR__c: string;
-  ENTITY_STATUS__c: "Active" | string;
+  ENTITY_EFT_INDICATOR__c: string | null;
+  ENTITY_STATUS__c: "Active" | string | null;
+  EXCLUSION_STATUS_FLAG__c: string | null;
+  DEBT_SUBJECT_TO_OFFSET_FLAG__c: "Y" | "N" | null;
   LEGAL_BUSINESS_NAME__c: string;
   PHYSICAL_ADDRESS_LINE_1__c: string;
   PHYSICAL_ADDRESS_LINE_2__c: string | null;

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -38,7 +38,7 @@ export type BapSamEntity = {
   UNIQUE_ENTITY_ID__c: string;
   ENTITY_EFT_INDICATOR__c: string | null;
   ENTITY_STATUS__c: "Active" | string | null;
-  EXCLUSION_STATUS_FLAG__c: string | null;
+  EXCLUSION_STATUS_FLAG__c: "D" | null;
   DEBT_SUBJECT_TO_OFFSET_FLAG__c: "Y" | "N" | null;
   LEGAL_BUSINESS_NAME__c: string;
   PHYSICAL_ADDRESS_LINE_1__c: string;

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -21,6 +21,8 @@ const { submissionPeriodOpen } = require("../config/formio");
  * @property {string} UNIQUE_ENTITY_ID__c
  * @property {?string} ENTITY_EFT_INDICATOR__c
  * @property {string} ENTITY_STATUS__c
+ * @property {?string} EXCLUSION_STATUS_FLAG__c
+ * @property {?string} DEBT_SUBJECT_TO_OFFSET_FLAG__c
  * @property {string} LEGAL_BUSINESS_NAME__c
  * @property {string} PHYSICAL_ADDRESS_LINE_1__c
  * @property {?string} PHYSICAL_ADDRESS_LINE_2__c
@@ -373,6 +375,8 @@ async function queryForSamEntities(req, email) {
   //   UNIQUE_ENTITY_ID__c,
   //   ENTITY_EFT_INDICATOR__c,
   //   ENTITY_STATUS__c,
+  //   EXCLUSION_STATUS_FLAG__c,
+  //   DEBT_SUBJECT_TO_OFFSET_FLAG__c,
   //   LEGAL_BUSINESS_NAME__c,
   //   PHYSICAL_ADDRESS_LINE_1__c,
   //   PHYSICAL_ADDRESS_LINE_2__c,
@@ -418,6 +422,8 @@ async function queryForSamEntities(req, email) {
         UNIQUE_ENTITY_ID__c: 1,
         ENTITY_EFT_INDICATOR__c: 1,
         ENTITY_STATUS__c: 1,
+        EXCLUSION_STATUS_FLAG__c: 1,
+        DEBT_SUBJECT_TO_OFFSET_FLAG__c: 1,
         LEGAL_BUSINESS_NAME__c: 1,
         PHYSICAL_ADDRESS_LINE_1__c: 1,
         PHYSICAL_ADDRESS_LINE_2__c: 1,

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -18,28 +18,28 @@ const { submissionPeriodOpen } = require("../config/formio");
  * @typedef {Object} BapSamEntity
  * @property {string} Id
  * @property {string} ENTITY_COMBO_KEY__c
- * @property {string} ENTITY_STATUS__c
  * @property {string} UNIQUE_ENTITY_ID__c
  * @property {?string} ENTITY_EFT_INDICATOR__c
+ * @property {string} ENTITY_STATUS__c
  * @property {string} LEGAL_BUSINESS_NAME__c
- * @property {?string} GOVT_BUS_POC_NAME__c
- * @property {?string} GOVT_BUS_POC_EMAIL__c
- * @property {?string} GOVT_BUS_POC_TITLE__c
- * @property {?string} ALT_GOVT_BUS_POC_NAME__c
- * @property {?string} ALT_GOVT_BUS_POC_EMAIL__c
- * @property {?string} ALT_GOVT_BUS_POC_TITLE__c
- * @property {?string} ELEC_BUS_POC_NAME__c
- * @property {?string} ELEC_BUS_POC_EMAIL__c
- * @property {?string} ELEC_BUS_POC_TITLE__c
- * @property {?string} ALT_ELEC_BUS_POC_NAME__c
- * @property {?string} ALT_ELEC_BUS_POC_EMAIL__c
- * @property {?string} ALT_ELEC_BUS_POC_TITLE__c
  * @property {string} PHYSICAL_ADDRESS_LINE_1__c
  * @property {?string} PHYSICAL_ADDRESS_LINE_2__c
  * @property {string} PHYSICAL_ADDRESS_CITY__c
  * @property {string} PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c
  * @property {string} PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c
  * @property {string} PHYSICAL_ADDRESS_ZIP_CODE_4__c
+ * @property {?string} ELEC_BUS_POC_EMAIL__c
+ * @property {?string} ELEC_BUS_POC_NAME__c
+ * @property {?string} ELEC_BUS_POC_TITLE__c
+ * @property {?string} ALT_ELEC_BUS_POC_EMAIL__c
+ * @property {?string} ALT_ELEC_BUS_POC_NAME__c
+ * @property {?string} ALT_ELEC_BUS_POC_TITLE__c
+ * @property {?string} GOVT_BUS_POC_EMAIL__c
+ * @property {?string} GOVT_BUS_POC_NAME__c
+ * @property {?string} GOVT_BUS_POC_TITLE__c
+ * @property {?string} ALT_GOVT_BUS_POC_EMAIL__c
+ * @property {?string} ALT_GOVT_BUS_POC_NAME__c
+ * @property {?string} ALT_GOVT_BUS_POC_TITLE__c
  * @property {{
  *  type: string
  *  url: string
@@ -370,29 +370,28 @@ async function queryForSamEntities(req, email) {
   // `SELECT
   //   Id,
   //   ENTITY_COMBO_KEY__c,
-  //   ENTITY_STATUS__c,
   //   UNIQUE_ENTITY_ID__c,
   //   ENTITY_EFT_INDICATOR__c,
-  //   CAGE_CODE__c,
+  //   ENTITY_STATUS__c,
   //   LEGAL_BUSINESS_NAME__c,
-  //   GOVT_BUS_POC_NAME__c,
-  //   GOVT_BUS_POC_EMAIL__c,
-  //   GOVT_BUS_POC_TITLE__c,
-  //   ALT_GOVT_BUS_POC_NAME__c,
-  //   ALT_GOVT_BUS_POC_EMAIL__c,
-  //   ALT_GOVT_BUS_POC_TITLE__c,
-  //   ELEC_BUS_POC_NAME__c,
-  //   ELEC_BUS_POC_EMAIL__c,
-  //   ELEC_BUS_POC_TITLE__c,
-  //   ALT_ELEC_BUS_POC_NAME__c,
-  //   ALT_ELEC_BUS_POC_EMAIL__c,
-  //   ALT_ELEC_BUS_POC_TITLE__c,
   //   PHYSICAL_ADDRESS_LINE_1__c,
   //   PHYSICAL_ADDRESS_LINE_2__c,
   //   PHYSICAL_ADDRESS_CITY__c,
   //   PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c,
   //   PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c,
-  //   PHYSICAL_ADDRESS_ZIP_CODE_4__c
+  //   PHYSICAL_ADDRESS_ZIP_CODE_4__c,
+  //   ELEC_BUS_POC_EMAIL__c,
+  //   ELEC_BUS_POC_NAME__c,
+  //   ELEC_BUS_POC_TITLE__c,
+  //   ALT_ELEC_BUS_POC_EMAIL__c,
+  //   ALT_ELEC_BUS_POC_NAME__c,
+  //   ALT_ELEC_BUS_POC_TITLE__c,
+  //   GOVT_BUS_POC_EMAIL__c,
+  //   GOVT_BUS_POC_NAME__c,
+  //   GOVT_BUS_POC_TITLE__c,
+  //   ALT_GOVT_BUS_POC_EMAIL__c,
+  //   ALT_GOVT_BUS_POC_NAME__c,
+  //   ALT_GOVT_BUS_POC_TITLE__c
   // FROM
   //   Data_Staging__c
   // WHERE
@@ -416,28 +415,28 @@ async function queryForSamEntities(req, email) {
         // "*": 1,
         Id: 1,
         ENTITY_COMBO_KEY__c: 1,
-        ENTITY_STATUS__c: 1,
         UNIQUE_ENTITY_ID__c: 1,
         ENTITY_EFT_INDICATOR__c: 1,
+        ENTITY_STATUS__c: 1,
         LEGAL_BUSINESS_NAME__c: 1,
-        GOVT_BUS_POC_NAME__c: 1,
-        GOVT_BUS_POC_EMAIL__c: 1,
-        GOVT_BUS_POC_TITLE__c: 1,
-        ALT_GOVT_BUS_POC_NAME__c: 1,
-        ALT_GOVT_BUS_POC_EMAIL__c: 1,
-        ALT_GOVT_BUS_POC_TITLE__c: 1,
-        ELEC_BUS_POC_NAME__c: 1,
-        ELEC_BUS_POC_EMAIL__c: 1,
-        ELEC_BUS_POC_TITLE__c: 1,
-        ALT_ELEC_BUS_POC_NAME__c: 1,
-        ALT_ELEC_BUS_POC_EMAIL__c: 1,
-        ALT_ELEC_BUS_POC_TITLE__c: 1,
         PHYSICAL_ADDRESS_LINE_1__c: 1,
         PHYSICAL_ADDRESS_LINE_2__c: 1,
         PHYSICAL_ADDRESS_CITY__c: 1,
         PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c: 1,
         PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c: 1,
         PHYSICAL_ADDRESS_ZIP_CODE_4__c: 1,
+        ELEC_BUS_POC_EMAIL__c: 1,
+        ELEC_BUS_POC_NAME__c: 1,
+        ELEC_BUS_POC_TITLE__c: 1,
+        ALT_ELEC_BUS_POC_EMAIL__c: 1,
+        ALT_ELEC_BUS_POC_NAME__c: 1,
+        ALT_ELEC_BUS_POC_TITLE__c: 1,
+        GOVT_BUS_POC_EMAIL__c: 1,
+        GOVT_BUS_POC_NAME__c: 1,
+        GOVT_BUS_POC_TITLE__c: 1,
+        ALT_GOVT_BUS_POC_EMAIL__c: 1,
+        ALT_GOVT_BUS_POC_NAME__c: 1,
+        ALT_GOVT_BUS_POC_TITLE__c: 1,
       },
     )
     .execute(async (err, records) => ((await err) ? err : records));


### PR DESCRIPTION
## Related Issues:
* CSBAPP-371

## Main Changes:
Prevents a user from using a SAM.gov entity with a debt offset or exemption status.

## Steps To Test:
1. If you don't already have a SAM.gov entity associated with your email address that has an exemption/exclusion status or debt subject to offset, you'll need to request the BAP change at least one of those fields for you on one of your SAM.gov entity records in the BAP.
2. Navigate to the dashboard.
3. Click the "New Application" button.
4. Ensure any SAM.gov entities you have access to with an exemption/exclusion status or a debt subject to offset are not available to be used in a new FRF submission and there's some explanatory text above indicating that.

## TODO:
- [ ] We should update the SAM.gov test data CSV file to have at least one of each of our test SAM.gov entities have an exemption status and at least one have a debt subject to offset.
- [ ] Get feedback from OAR on the overall layout, text displayed, and functionality.
