### PR TITLE
Feature/update production build github action

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -79,6 +79,10 @@ jobs:
         run: rm -rf .env.example .eslintrc.js .prettierrc.json
         working-directory: app/server
 
+      - name: Remove NCES JSON files, as they're served from S3 in production
+        run: rm -rf nces-2023.json nces-2024.json
+        working-directory: app/server/app/content
+
       - name: Copy production manifest file to server app
         run: cp manifest-production.yml server/manifest-production.yml
         working-directory: app


### PR DESCRIPTION
## Related Issues:
* CSBAPP-442

## Main Changes:
* Add a step to the 'Production Build' GitHub Action workflow to remove the NCES JSON files, as they're fetched from an S3 bucket in production, so don't need to be in the deployed codebase

## Steps To Test:
1. Create a new production build, and ensure the NCES JSON files aren't included.