### PR TITLE
Feature/update frf 2024 submission dashboard fields

### DIFF
--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -1704,8 +1704,14 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
   const frfSubmissionPeriodOpen = configData.submissionPeriodOpen["2024"].frf;
 
-  const { _user_email, _bap_entity_combo_key } = frf.formio.data;
-  const placeholder = true; // TODO: remove once we have UEI, EFTI, org name, and school district fields above
+  const {
+    _user_email,
+    _bap_entity_combo_key,
+    appInfo_uei,
+    appInfo_efti,
+    appInfo_organization_name,
+    _formio_schoolDistrictName,
+  } = frf.formio.data;
 
   const date = new Date(frf.formio.modified).toLocaleDateString();
   const time = new Date(frf.formio.modified).toLocaleTimeString();
@@ -1810,8 +1816,8 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
       <td className={statusTableCellClassNames}>
         <>
-          {Boolean(placeholder) ? (
-            "TODO"
+          {Boolean(appInfo_uei) ? (
+            appInfo_uei
           ) : (
             <TextWithTooltip
               text=" "
@@ -1819,8 +1825,8 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
             />
           )}
           <br />
-          {Boolean(placeholder) ? (
-            "TODO"
+          {Boolean(appInfo_efti) ? (
+            appInfo_efti
           ) : (
             <TextWithTooltip
               text=" "
@@ -1832,8 +1838,8 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
       <td className={statusTableCellClassNames}>
         <>
-          {Boolean(placeholder) ? (
-            "TODO"
+          {Boolean(appInfo_organization_name) ? (
+            appInfo_organization_name
           ) : (
             <TextWithTooltip
               text=" "
@@ -1841,8 +1847,8 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
             />
           )}
           <br />
-          {Boolean(placeholder) ? (
-            "TODO"
+          {Boolean(_formio_schoolDistrictName) ? (
+            _formio_schoolDistrictName
           ) : (
             <TextWithTooltip
               text=" "

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -274,6 +274,11 @@ type FormioFRF2024Data = {
   _bap_applicant_city: string;
   _bap_applicant_state: string;
   _bap_applicant_zip: string;
+  // fields set by form definition (among others):
+  appInfo_uei: string;
+  appInfo_efti: string;
+  appInfo_organization_name: string;
+  _formio_schoolDistrictName: string;
 };
 
 type FormioPRF2024Data = {

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -943,9 +943,10 @@ function fetchFRFSubmission({ rebateYear, req, res }) {
         return res.json(formioNoUserAccess);
       }
 
-      /** Modify 2023 FRF's NCES API endpoint URL for local development */
+      /** Modify 2023 and 2024 FRF's NCES API endpoint URL for local development */
       const formSchemaJson =
-        NODE_ENV === "development" && rebateYear === "2023"
+        NODE_ENV === "development" &&
+        (rebateYear === "2023" || rebateYear === "2024")
           ? modifyDatasourceComponentsUrl(schema)
           : schema;
 


### PR DESCRIPTION
## Related Issues:
* CSB-367

## Main Changes:
Follow-up to #452 – Updates the fields shown on the user's dashboard for the 2024 FRF to be the fields used in the new form (UEI, EFTI, org name, school district name). Also ensures the NCES API lookup works when the 2024 FRF is tested locally.

## Steps To Test:
1. Navigate to the dashboard.
2. Change the rebate year selection to 2024.
3. Create a new 2024 FRF and advance through the form at least through the school district page.
4. Return to the dashboard, and ensure the fields shown reflect the values used in the 2024 FRF submission.