### PR TITLE
Feature/update helpdesk

### DIFF
--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -154,6 +154,7 @@ router.get("/formio/submission/:rebateYear/:formType/:id", async (req, res) => {
   const { rebateYear, formType, id } = req.params;
 
   const result = {
+    rebateId: null,
     formSchema: null,
     formio: null,
     bap: null,
@@ -235,7 +236,13 @@ router.get("/formio/submission/:rebateYear/:formType/:id", async (req, res) => {
     return res.status(errorStatus).json({ message: errorMessage });
   }
 
-  return res.json(result);
+  const bapRebateId = result.bap?.rebateId;
+  const formioRebateId = result.formio?.data?.[rebateIdFieldName];
+
+  return res.json({
+    ...result,
+    rebateId: bapRebateId || formioRebateId || null,
+  });
 });
 
 // --- post an update to an existing form submission to Formio (change submission to 'draft')

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -45,9 +45,9 @@ function fetchFormioFormSchema({ formioFormUrl, req }) {
     .get(formioFormUrl)
     .then((axiosRes) => axiosRes.data)
     .then((schema) => ({ url: formioFormUrl, json: schema }))
-    .catch((error) => {
+    .catch((_error) => {
       // NOTE: error is logged in axiosFormio response interceptor
-      throw error;
+      return null;
     });
 }
 
@@ -81,9 +81,9 @@ function fetchFormioSubmissionData({ formioSubmissionUrl, id, req }) {
       const result = id === "rebateId" ? json[0] : json;
       return result || null;
     })
-    .catch((error) => {
+    .catch((_error) => {
       // NOTE: error is logged in axiosFormio response interceptor
-      throw error;
+      return null;
     });
 }
 

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -10,6 +10,7 @@ const {
 } = require("../config/formio");
 const { ensureAuthenticated, ensureHelpdesk } = require("../middleware");
 const { getBapFormSubmissionData } = require("../utilities/bap");
+const { getRebateIdFieldName } = require("../utilities/formio");
 
 /**
  * @typedef {'2022' | '2023' | '2024'} RebateYear
@@ -32,33 +33,142 @@ const formioFormNameMap = new Map()
   .set("crf", "CSB Close Out");
 
 /**
- * Fetches data associated with a provided form submission from Formio.
+ * Fetches Formio form schema when provided a Formio form url.
  *
- * @param {Object} param
- * @param {RebateYear} param.rebateYear
- * @param {FormType} param.formType
- * @param {string} param.mongoId
  * @param {{
- *  modified: string | null
- *  comboKey: string | null
- *  mongoId: string | null
- *  rebateId: string | null
- *  reviewItemId: string | null
- *  status: string | null
- * }} param.bap
- * @param {express.Request} param.req
- * @param {express.Response} param.res
+ *  formioFormUrl: string
+ *  req: express.Request
+ * }} param
  */
-function fetchFormioSubmission({
+function fetchFormioFormSchema({ formioFormUrl, req }) {
+  return axiosFormio(req)
+    .get(formioFormUrl)
+    .then((axiosRes) => axiosRes.data)
+    .then((schema) => ({ url: formioFormUrl, json: schema }))
+    .catch((error) => {
+      // NOTE: error is logged in axiosFormio response interceptor
+      throw error;
+    });
+}
+
+/**
+ * Fetches Formio form submission data when provided a Formio submission url.
+ *
+ * @param {{
+ *  formioSubmissionUrl: string
+ *  id: 'rebateId' | 'mongoId'
+ *  req: express.Request
+ * }} param
+ */
+function fetchFormioSubmissionData({ formioSubmissionUrl, id, req }) {
+  /**
+   * NOTE:
+   * If the provided id is 'rebateId', the provided formSubmissionUrl includes
+   * the rebateId within it and we'll query Formio for all submissions that
+   * include the rebateId field and its value (which should only be one
+   * submission). In that case, the Formio query's response will be an array of
+   * submission objects, so we'll return the first one.
+   *
+   * Else, if the provided id is 'mongoId', the provided formSubmissionUrl
+   * includes the mongoId within it and we'll query Formio for the single
+   * submission. In that case, the Formio query's response will be a single
+   * submission object, so we'll return it.
+   */
+  return axiosFormio(req)
+    .get(formioSubmissionUrl)
+    .then((axiosRes) => axiosRes.data)
+    .then((json) => {
+      const result = id === "rebateId" ? json[0] : json;
+      return result || null;
+    })
+    .catch((error) => {
+      // NOTE: error is logged in axiosFormio response interceptor
+      throw error;
+    });
+}
+
+/**
+ * Fetches BAP form submission data for a given rebate form.
+ *
+ * @param {{
+ *  rebateYear: RebateYear
+ *  formType: FormType
+ *  rebateId: string | null
+ *  mongoId: string | null
+ *  req: express.Request
+ * }} param
+ */
+function fetchBapSubmissionData({
   rebateYear,
   formType,
+  rebateId,
   mongoId,
-  bap,
   req,
-  res,
 }) {
+  return getBapFormSubmissionData({
+    rebateYear,
+    formType,
+    rebateId,
+    mongoId,
+    req,
+  }).then((json) => {
+    if (!json) return null;
+
+    const {
+      UEI_EFTI_Combo_Key__c,
+      CSB_Form_ID__c,
+      CSB_Modified_Full_String__c,
+      CSB_Review_Item_ID__c,
+      Parent_Rebate_ID__c,
+      Record_Type_Name__c,
+      Parent_CSB_Rebate__r,
+    } = json;
+
+    const {
+      CSB_Funding_Request_Status__c,
+      CSB_Payment_Request_Status__c,
+      CSB_Closeout_Request_Status__c,
+      Reimbursement_Needed__c,
+    } = Parent_CSB_Rebate__r ?? {};
+
+    return {
+      modified: CSB_Modified_Full_String__c, // ISO 8601 date time string
+      comboKey: UEI_EFTI_Combo_Key__c, // UEI + EFTI combo key
+      mongoId: CSB_Form_ID__c, // MongoDB Object ID
+      rebateId: Parent_Rebate_ID__c, // CSB Rebate ID (6 digits)
+      reviewItemId: CSB_Review_Item_ID__c, // CSB Rebate ID with form/version ID (9 digits)
+      status: Record_Type_Name__c?.startsWith("CSB Funding Request")
+        ? CSB_Funding_Request_Status__c
+        : Record_Type_Name__c?.startsWith("CSB Payment Request")
+          ? CSB_Payment_Request_Status__c
+          : Record_Type_Name__c?.startsWith("CSB Close Out Request")
+            ? CSB_Closeout_Request_Status__c
+            : "",
+      reimbursementNeeded: Reimbursement_Needed__c,
+    };
+  });
+}
+
+// --- get an existing form's submission data from Formio and the BAP
+router.get("/formio/submission/:rebateYear/:formType/:id", async (req, res) => {
+  const { rebateYear, formType, id } = req.params;
+
+  const result = {
+    formSchema: null,
+    formio: null,
+    bap: null,
+  };
+
+  // NOTE: included to support EPA API scan
+  if (id === formioExampleRebateId) {
+    return res.json({});
+  }
+
+  const rebateId = id.length === 6 ? id : null;
+  const mongoId = !rebateId ? id : null;
+
   /** NOTE: verifyMongoObjectId */
-  if (!ObjectId.isValid(mongoId)) {
+  if (mongoId && !ObjectId.isValid(mongoId)) {
     const errorStatus = 400;
     const errorMessage = `MongoDB ObjectId validation error for: '${mongoId}'.`;
     return res.status(errorStatus).json({ message: errorMessage });
@@ -69,104 +179,63 @@ function fetchFormioSubmission({
 
   if (!formioFormUrl) {
     const errorStatus = 400;
-    const errorMessage = `Formio form URL does not exist for ${rebateYear} ${formName}.`;
+    const errorMessage = `Formio form URL does not exist for ${rebateYear} ${formName} form.`;
     return res.status(errorStatus).json({ message: errorMessage });
   }
 
-  return Promise.all([
-    axiosFormio(req).get(`${formioFormUrl}/submission/${mongoId}`),
-    axiosFormio(req).get(formioFormUrl),
-  ])
-    .then((responses) => responses.map((axiosRes) => axiosRes.data))
-    .then(([formioSubmission, schema]) => {
-      return res.json({
-        formSchema: { url: formioFormUrl, json: schema },
-        formio: formioSubmission,
-        bap,
-      });
-    })
-    .catch((error) => {
-      // NOTE: error is logged in axiosFormio response interceptor
-      const errorStatus = error.response?.status || 500;
-      const errorMessage = `Error getting Formio ${rebateYear} ${formName} form submission '${mongoId}'.`;
-      return res.status(errorStatus).json({ message: errorMessage });
-    });
-}
+  result.formSchema = await fetchFormioFormSchema({ formioFormUrl, req });
 
-// --- get an existing form's submission data from Formio
-router.get("/formio/submission/:rebateYear/:formType/:id", (req, res) => {
-  const { rebateYear, formType, id } = req.params;
-
-  // NOTE: included to support EPA API scan
-  if (id === formioExampleRebateId) {
-    return res.json({});
+  if (!result.formSchema) {
+    const errorStatus = 400;
+    const errorMessage = `Error getting Formio ${rebateYear} ${formName} form schema.`;
+    return res.status(errorStatus).json({ message: errorMessage });
   }
 
-  const rebateId = id.length === 6 ? id : null;
-  const mongoId = !rebateId ? id : null;
+  const rebateIdFieldName = getRebateIdFieldName({ rebateYear });
+  const formioSubmissionUrl = rebateId
+    ? `${formioFormUrl}/submission?data.${rebateIdFieldName}=${rebateId}`
+    : `${formioFormUrl}/submission/${mongoId}`;
 
-  return getBapFormSubmissionData({
+  /**
+   * NOTE: FRF submissions don't include a CSB Rebate Id field, as it's created
+   * by the BAP after they ETL the FRF submissions. So if the user searched for
+   * an FRF submission with a CSB Rebate Id, we'll need to use the returned
+   * MongoDB ObjectId from the upcoming BAP query's response and then attempt to
+   * re-fetch the formio submission data using that mongoId.
+   */
+  result.formio =
+    rebateId && formType === "frf"
+      ? null
+      : await fetchFormioSubmissionData({
+          formioSubmissionUrl,
+          id: rebateId ? "rebateId" : "mongoId",
+          req,
+        });
+
+  result.bap = await fetchBapSubmissionData({
     rebateYear,
     formType,
     rebateId,
     mongoId,
     req,
-  }).then((bapSubmission) => {
-    /**
-     * NOTE: Some submissions will not be returned from the BAP (e.g., drafts or
-     * submissions not yet picked up by the BAP ETLs).
-     */
-    if (!bapSubmission && !mongoId) {
-      const errorStatus = 400;
-      const errorMessage = `A valid MongoDB ObjectId must be provided for submissions not yet picked up by the BAP.`;
-      return res.status(errorStatus).json({ message: errorMessage });
-    }
-
-    const {
-      UEI_EFTI_Combo_Key__c,
-      CSB_Form_ID__c,
-      CSB_Modified_Full_String__c,
-      CSB_Review_Item_ID__c,
-      Parent_Rebate_ID__c,
-      Record_Type_Name__c,
-      Parent_CSB_Rebate__r,
-    } = bapSubmission ?? {};
-
-    const {
-      CSB_Funding_Request_Status__c,
-      CSB_Payment_Request_Status__c,
-      CSB_Closeout_Request_Status__c,
-      Reimbursement_Needed__c,
-    } = Parent_CSB_Rebate__r ?? {};
-
-    /**
-     * NOTE: For submissions not in the BAP, each property of the bap object
-     * parameter will be null.
-     */
-    return fetchFormioSubmission({
-      rebateYear,
-      formType,
-      mongoId: CSB_Form_ID__c || mongoId,
-      bap: {
-        modified: CSB_Modified_Full_String__c || null, // ISO 8601 date time string
-        comboKey: UEI_EFTI_Combo_Key__c || null, // UEI + EFTI combo key
-        mongoId: CSB_Form_ID__c || null, // MongoDB Object ID
-        rebateId: Parent_Rebate_ID__c || null, // CSB Rebate ID (6 digits)
-        reviewItemId: CSB_Review_Item_ID__c || null, // CSB Rebate ID with form/version ID (9 digits)
-        status:
-          (Record_Type_Name__c?.startsWith("CSB Funding Request")
-            ? CSB_Funding_Request_Status__c
-            : Record_Type_Name__c?.startsWith("CSB Payment Request")
-              ? CSB_Payment_Request_Status__c
-              : Record_Type_Name__c?.startsWith("CSB Close Out Request")
-                ? CSB_Closeout_Request_Status__c
-                : "") || null,
-        reimbursementNeeded: Reimbursement_Needed__c || null,
-      },
-      req,
-      res,
-    });
   });
+
+  /** NOTE: See previous note above setting of `result.formio` value */
+  if (!result.formio && result.bap) {
+    result.formio = await fetchFormioSubmissionData({
+      formioSubmissionUrl: `${formioFormUrl}/submission/${result.bap.mongoId}`,
+      id: "mongoId",
+      req,
+    });
+  }
+
+  if (!result.formio && !result.bap) {
+    const errorStatus = 400;
+    const errorMessage = `Error getting ${rebateYear} ${formName} form submission '${rebateId | mongoId}'.`;
+    return res.status(errorStatus).json({ message: errorMessage });
+  }
+
+  return res.json(result);
 });
 
 // --- post an update to an existing form submission to Formio (change submission to 'draft')

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -514,13 +514,13 @@ async function queryForBapFormSubmissionData(
     },
     2023: {
       frf: "CSB_Funding_Request_2023",
-      prf: null, // TODO: "CSB_Payment_Request_2023"
-      crf: null, // TODO: "CSB_Closeout_Request_2023"
+      prf: "CSB_Payment_Request_2023",
+      crf: "CSB_Closeout_Request_2023",
     },
     2024: {
-      frf: null, // TODO: "CSB_Funding_Request_2024"
-      prf: null, // TODO: "CSB_Payment_Request_2024"
-      crf: null, // TODO: "CSB_Closeout_Request_2024"
+      frf: "CSB_Funding_Request_2024",
+      prf: "CSB_Payment_Request_2024",
+      crf: "CSB_Closeout_Request_2024",
     },
   };
 

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -85,7 +85,7 @@ function getRebateIdFieldName({ rebateYear }) {
     : rebateYear === "2023"
       ? "_bap_rebate_id"
       : rebateYear === "2024"
-        ? "" // TODO
+        ? "_bap_rebate_id"
         : "";
 }
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-487

## Main Changes:
* Update the helpdesk query logic to support querying Formio and the BAP independently. Decouples the previous requirement that we first query the BAP, and if given a Mongo Id, then query Formio. Now you can query via a CSB Rebate Id, and get results even if that form submission has not yet been picked up from the BAP (but of course exists in Formio).
* This also updates the helpdesk page to work immediately after new Formio forms go live and are supported by the wrapper. Since we the logic for the Formio Form paths for future forms have now been established, as soon as the 2023 CRF, 2024 PRF, and 2024 CRF go live, the helpdesk page will support querying for those forms immediately (without the need to go back and update the code to support them).

## Steps To Test:
1. Navigate to the helpdesk page.
2. Search for a form submission that has not yet been picked up by the BAP (e.g., 2022 CRF submission "025648")
3. Ensure the helpdesk page returns results.
