### PR TITLE
Feature/update helpdesk

### DIFF
--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -36,6 +36,7 @@ import {
   useContentData,
   useHelpdeskAccess,
   submissionNeedsEdits,
+  submissionNeedsReimbursement,
 } from "@/utilities";
 import { Loading, LoadingButtonIcon } from "@/components/loading";
 import { Message } from "@/components/message";
@@ -183,12 +184,24 @@ function ResultTableRow(props: {
 
   const bapInternalStatus = bap.status || "";
   const formioStatus = formioStatusMap.get(formio.state);
+  const bapReimbursementNeeded = bap.reimbursementNeeded || false;
 
-  const status = submissionNeedsEdits({ formio, bap })
+  const needsEdits = submissionNeedsEdits({ formio, bap });
+
+  const crfNeedsReimbursement =
+    formType === "crf" &&
+    submissionNeedsReimbursement({
+      status: bapInternalStatus,
+      reimbursementNeeded: bapReimbursementNeeded,
+    });
+
+  const status = needsEdits
     ? "Edits Requested"
-    : bapStatusMap[rebateYear][formType].get(bapInternalStatus) ||
-      formioStatus ||
-      "";
+    : crfNeedsReimbursement
+      ? "Reimbursement Needed"
+      : bapStatusMap[rebateYear][formType].get(bapInternalStatus) ||
+        formioStatus ||
+        "";
 
   const nameField = formioNameField[rebateYear][formType];
   const emailField = formioEmailField[rebateYear][formType];

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -132,6 +132,13 @@ router.get("/formio/submission/:rebateYear/:formType/:id", (req, res) => {
       Parent_CSB_Rebate__r,
     } = bapSubmission ?? {};
 
+    const {
+      CSB_Funding_Request_Status__c,
+      CSB_Payment_Request_Status__c,
+      CSB_Closeout_Request_Status__c,
+      Reimbursement_Needed__c,
+    } = Parent_CSB_Rebate__r ?? {};
+
     /**
      * NOTE: For submissions not in the BAP, each property of the bap object
      * parameter will be null.
@@ -148,12 +155,13 @@ router.get("/formio/submission/:rebateYear/:formType/:id", (req, res) => {
         reviewItemId: CSB_Review_Item_ID__c || null, // CSB Rebate ID with form/version ID (9 digits)
         status:
           (Record_Type_Name__c?.startsWith("CSB Funding Request")
-            ? Parent_CSB_Rebate__r?.CSB_Funding_Request_Status__c
+            ? CSB_Funding_Request_Status__c
             : Record_Type_Name__c?.startsWith("CSB Payment Request")
-              ? Parent_CSB_Rebate__r?.CSB_Payment_Request_Status__c
+              ? CSB_Payment_Request_Status__c
               : Record_Type_Name__c?.startsWith("CSB Close Out Request")
-                ? Parent_CSB_Rebate__r?.CSB_Closeout_Request_Status__c
+                ? CSB_Closeout_Request_Status__c
                 : "") || null,
+        reimbursementNeeded: Reimbursement_Needed__c || null,
       },
       req,
       res,

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -61,6 +61,9 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  | 'CSB Funding Request 2023'
  *  | 'CSB Payment Request 2023'
  *  | 'CSB Close Out Request 2023'
+ *  | 'CSB Funding Request 2024'
+ *  | 'CSB Payment Request 2024'
+ *  | 'CSB Close Out Request 2024'
  * } Record_Type_Name__c
  * @property {string | null} Rebate_Program_Year__c
  * @property {{
@@ -561,7 +564,7 @@ async function queryForBapFormSubmissionData(
         CSB_Modified_Full_String__c: 1, // ISO 8601 date time string
         CSB_Review_Item_ID__c: 1, // CSB Rebate ID with form/version ID (9 digits)
         Parent_Rebate_ID__c: 1, // CSB Rebate ID (6 digits)
-        Record_Type_Name__c: 1, // 'CSB Funding Request' | 'CSB Payment Request' | 'CSB Close Out Request' | 'CSB Funding Request 2023' | 'CSB Payment Request 2023' | 'CSB Close Out Request 2023'
+        Record_Type_Name__c: 1, // 'CSB Funding Request' | 'CSB Payment Request' | 'CSB Close Out Request' | same three forms with rebate year (.e.g., 'CSB Funding Request 2023')
         Rebate_Program_Year__c: 1, // '2022' | '2023' | '2024'
         "Parent_CSB_Rebate__r.CSB_Funding_Request_Status__c": 1,
         "Parent_CSB_Rebate__r.CSB_Payment_Request_Status__c": 1,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-369

## Main Changes:
* Follow up for #455 and #456 – updates the helpdesk page to support showing the "Reimbursement Needed" status for CRF submissions.

## Steps To Test:
1. Ensure you have at least one 2022 CRF submission in the "Reimbursement Needed" status.
2. Navigate to the helpdesk page.
3. Search for that 2022 CRF submission by Rebate Id, and ensure the status shown in the results shows the correct "Reimbursement Needed" status.