### PR TITLE
Feature/update 2022 crf status

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -21,7 +21,7 @@ jobs:
 
     # Set environment variables
     env:
-      APP_VERSION: 5.0
+      APP_VERSION: 5.0.2
       CLOUD_SPACE: production
       SERVER_BASE_PATH: /csb
       FORMIO_BASE_URL: ${{ secrets.FORMIO_BASE_URL }}

--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epa-csb-rebate-forms-app-client",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app-client",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "CC0-1.0",
       "dependencies": {
         "@formio/premium": "1.18.4",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app-client",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "U.S. EPA CSB Rebate Forms Application (client app)",
   "homepage": ".",
   "license": "CC0-1.0",

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -75,9 +75,14 @@ export const formioStatusMap = new Map<string, string>()
 /**
  * BAP internal to external status mapping by year and form type.
  *
- * NOTE: The "Edits Requested" BAP status is supported in the app, but not
- * included in the maps because the BAP status alone can't be used in
- * "Edits Requested" scenarios. See `submissionNeedsEdits()` in `utilities.ts`.
+ * NOTES:
+ * 1. The "Edits Requested" BAP status is supported in the app, but not included
+ * in the maps because the BAP status alone can't be used in "Edits Requested"
+ * scenarios (See `submissionNeedsEdits()` in `utilities.ts`).
+ * 2. The 2022 CRF status "Reimbursement Needed" is supported in the app, but
+ * not included in the map because it relies on both the BAP internal status of
+ * "Branch Director Approved" and the BAP's "Reimbursement_Needed__c" field
+ * (see `submissionNeedsReimbursement()` in `utilities.ts`).
  */
 export const bapStatusMap = {
   2022: {
@@ -93,9 +98,8 @@ export const bapStatusMap = {
       .set("Accepted", "Funding Approved"),
     crf: new Map<string, string>()
       .set("Needs Clarification", "Needs Clarification")
-      .set("Reimbursement Needed", "Reimbursement Needed")
       .set("Branch Director Denied", "Close Out Not Approved")
-      .set("Branch Director Approved", "Close Out Approved"),
+      .set("Accepted", "Close Out Approved"),
   },
   2023: {
     frf: new Map<string, string>()
@@ -108,7 +112,7 @@ export const bapStatusMap = {
       .set("Withdrawn", "Withdrawn")
       .set("Coordinator Denied", "Funding Denied")
       .set("Accepted", "Funding Approved"),
-    crf: new Map<string, string>(),
+    crf: new Map<string, string>(), // TODO
   },
 };
 

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -33,6 +33,7 @@ import {
   useSubmissionsQueries,
   useSubmissions,
   submissionNeedsEdits,
+  submissionNeedsReimbursement,
   getUserInfo,
 } from "@/utilities";
 import { Loading, LoadingButtonIcon } from "@/components/loading";
@@ -724,12 +725,20 @@ function CRF2022Submission(props: { rebate: Rebate }) {
 
   const crfBapInternalStatus = crf.bap?.status || "";
   const crfFormioStatus = formioStatusMap.get(crf.formio.state);
+  const crfBapReimbursementNeeded = crf.bap?.reimbursementNeeded || false;
+
+  const crfNeedsReimbursement = submissionNeedsReimbursement({
+    status: crfBapInternalStatus,
+    reimbursementNeeded: crfBapReimbursementNeeded,
+  });
 
   const crfStatus = crfNeedsEdits
     ? "Edits Requested"
-    : bapStatusMap["2022"].crf.get(crfBapInternalStatus) ||
-      crfFormioStatus ||
-      "";
+    : crfNeedsReimbursement
+      ? "Reimbursement Needed"
+      : bapStatusMap["2022"].crf.get(crfBapInternalStatus) ||
+        crfFormioStatus ||
+        "";
 
   const crfApproved = crfStatus === "Close Out Approved";
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epa-csb-rebate-forms-app",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "CC0-1.0",
       "devDependencies": {
         "concurrently": "8.2.2",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "U.S. EPA CSB Rebate Forms Application",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -57,6 +57,7 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  CSB_Funding_Request_Status__c: string
  *  CSB_Payment_Request_Status__c: string
  *  CSB_Closeout_Request_Status__c: string
+ *  Reimbursement_Needed__c: boolean
  * }} Parent_CSB_Rebate__r
  * @property {{
  *  type: string
@@ -517,7 +518,8 @@ async function queryForBapFormSubmissionData(
   //   Rebate_Program_Year__c,
   //   Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c,
   //   Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c,
-  //   Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c
+  //   Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c,
+  //   Parent_CSB_Rebate__r.Reimbursement_Needed__c
   // FROM
   //   Order_Request__c
   // WHERE
@@ -546,6 +548,7 @@ async function queryForBapFormSubmissionData(
         "Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c": 1,
+        "Parent_CSB_Rebate__r.Reimbursement_Needed__c": 1,
       },
     )
     .execute(async (err, records) => ((await err) ? err : records));
@@ -613,7 +616,8 @@ async function queryForBapFormSubmissionsStatuses(req) {
   //   Rebate_Program_Year__c,
   //   Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c,
   //   Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c,
-  //   Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c
+  //   Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c,
+  //   Parent_CSB_Rebate__r.Reimbursement_Needed__c
   // FROM
   //   Order_Request__c
   // WHERE
@@ -643,6 +647,7 @@ async function queryForBapFormSubmissionsStatuses(req) {
         "Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c": 1,
+        "Parent_CSB_Rebate__r.Reimbursement_Needed__c": 1,
       },
     )
     .sort({ CreatedDate: -1 })
@@ -1599,10 +1604,10 @@ function checkFormSubmissionPeriodAndBapStatus({
       formType === "frf"
         ? "CSB_Funding_Request_Status__c"
         : formType === "prf"
-        ? "CSB_Payment_Request_Status__c"
-        : formType === "crf"
-        ? "CSB_Closeout_Request_Status__c"
-        : null;
+          ? "CSB_Payment_Request_Status__c"
+          : formType === "crf"
+            ? "CSB_Closeout_Request_Status__c"
+            : null;
 
     return submission?.Parent_CSB_Rebate__r?.[statusField] === "Edits Requested"
       ? Promise.resolve()

--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epa-csb-rebate-forms-app-server",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app-server",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "CC0-1.0",
       "dependencies": {
         "axios": "1.6.8",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app-server",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "U.S. EPA CSB Rebate Forms Application (server app)",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",


### PR DESCRIPTION
## Related Issues:
* CSBAPP-369

## Main Changes:
Updates handling of 2022 CRF statuses (in particular, the logic around "Reimbursement Needed" and the internal BAP status used to indicate the external status of "Close Out Approved") to support the logic changes the BAP team implemented in their CRF work, after the wrapping application went live.

## Steps To Test:
1. Navigate to the dashboard.
2. Work with the BAP team to ensure at least one of your 2022 CRF submissions has an internal status of "Branch Director Approved" and the "Parent_CSB_Rebate__r.Reimbursement_Needed__c" flag is set to true. Ensure "Reimbursement Needed" is displayed for that submission.
4. Work with the BAP team to ensure at least one of our 2022 CRF submissions has an internal status of "Accepted." Ensure "Close Out Approved" is displayed for that submission.
