### PR TITLE
Feature/update GitHub actions workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -97,7 +97,7 @@ jobs:
         working-directory: app/client
 
       - name: Install front-end dependencies
-        run: npm install --production
+        run: npm install
         working-directory: app/client
 
       - name: Build front-end files and move to server

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -96,11 +96,11 @@ jobs:
         run: echo "//pkg.form.io/:_authToken=${FORMIO_PKG_AUTH_TOKEN}" > .npmrc
         working-directory: app/client
 
-      - name: Install front-end dependencies
+      - name: Install client app dependencies
         run: npm install
         working-directory: app/client
 
-      - name: Build front-end files and move to server
+      - name: Build client app and move files to server app
         run: |
           VITE_SERVER_BASE_PATH="$SERVER_BASE_PATH" \
             VITE_CLOUD_SPACE="$CLOUD_SPACE" \
@@ -122,7 +122,7 @@ jobs:
           cf auth "$CF_USER_DEV" "$CF_PASSWORD_DEV"
           cf target -o "$CF_ORG" -s "$CF_SPACE"
 
-      - name: Set application-level variables
+      - name: Set application level variables
         run: |
           cf set-env $APP_NAME "CLOUD_SPACE" "$CLOUD_SPACE" > /dev/null
           cf set-env $APP_NAME "SERVER_URL" "$SERVER_URL" > /dev/null
@@ -177,7 +177,7 @@ jobs:
         run: aws s3api put-bucket-cors --bucket $S3_PUBLIC_BUCKET --cors-configuration file://s3CORS.json
         working-directory: app/server/app/config
 
-      # Now that front-end is built in server/dist, only push server dir to Cloud.gov
+      # Now that client is built and included in server app, only push server app to Cloud.gov
       - name: Deploy application to Cloud.gov
         run: cf push $APP_NAME --strategy rolling -f ../manifest-dev.yml -p . -t 180
         working-directory: app/server

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: app/client
 
       - name: Install client app dependencies
-        run: npm install --production
+        run: npm install
         working-directory: app/client
 
       - name: Build client app

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -63,7 +63,7 @@ jobs:
         run: npm install
         working-directory: app/client
 
-      - name: Build client app
+      - name: Build client app and move files to server app
         run: |
           VITE_SERVER_BASE_PATH="$SERVER_BASE_PATH" \
             VITE_CLOUD_SPACE="$CLOUD_SPACE" \

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -97,7 +97,7 @@ jobs:
         working-directory: app/client
 
       - name: Install front-end dependencies
-        run: npm install --production
+        run: npm install
         working-directory: app/client
 
       - name: Build front-end files and move to server

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -96,11 +96,11 @@ jobs:
         run: echo "//pkg.form.io/:_authToken=${FORMIO_PKG_AUTH_TOKEN}" > .npmrc
         working-directory: app/client
 
-      - name: Install front-end dependencies
+      - name: Install client app dependencies
         run: npm install
         working-directory: app/client
 
-      - name: Build front-end files and move to server
+      - name: Build client app and move files to server app
         run: |
           VITE_SERVER_BASE_PATH="$SERVER_BASE_PATH" \
             VITE_CLOUD_SPACE="$CLOUD_SPACE" \
@@ -122,7 +122,7 @@ jobs:
           cf auth "$CF_USER_STAGING" "$CF_PASSWORD_STAGING"
           cf target -o "$CF_ORG" -s "$CF_SPACE"
 
-      - name: Set application-level variables
+      - name: Set application level variables
         run: |
           cf set-env $APP_NAME "CLOUD_SPACE" "$CLOUD_SPACE" > /dev/null
           cf set-env $APP_NAME "SERVER_URL" "$SERVER_URL" > /dev/null
@@ -177,7 +177,7 @@ jobs:
         run: aws s3api put-bucket-cors --bucket $S3_PUBLIC_BUCKET --cors-configuration file://s3CORS.json
         working-directory: app/server/app/config
 
-      # Now that front-end is built in server/dist, only push server dir to Cloud.gov
+      # Now that client is built and included in server app, only push server app to Cloud.gov
       - name: Deploy application to Cloud.gov
         run: cf push $APP_NAME --strategy rolling -f ../manifest-staging.yml -p . -t 180
         working-directory: app/server


### PR DESCRIPTION
## Related Issues:
* CSBAPP-477

## Main Changes:
* Fixes CI error due to previous PR #495 – updates GitHub Action workflows to pass the `--production` flag to the client app's `npm install` script, as removing it breaks the CI build.

## Steps To Test:
1. Same as before – Navigate to the dashboard. The rebate year should default to 2024.
