### PR TITLE
Feature/support 2022 crf status changes

### DIFF
--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -75,9 +75,14 @@ export const formioStatusMap = new Map<string, string>()
 /**
  * BAP internal to external status mapping by year and form type.
  *
- * NOTE: The "Edits Requested" BAP status is supported in the app, but not
- * included in the maps because the BAP status alone can't be used in
- * "Edits Requested" scenarios. See `submissionNeedsEdits()` in `utilities.ts`.
+ * NOTES:
+ * 1. The "Edits Requested" BAP status is supported in the app, but not included
+ * in the maps because the BAP status alone can't be used in "Edits Requested"
+ * scenarios (See `submissionNeedsEdits()` in `utilities.ts`).
+ * 2. The 2022 CRF status "Reimbursement Needed" is supported in the app, but
+ * not included in the map because it relies on both the BAP internal status of
+ * "Branch Director Approved" and the BAP's "Reimbursement_Needed__c" field
+ * (see `submissionNeedsReimbursement()` in `utilities.ts`).
  */
 export const bapStatusMap = {
   2022: {
@@ -93,9 +98,8 @@ export const bapStatusMap = {
       .set("Accepted", "Funding Approved"),
     crf: new Map<string, string>()
       .set("Needs Clarification", "Needs Clarification")
-      .set("Reimbursement Needed", "Reimbursement Needed")
       .set("Branch Director Denied", "Close Out Not Approved")
-      .set("Branch Director Approved", "Close Out Approved"),
+      .set("Accepted", "Close Out Approved"),
   },
   2023: {
     frf: new Map<string, string>()

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -32,6 +32,7 @@ import {
   useSubmissionsQueries,
   useSubmissions,
   submissionNeedsEdits,
+  submissionNeedsReimbursement,
   getUserInfo,
 } from "@/utilities";
 import { Loading, LoadingButtonIcon } from "@/components/loading";
@@ -717,12 +718,20 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
 
   const crfBapInternalStatus = crf.bap?.status || "";
   const crfFormioStatus = formioStatusMap.get(crf.formio.state);
+  const crfBapReimbursementNeeded = crf.bap?.reimbursementNeeded || false;
+
+  const crfNeedsReimbursement = submissionNeedsReimbursement({
+    status: crfBapInternalStatus,
+    reimbursementNeeded: crfBapReimbursementNeeded,
+  });
 
   const crfStatus = crfNeedsEdits
     ? "Edits Requested"
-    : bapStatusMap["2022"].crf.get(crfBapInternalStatus) ||
-      crfFormioStatus ||
-      "";
+    : crfNeedsReimbursement
+      ? "Reimbursement Needed"
+      : bapStatusMap["2022"].crf.get(crfBapInternalStatus) ||
+        crfFormioStatus ||
+        "";
 
   const crfApproved = crfStatus === "Close Out Approved";
 

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -98,6 +98,7 @@ export type BapFormSubmission = {
     CSB_Funding_Request_Status__c: string;
     CSB_Payment_Request_Status__c: string;
     CSB_Closeout_Request_Status__c: string;
+    Reimbursement_Needed__c: boolean;
     attributes: { type: string; url: string };
   };
   attributes: { type: string; url: string };
@@ -128,6 +129,7 @@ export type BapSubmissionData = {
   rebateId: string | null; // CSB Rebate ID (6 digits)
   reviewItemId: string | null; // CSB Rebate ID with form/version ID (9 digits)
   status: string | null;
+  reimbursementNeeded: boolean;
 };
 
 export type FormioSubmission = {

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -494,6 +494,7 @@ function useCombinedSubmissions<Year extends RebateYear>(
     const rebateId = bapMatch?.Parent_Rebate_ID__c || null;
     const reviewItemId = bapMatch?.CSB_Review_Item_ID__c || null;
     const status = bapMatch?.Parent_CSB_Rebate__r?.CSB_Funding_Request_Status__c || null; // prettier-ignore
+    const reimbursementNeeded = bapMatch?.Parent_CSB_Rebate__r?.Reimbursement_Needed__c || false; // prettier-ignore
 
     /**
      * NOTE: If new FRF submissions have been reciently created in Formio and
@@ -507,7 +508,15 @@ function useCombinedSubmissions<Year extends RebateYear>(
       rebateYear,
       frf: {
         formio: { ...formioFRFSubmission },
-        bap: { modified, comboKey, mongoId, rebateId, reviewItemId, status },
+        bap: {
+          modified,
+          comboKey,
+          mongoId,
+          rebateId,
+          reviewItemId,
+          status,
+          reimbursementNeeded,
+        },
       },
       prf: { formio: null, bap: null },
       crf: { formio: null, bap: null },
@@ -533,11 +542,20 @@ function useCombinedSubmissions<Year extends RebateYear>(
     const rebateId = bapMatch?.Parent_Rebate_ID__c || null;
     const reviewItemId = bapMatch?.CSB_Review_Item_ID__c || null;
     const status = bapMatch?.Parent_CSB_Rebate__r?.CSB_Payment_Request_Status__c || null; // prettier-ignore
+    const reimbursementNeeded = bapMatch?.Parent_CSB_Rebate__r?.Reimbursement_Needed__c || false; // prettier-ignore
 
     if (formioBapRebateId && submissions[formioBapRebateId]) {
       submissions[formioBapRebateId].prf = {
         formio: { ...formioPRFSubmission },
-        bap: { modified, comboKey, mongoId, rebateId, reviewItemId, status },
+        bap: {
+          modified,
+          comboKey,
+          mongoId,
+          rebateId,
+          reviewItemId,
+          status,
+          reimbursementNeeded,
+        },
       } as Rebate<Year>["prf"];
     }
   }
@@ -561,11 +579,20 @@ function useCombinedSubmissions<Year extends RebateYear>(
     const rebateId = bapMatch?.Parent_Rebate_ID__c || null;
     const reviewItemId = bapMatch?.CSB_Review_Item_ID__c || null;
     const status = bapMatch?.Parent_CSB_Rebate__r?.CSB_Closeout_Request_Status__c || null; // prettier-ignore
+    const reimbursementNeeded = bapMatch?.Parent_CSB_Rebate__r?.Reimbursement_Needed__c || false; // prettier-ignore
 
     if (formioBapRebateId && submissions[formioBapRebateId]) {
       submissions[formioBapRebateId].crf = {
         formio: { ...formioCRFSubmission },
-        bap: { modified, comboKey, mongoId, rebateId, reviewItemId, status },
+        bap: {
+          modified,
+          comboKey,
+          mongoId,
+          rebateId,
+          reviewItemId,
+          status,
+          reimbursementNeeded,
+        },
       } as Rebate<Year>["crf"];
     }
   }
@@ -687,6 +714,19 @@ export function submissionNeedsEdits(options: {
     (formio.state === "draft" ||
       (formio.state === "submitted" && !submissionHasBeenUpdatedSinceLastETL))
   );
+}
+
+/**
+ * Determines whether a submission needs reimbursement, based on the BAP status
+ * and reimbursement status.
+ */
+export function submissionNeedsReimbursement(options: {
+  status: string;
+  reimbursementNeeded: boolean;
+}) {
+  const { status, reimbursementNeeded } = options;
+
+  return status === "Branch Director Approved" && reimbursementNeeded;
 }
 
 /**

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -67,6 +67,7 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  CSB_Funding_Request_Status__c: string
  *  CSB_Payment_Request_Status__c: string
  *  CSB_Closeout_Request_Status__c: string
+ *  Reimbursement_Needed__c: boolean
  * }} Parent_CSB_Rebate__r
  * @property {{
  *  type: string
@@ -535,7 +536,8 @@ async function queryForBapFormSubmissionData(
   //   Rebate_Program_Year__c,
   //   Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c,
   //   Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c,
-  //   Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c
+  //   Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c,
+  //   Parent_CSB_Rebate__r.Reimbursement_Needed__c
   // FROM
   //   Order_Request__c
   // WHERE
@@ -564,6 +566,7 @@ async function queryForBapFormSubmissionData(
         "Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c": 1,
+        "Parent_CSB_Rebate__r.Reimbursement_Needed__c": 1,
       },
     )
     .execute(async (err, records) => ((await err) ? err : records));
@@ -631,7 +634,8 @@ async function queryForBapFormSubmissionsStatuses(req) {
   //   Rebate_Program_Year__c,
   //   Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c,
   //   Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c,
-  //   Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c
+  //   Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c,
+  //   Parent_CSB_Rebate__r.Reimbursement_Needed__c
   // FROM
   //   Order_Request__c
   // WHERE
@@ -661,6 +665,7 @@ async function queryForBapFormSubmissionsStatuses(req) {
         "Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Closeout_Request_Status__c": 1,
+        "Parent_CSB_Rebate__r.Reimbursement_Needed__c": 1,
       },
     )
     .sort({ CreatedDate: -1 })


### PR DESCRIPTION
## Related Issues:
* CSBAPP-369

## Main Changes:
Implements the same changes made in #455 (which was against the staging branch) – this time against the develop branch (which includes v6.0.0 changes):

Update logic around setting 2022 CRF 'Reimbursement Needed' and 'Close Out Approved' statuses (requires fetching an additional field from the BAP, and moving the reimbursement needed logic into a new submissionNeedsReimbursement() function)

## Steps To Test:
1. Navigate to the dashboard.
2. Work with the BAP team to ensure at least one of your 2022 CRF submissions has an internal status of "Branch Director Approved" and the "Parent_CSB_Rebate__r.Reimbursement_Needed__c" flag is set to true. Ensure "Reimbursement Needed" is displayed for that submission.
3. Work with the BAP team to ensure at least one of our 2022 CRF submissions has an internal status of "Accepted." Ensure "Close Out Approved" is displayed for that submission.
