### PR TITLE
Bump up dev app's memory limit to 192MB

### DIFF
--- a/app/manifest-dev.yml
+++ b/app/manifest-dev.yml
@@ -4,7 +4,7 @@ applications:
     routes:
       - route: app-dev.app.cloud.gov/csb
     instances: 1
-    memory: 128M
+    memory: 192M
     disk_quota: 512MB
     timeout: 180
     buildpacks:


### PR DESCRIPTION
## Related Issues:
* CSBAPP-374

## Main Changes:
* Follow up to #464 – bumps up the dev app's memory limit to 192MB to account for increased data being stored in memory for 2024 NCES lookup.

## Steps To Test:
1. Test the app, ensure it works as expected

## TODO:
- [ ] Evaluate if this is the best long term approach to handling the growing amount of NCES data as each rebate year, more data will be added.
