### PR TITLE
Update all rebates intro text to include text for 2024 rebate year

### DIFF
--- a/app/server/app/content/all-rebates-intro.md
+++ b/app/server/app/content/all-rebates-intro.md
@@ -2,5 +2,6 @@
 
 Select a button below to _Edit_ or _View_ an existing rebate form.
 
+- For the 2024 rebate year, you may request edits or a withdrawal by selecting Change Request, _Change_.
 - For the 2023 rebate year, you may request edits, an extension, or a withdrawal by selecting Change Request, _Change_.
 - For the 2022 rebate year, you may request edits, a withdrawal, or a Close Out Form extension (see [Close Out Form webpage](https://www.epa.gov/cleanschoolbus/clean-school-bus-rebates-close-out-form "external")) by emailing [cleanschoolbus@epa.gov](mailto:cleanschoolbus@epa.gov).


### PR DESCRIPTION
## Related Issues:
* CSBAPP-367

## Main Changes:
* Update all rebates intro text to include text for 2024 rebate year

## Steps To Test:
1. Navigate to the dashboard
2. Ensure the 2024 rebate year text is displayed above the 2023 rebate year intro text.
