### PR TITLE
Feature/update app version number

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -21,7 +21,7 @@ jobs:
 
     # Set environment variables
     env:
-      APP_VERSION: 5.0.2
+      APP_VERSION: 6.0.0
       CLOUD_SPACE: production
       SERVER_BASE_PATH: /csb
       FORMIO_BASE_URL: ${{ secrets.FORMIO_BASE_URL }}

--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epa-csb-rebate-forms-app-client",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app-client",
-      "version": "5.0.2",
+      "version": "6.0.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@formio/premium": "1.18.4",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app-client",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "description": "U.S. EPA CSB Rebate Forms Application (client app)",
   "homepage": ".",
   "license": "CC0-1.0",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epa-csb-rebate-forms-app",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app",
-      "version": "5.0.2",
+      "version": "6.0.0",
       "license": "CC0-1.0",
       "devDependencies": {
         "concurrently": "8.2.2",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "description": "U.S. EPA CSB Rebate Forms Application",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",

--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epa-csb-rebate-forms-app-server",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app-server",
-      "version": "5.0.2",
+      "version": "6.0.0",
       "license": "CC0-1.0",
       "dependencies": {
         "axios": "1.6.8",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app-server",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "description": "U.S. EPA CSB Rebate Forms Application (server app)",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",


### PR DESCRIPTION
## Related Issues:
* CSBAPP-427

## Main Changes:
Update app version number in all package.json (and package-lock.json) files, and in "Production Build" GitHub workflow action

## Steps To Test:
1. Ensure version number is correct across codebase for future v6.0.0 release.