### PR TITLE
Feature/fix nces api routes

### DIFF
--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -39,7 +39,7 @@ const router = express.Router();
 router.use(ensureAuthenticated);
 
 // --- search 2023 NCES data with the provided NCES ID and return a match
-router.get("/nces/:searchText", (req, res) => {
+router.get("/nces/:searchText?", (req, res) => {
   searchNcesData({ rebateYear, req, res });
 });
 

--- a/app/server/app/routes/formio2024.js
+++ b/app/server/app/routes/formio2024.js
@@ -39,7 +39,7 @@ const router = express.Router();
 router.use(ensureAuthenticated);
 
 // --- search 2024 NCES data with the provided NCES ID and return a match
-router.get("/nces/:searchText", (req, res) => {
+router.get("/nces/:searchText?", (req, res) => {
   searchNcesData({ rebateYear, req, res });
 });
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-374

## Main Changes:
* Follow up to #483 – updates 2023 and 2024 NCES API routes to make `searchText` optional, so when the endpoint is called without an NCES ID (which happens when the user clicks the button to clear out the value), the endpoint is still called.

## Steps To Test:
1. Navigate to a 2023 or 2024 FRF draft submission.
2. Advance to the "School District Info" page/section of the form, and click the "Edit NCES District ID" button to clear out any previously entered NCES ID value.
3. Open the network panel, and ensure when the NCES API endpoint is called by the form without any search text (e.g., `/api/formio/2024/nces/`) the request succeeds.
