### PR TITLE
Feature/update staging app memory

### DIFF
--- a/app/manifest-dev.yml
+++ b/app/manifest-dev.yml
@@ -16,3 +16,4 @@ applications:
       OPTIMIZE_MEMORY: true
     services:
       - s3-pub-csb-dev
+      - log-drain

--- a/app/manifest-production.yml
+++ b/app/manifest-production.yml
@@ -18,3 +18,4 @@ applications:
       OPTIMIZE_MEMORY: true
     services:
       - s3-pub-csb-prod
+      - log-drain

--- a/app/manifest-staging.yml
+++ b/app/manifest-staging.yml
@@ -16,3 +16,4 @@ applications:
       OPTIMIZE_MEMORY: true
     services:
       - s3-pub-csb-stage
+      - log-drain

--- a/app/manifest-staging.yml
+++ b/app/manifest-staging.yml
@@ -4,7 +4,7 @@ applications:
     routes:
       - route: app-stage.app.cloud.gov/csb
     instances: 2
-    memory: 128M
+    memory: 192M
     disk_quota: 512MB
     timeout: 180
     buildpacks:


### PR DESCRIPTION
## Related Issues:
* CSBAPP-374

## Main Changes:
* Follow up to #465 – bumps the staging Cloud.gov app's memory limit up to 192MB, and adds the "log-drain" service to dev, staging, and production Cloud.gov apps.

## Steps To Test:
1. Nothing yet, but when the `develop` branch gets merged into the `staging` branch, we'll want to test the NCES update still works on staging.
