### PR TITLE
Feature/add initial 2024 prf support

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -43,7 +43,7 @@ import { PRF2023 } from "@/routes/prf2023";
 // import { CRF2023 } from "@/routes/crf2023";
 import { Change2024 } from "@/routes/change2024";
 import { FRF2024 } from "@/routes/frf2024";
-// import { PRF2024 } from "@/routes/prf2024";
+import { PRF2024 } from "@/routes/prf2024";
 // import { CRF2024 } from "@/routes/crf2024";
 import { useDialogState, useDialogActions } from "@/contexts/dialog";
 
@@ -263,7 +263,7 @@ export function App() {
 
         <Route path="/change/2024/:id" element={<Change2024 />} />
         <Route path="frf/2024/:id" element={<FRF2024 />} />
-        {/* <Route path="prf/2024/:id" element={<PRF2024 />} /> */}
+        <Route path="prf/2024/:id" element={<PRF2024 />} />
         {/* <Route path="crf/2024/:id" element={<CRF2024 />} /> */}
 
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -121,7 +121,11 @@ export const bapStatusMap = {
       .set("Withdrawn", "Withdrawn")
       .set("Coordinator Denied", "Not Selected")
       .set("Accepted", "Selected"),
-    prf: new Map<string, string>(), // TODO
+    prf: new Map<string, string>()
+      .set("Needs Clarification", "Needs Clarification")
+      .set("Withdrawn", "Withdrawn")
+      .set("Coordinator Denied", "Funding Denied")
+      .set("Accepted", "Funding Approved"),
     crf: new Map<string, string>(), // TODO
   },
 };

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -1,0 +1,484 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useNavigate, useOutletContext, useParams } from "react-router-dom";
+import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
+import { Dialog } from "@headlessui/react";
+import { Formio, Form } from "@formio/react";
+import s3 from "formiojs/providers/storage/s3";
+import clsx from "clsx";
+import { cloneDeep, isEqual } from "lodash";
+import icons from "uswds/img/sprite.svg";
+// ---
+import {
+  type FormioSchemaAndSubmission,
+  type FormioPRF2024Submission,
+} from "@/types";
+import { serverUrl, messages } from "@/config";
+import {
+  getData,
+  postData,
+  useContentData,
+  useConfigData,
+  useBapSamData,
+  useSubmissionsQueries,
+  useSubmissions,
+  submissionNeedsEdits,
+  entityIsActive,
+  entityHasExclusionStatus,
+  entityHasDebtSubjectToOffset,
+  getUserInfo,
+} from "@/utilities";
+import { Loading } from "@/components/loading";
+import { Message } from "@/components/message";
+import { MarkdownContent } from "@/components/markdownContent";
+import { useNotificationsActions } from "@/contexts/notifications";
+
+type Response = FormioSchemaAndSubmission<FormioPRF2024Submission>;
+
+/** Custom hook to fetch and update Formio submission data */
+function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.resetQueries({ queryKey: ["formio/2024/prf-submission"] });
+  }, [queryClient]);
+
+  const url = `${serverUrl}/api/formio/2024/prf-submission/${rebateId}`;
+
+  const query = useQuery({
+    queryKey: ["formio/2024/prf-submission", { id: rebateId }],
+    queryFn: () => {
+      return getData<Response>(url).then((res) => {
+        const mongoId = res.submission?._id;
+        const comboKey = res.submission?.data._bap_entity_combo_key;
+
+        /**
+         * Change the formUrl the File component's `uploadFile` uses, so the s3
+         * upload PUT request is routed through the server app.
+         *
+         * https://github.com/formio/formio.js/blob/master/src/components/file/File.js#L760
+         * https://github.com/formio/formio.js/blob/master/src/providers/storage/s3.js#L5
+         * https://github.com/formio/formio.js/blob/master/src/providers/storage/xhr.js#L90
+         */
+        Formio.Providers.providers.storage.s3 = function (formio: {
+          formUrl: string;
+          [field: string]: unknown;
+        }) {
+          const s3Formio = cloneDeep(formio);
+          s3Formio.formUrl = `${serverUrl}/api/formio/2024/s3/prf/${mongoId}/${comboKey}`;
+          return s3(s3Formio);
+        };
+
+        return Promise.resolve(res);
+      });
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (updatedSubmission: {
+      mongoId: string;
+      submission: {
+        data: { [field: string]: unknown };
+        metadata: { [field: string]: unknown };
+        state: "submitted" | "draft";
+      };
+    }) => {
+      return postData<FormioPRF2024Submission>(url, updatedSubmission);
+    },
+    onSuccess: (res) => {
+      return queryClient.setQueryData<Response>(
+        ["formio/2024/prf-submission", { id: rebateId }],
+        (prevData) => {
+          return prevData?.submission
+            ? { ...prevData, submission: res }
+            : prevData;
+        },
+      );
+    },
+  });
+
+  return { query, mutation };
+}
+
+export function PRF2024() {
+  const { email } = useOutletContext<{ email: string }>();
+  /* ensure user verification (JWT refresh) doesn't cause form to re-render */
+  return useMemo(() => {
+    return <PaymentRequestForm email={email} />;
+  }, [email]);
+}
+
+function PaymentRequestForm(props: { email: string }) {
+  const { email } = props;
+
+  const navigate = useNavigate();
+  const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
+
+  const content = useContentData();
+  const configData = useConfigData();
+  const bapSamData = useBapSamData();
+  const {
+    displaySuccessNotification,
+    displayErrorNotification,
+    dismissNotification,
+  } = useNotificationsActions();
+
+  const submissionsQueries = useSubmissionsQueries("2024");
+  const submissions = useSubmissions("2024");
+
+  const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
+  const { userAccess, formSchema, submission } = query.data ?? {};
+
+  /**
+   * Stores when data is being posted to the server, so a loading overlay can
+   * be rendered over the form, preventing the user from losing input data when
+   * the form is re-rendered with data returned from the server's successful
+   * post response.
+   */
+  const dataIsPosting = useRef(false);
+
+  /**
+   * Stores when the form is being submitted, so it can be referenced in the
+   * Form component's `onSubmit` event prop to prevent double submits.
+   */
+  const formIsBeingSubmitted = useRef(false);
+
+  /**
+   * Stores the form data's state right after the user clicks the Save, Submit,
+   * or Next button. As soon as a post request to update the data succeeds, this
+   * pending submission data is reset to an empty object. This pending data,
+   * along with the submission data returned from the server is passed into the
+   * Form component's `submission` prop.
+   */
+  const pendingSubmissionData = useRef<{ [field: string]: unknown }>({});
+
+  /**
+   * Stores the last succesfully submitted data, so it can be used in the Form
+   * component's `onNextPage` event prop's "dirty check" which determines if
+   * posting of updated data is needed (so we don't make needless requests if no
+   * field data in the form has changed).
+   */
+  const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  if (!configData || !bapSamData) {
+    return <Loading />;
+  }
+
+  if (submissionsQueries.some((query) => query.isFetching)) {
+    return <Loading />;
+  }
+
+  if (submissionsQueries.some((query) => query.isError)) {
+    return <Message type="error" text={messages.formSubmissionsError} />;
+  }
+
+  if (query.isInitialLoading) {
+    return <Loading />;
+  }
+
+  if (query.isError || !userAccess || !formSchema || !submission) {
+    return <Message type="error" text={messages.formSubmissionError} />;
+  }
+
+  const rebate = submissions.find((r) => r.rebateId === rebateId);
+
+  const frfNeedsEdits = !rebate
+    ? false
+    : submissionNeedsEdits({
+        formio: rebate.frf.formio,
+        bap: rebate.frf.bap,
+      });
+
+  const prfNeedsEdits = !rebate
+    ? false
+    : submissionNeedsEdits({
+        formio: rebate.prf.formio,
+        bap: rebate.prf.bap,
+      });
+
+  const prfSubmissionPeriodOpen = configData.submissionPeriodOpen["2024"].prf;
+
+  const formIsReadOnly =
+    frfNeedsEdits ||
+    ((submission.state === "submitted" || !prfSubmissionPeriodOpen) &&
+      !prfNeedsEdits);
+
+  /** matched SAM.gov entity for the Payment Request submission */
+  const entity = bapSamData.entities.find((entity) => {
+    const { ENTITY_COMBO_KEY__c } = entity;
+    return ENTITY_COMBO_KEY__c === submission.data._bap_entity_combo_key;
+  });
+
+  if (!entity) {
+    return <Message type="error" text={messages.formSubmissionError} />;
+  }
+
+  const isActive = entityIsActive(entity);
+  const hasExclusionStatus = entityHasExclusionStatus(entity);
+  const hasDebtSubjectToOffset = entityHasDebtSubjectToOffset(entity);
+
+  if (!isActive || hasExclusionStatus || hasDebtSubjectToOffset) {
+    return <Message type="error" text={messages.bapSamIneligible} />;
+  }
+
+  const {
+    ELEC_BUS_POC_EMAIL__c,
+    ALT_ELEC_BUS_POC_EMAIL__c,
+    GOVT_BUS_POC_EMAIL__c,
+    ALT_GOVT_BUS_POC_EMAIL__c,
+  } = entity;
+
+  const { title, name } = getUserInfo(email, entity);
+
+  return (
+    <div className="margin-top-2">
+      {content && (
+        <MarkdownContent
+          className="margin-top-4"
+          children={
+            submission.state === "draft"
+              ? content.draftPRFIntro
+              : submission.state === "submitted"
+                ? content.submittedPRFIntro
+                : ""
+          }
+        />
+      )}
+
+      {frfNeedsEdits && (
+        <Message type="warning" text={messages.prfWillBeDeleted} />
+      )}
+
+      <ul className="usa-icon-list">
+        <li className="usa-icon-list__item">
+          <div className="usa-icon-list__icon text-primary">
+            <svg className="usa-icon" aria-hidden="true" role="img">
+              <use href={`${icons}#local_offer`} />
+            </svg>
+          </div>
+          <div className="usa-icon-list__content">
+            <strong>Rebate ID:</strong> {rebateId}
+          </div>
+        </li>
+      </ul>
+
+      <Dialog as="div" open={dataIsPosting.current} onClose={(_value) => {}}>
+        <div className={clsx("tw-fixed tw-inset-0 tw-bg-black/30")} />
+        <div className={clsx("tw-fixed tw-inset-0 tw-z-20")}>
+          <div
+            className={clsx(
+              "tw-flex tw-min-h-full tw-items-center tw-justify-center",
+            )}
+          >
+            <Dialog.Panel
+              className={clsx(
+                "tw-rounded-lg tw-bg-white tw-px-4 tw-pb-4 tw-shadow-xl",
+              )}
+            >
+              <Loading />
+            </Dialog.Panel>
+          </div>
+        </div>
+      </Dialog>
+
+      <div className="csb-form">
+        <Form
+          form={formSchema.json}
+          url={formSchema.url} // NOTE: used for file uploads
+          submission={{
+            state: submission.state,
+            data: {
+              ...submission.data,
+              _user_email: email,
+              _user_title: title,
+              _user_name: name,
+              _bap_elec_bus_poc_email: ELEC_BUS_POC_EMAIL__c,
+              _bap_alt_elec_bus_poc_email: ALT_ELEC_BUS_POC_EMAIL__c,
+              _bap_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
+              _bap_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
+              ...pendingSubmissionData.current,
+            },
+          }}
+          options={{
+            readOnly: formIsReadOnly,
+            noAlerts: true,
+          }}
+          onSubmit={(onSubmitSubmission: {
+            data: { [field: string]: unknown };
+            metadata: { [field: string]: unknown };
+            state: "submitted" | "draft";
+          }) => {
+            if (formIsReadOnly) return;
+
+            // account for when form is being submitted to prevent double submits
+            if (formIsBeingSubmitted.current) return;
+            if (onSubmitSubmission.state === "submitted") {
+              formIsBeingSubmitted.current = true;
+            }
+
+            const data = { ...onSubmitSubmission.data };
+
+            const updatedSubmission = {
+              mongoId: submission._id,
+              submission: {
+                ...onSubmitSubmission,
+                data,
+              },
+            };
+
+            dismissNotification({ id: 0 });
+            dataIsPosting.current = true;
+            pendingSubmissionData.current = data;
+
+            mutation.mutate(updatedSubmission, {
+              onSuccess: (res, _payload, _context) => {
+                pendingSubmissionData.current = {};
+                lastSuccesfullySubmittedData.current = cloneDeep(res.data);
+
+                /** success notification id */
+                const id = Date.now();
+
+                displaySuccessNotification({
+                  id,
+                  body: (
+                    <p
+                      className={clsx(
+                        "tw-text-sm tw-font-medium tw-text-gray-900",
+                      )}
+                    >
+                      {onSubmitSubmission.state === "submitted" ? (
+                        <>
+                          Payment Request <em>{rebateId}</em> submitted
+                          successfully.
+                        </>
+                      ) : (
+                        <>Draft saved successfully.</>
+                      )}
+                    </p>
+                  ),
+                });
+
+                if (onSubmitSubmission.state === "submitted") {
+                  /**
+                   * NOTE: we'll keep the success notification displayed and
+                   * redirect the user to their dashboard
+                   */
+                  navigate("/");
+                }
+
+                if (onSubmitSubmission.state === "draft") {
+                  setTimeout(() => dismissNotification({ id }), 5000);
+                }
+              },
+              onError: (_error, _payload, _context) => {
+                displayErrorNotification({
+                  id: Date.now(),
+                  body: (
+                    <p
+                      className={clsx(
+                        "tw-text-sm tw-font-medium tw-text-gray-900",
+                      )}
+                    >
+                      {onSubmitSubmission.state === "submitted" ? (
+                        <>Error submitting Payment Request form.</>
+                      ) : (
+                        <>Error saving draft.</>
+                      )}
+                    </p>
+                  ),
+                });
+              },
+              onSettled: (_data, _error, _payload, _context) => {
+                dataIsPosting.current = false;
+                formIsBeingSubmitted.current = false;
+              },
+            });
+          }}
+          onNextPage={(onNextPageParam: {
+            page: number;
+            submission: {
+              data: { [field: string]: unknown };
+              metadata: { [field: string]: unknown };
+            };
+          }) => {
+            if (formIsReadOnly) return;
+
+            const data = { ...onNextPageParam.submission.data };
+
+            // "dirty check" – don't post an update if no changes have been made
+            // to the form (ignoring current user fields)
+            const currentData = { ...data };
+            const submittedData = { ...lastSuccesfullySubmittedData.current };
+
+            delete currentData._user_email;
+            delete currentData._user_title;
+            delete currentData._user_name;
+            delete submittedData._user_email;
+            delete submittedData._user_title;
+            delete submittedData._user_name;
+            if (isEqual(currentData, submittedData)) return;
+
+            const updatedSubmission = {
+              mongoId: submission._id,
+              submission: {
+                ...onNextPageParam.submission,
+                data,
+                state: "draft" as const,
+              },
+            };
+
+            dismissNotification({ id: 0 });
+            dataIsPosting.current = true;
+            pendingSubmissionData.current = data;
+
+            mutation.mutate(updatedSubmission, {
+              onSuccess: (res, _payload, _context) => {
+                pendingSubmissionData.current = {};
+                lastSuccesfullySubmittedData.current = cloneDeep(res.data);
+
+                /** success notification id */
+                const id = Date.now();
+
+                displaySuccessNotification({
+                  id,
+                  body: (
+                    <p
+                      className={clsx(
+                        "tw-text-sm tw-font-medium tw-text-gray-900",
+                      )}
+                    >
+                      Draft saved successfully.
+                    </p>
+                  ),
+                });
+
+                setTimeout(() => dismissNotification({ id }), 5000);
+              },
+              onError: (_error, _payload, _context) => {
+                displayErrorNotification({
+                  id: Date.now(),
+                  body: (
+                    <p
+                      className={clsx(
+                        "tw-text-sm tw-font-medium tw-text-gray-900",
+                      )}
+                    >
+                      Error saving draft.
+                    </p>
+                  ),
+                });
+              },
+              onSettled: (_data, _error, _payload, _context) => {
+                dataIsPosting.current = false;
+              },
+            });
+          }}
+        />
+      </div>
+
+      {frfNeedsEdits && (
+        <Message type="warning" text={messages.prfWillBeDeleted} />
+      )}
+    </div>
+  );
+}

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -196,13 +196,12 @@ function FRF2022Submission(props: { rebate: Rebate2022 }) {
   });
 
   const frfBapInternalStatus = frf.bap?.status || "";
+  const frfBapStatus = bapStatusMap["2022"].frf.get(frfBapInternalStatus);
   const frfFormioStatus = formioStatusMap.get(frf.formio.state);
 
   const frfStatus = frfNeedsEdits
     ? "Edits Requested"
-    : bapStatusMap["2022"].frf.get(frfBapInternalStatus) ||
-      frfFormioStatus ||
-      "";
+    : frfBapStatus || frfFormioStatus || "";
 
   const frfSelected = frfStatus === "Selected";
   const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
@@ -512,13 +511,12 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
   });
 
   const prfBapInternalStatus = prf.bap?.status || "";
+  const prfBapStatus = bapStatusMap["2022"].prf.get(prfBapInternalStatus);
   const prfFormioStatus = formioStatusMap.get(prf.formio.state);
 
   const prfStatus = prfNeedsEdits
     ? "Edits Requested"
-    : bapStatusMap["2022"].prf.get(prfBapInternalStatus) ||
-      prfFormioStatus ||
-      "";
+    : prfBapStatus || prfFormioStatus || "";
 
   const prfApproved = prfStatus === "Funding Approved";
   const prfApprovedButNoCRF = prfApproved && !Boolean(crf.formio);
@@ -716,6 +714,7 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
   });
 
   const crfBapInternalStatus = crf.bap?.status || "";
+  const crfBapStatus = bapStatusMap["2022"].crf.get(crfBapInternalStatus);
   const crfFormioStatus = formioStatusMap.get(crf.formio.state);
   const crfBapReimbursementNeeded = crf.bap?.reimbursementNeeded || false;
 
@@ -728,9 +727,7 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
     ? "Edits Requested"
     : crfNeedsReimbursement
       ? "Reimbursement Needed"
-      : bapStatusMap["2022"].crf.get(crfBapInternalStatus) ||
-        crfFormioStatus ||
-        "";
+      : crfBapStatus || crfFormioStatus || "";
 
   const crfApproved = crfStatus === "Close Out Approved";
 
@@ -1060,13 +1057,12 @@ function FRF2023Submission(props: { rebate: Rebate2023 }) {
   });
 
   const frfBapInternalStatus = frf.bap?.status || "";
+  const frfBapStatus = bapStatusMap["2023"].frf.get(frfBapInternalStatus);
   const frfFormioStatus = formioStatusMap.get(frf.formio.state);
 
   const frfStatus = frfNeedsEdits
     ? "Edits Requested"
-    : bapStatusMap["2023"].frf.get(frfBapInternalStatus) ||
-      frfFormioStatus ||
-      "";
+    : frfBapStatus || frfFormioStatus || "";
 
   const frfSelected = frfStatus === "Selected";
   const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
@@ -1366,13 +1362,12 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
   });
 
   const prfBapInternalStatus = prf.bap?.status || "";
+  const prfBapStatus = bapStatusMap["2023"].prf.get(prfBapInternalStatus);
   const prfFormioStatus = formioStatusMap.get(prf.formio.state);
 
   const prfStatus = prfNeedsEdits
     ? "Edits Requested"
-    : bapStatusMap["2023"].prf.get(prfBapInternalStatus) ||
-      prfFormioStatus ||
-      "";
+    : prfBapStatus || prfFormioStatus || "";
 
   const prfApproved = prfStatus === "Funding Approved";
   const prfApprovedButNoCRF = prfApproved && !Boolean(crf.formio);
@@ -1727,13 +1722,12 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
   });
 
   const frfBapInternalStatus = frf.bap?.status || "";
+  const frfBapStatus = bapStatusMap["2024"].frf.get(frfBapInternalStatus);
   const frfFormioStatus = formioStatusMap.get(frf.formio.state);
 
   const frfStatus = frfNeedsEdits
     ? "Edits Requested"
-    : bapStatusMap["2024"].frf.get(frfBapInternalStatus) ||
-      frfFormioStatus ||
-      "";
+    : frfBapStatus || frfFormioStatus || "";
 
   const frfSelected = frfStatus === "Selected";
   const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -1887,9 +1887,229 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
   );
 }
 
-// function PRF2024Submission(props: { rebate: Rebate2024 }) {
-//   //
-// }
+function PRF2024Submission(props: { rebate: Rebate2024 }) {
+  const { rebate } = props;
+  const { frf, prf, crf } = rebate;
+
+  const navigate = useNavigate();
+  const { email } = useOutletContext<{ email: string }>();
+
+  const configData = useConfigData();
+  const bapSamData = useBapSamData();
+  const { displayErrorNotification } = useNotificationsActions();
+
+  /**
+   * Stores when data is being posted to the server, so a loading indicator can
+   * be rendered inside the "New Payment Request" button, and we can prevent
+   * double submits/creations of new PRF submissions.
+   */
+  const [dataIsPosting, setDataIsPosting] = useState(false);
+
+  if (!configData || !bapSamData) return null;
+
+  /** matched SAM.gov entity for the FRF submission */
+  const entity = bapSamData.entities.find((entity) => {
+    const comboKey = frf.formio.data._bap_entity_combo_key;
+    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+  });
+
+  if (!entity) return null;
+
+  const { title, name } = getUserInfo(email, entity);
+
+  const prfSubmissionPeriodOpen = configData.submissionPeriodOpen["2024"].prf;
+
+  const frfSelected = frf.bap?.status === "Accepted";
+  const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
+
+  if (frfSelectedButNoPRF) {
+    return (
+      <tr className={highlightedTableRowClassNames}>
+        <th scope="row" colSpan={7}>
+          <button
+            className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+            disabled={!prfSubmissionPeriodOpen}
+            onClick={(_ev) => {
+              if (!prfSubmissionPeriodOpen) return;
+              if (!frf.bap) return;
+
+              // account for when data is posting to prevent double submits
+              if (dataIsPosting) return;
+              setDataIsPosting(true);
+
+              // create a new draft PRF submission
+              postData(`${serverUrl}/api/formio/2024/prf-submission/`, {
+                email,
+                title,
+                name,
+                entity,
+                comboKey: frf.bap.comboKey,
+                rebateId: frf.bap.rebateId, // CSB Rebate ID (6 digits)
+                frfReviewItemId: frf.bap.reviewItemId, // CSB Rebate ID with form/version ID (9 digits)
+                frfModified: frf.bap.modified,
+              })
+                .then((_res) => {
+                  navigate(`/prf/2024/${frf.bap?.rebateId}`);
+                })
+                .catch((_err) => {
+                  displayErrorNotification({
+                    id: Date.now(),
+                    body: (
+                      <>
+                        <p
+                          className={clsx(
+                            "tw-text-sm tw-font-medium tw-text-gray-900",
+                          )}
+                        >
+                          Error creating Payment Request{" "}
+                          <em>{frf.bap?.rebateId}</em>.
+                        </p>
+                        <p
+                          className={clsx(
+                            "tw-mt-1 tw-text-sm tw-text-gray-500",
+                          )}
+                        >
+                          Please try again.
+                        </p>
+                      </>
+                    ),
+                  });
+                })
+                .finally(() => {
+                  setDataIsPosting(false);
+                });
+            }}
+          >
+            <span className="display-flex flex-align-center">
+              <svg
+                className="usa-icon"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
+              >
+                <use href={`${icons}#add_circle`} />
+              </svg>
+              <span className="margin-left-1">New Payment Request</span>
+              {dataIsPosting && <LoadingButtonIcon position="end" />}
+            </span>
+          </button>
+        </th>
+      </tr>
+    );
+  }
+
+  // return if a Payment Request submission has not been created for this rebate
+  if (!prf.formio) return null;
+
+  const { _user_email, _bap_entity_combo_key, _bap_rebate_id } =
+    prf.formio.data;
+
+  const date = new Date(prf.formio.modified).toLocaleDateString();
+  const time = new Date(prf.formio.modified).toLocaleTimeString();
+
+  const frfNeedsEdits = submissionNeedsEdits({
+    formio: frf.formio,
+    bap: frf.bap,
+  });
+
+  const prfNeedsEdits = submissionNeedsEdits({
+    formio: prf.formio,
+    bap: prf.bap,
+  });
+
+  const prfBapInternalStatus = prf.bap?.status || "";
+  const prfBapStatus = bapStatusMap["2024"].prf.get(prfBapInternalStatus);
+  const prfFormioStatus = formioStatusMap.get(prf.formio.state);
+
+  const prfStatus = prfNeedsEdits
+    ? "Edits Requested"
+    : prfBapStatus || prfFormioStatus || "";
+
+  const prfApproved = prfStatus === "Funding Approved";
+  const prfApprovedButNoCRF = prfApproved && !Boolean(crf.formio);
+
+  const statusTableCellClassNames =
+    prf.formio.state === "submitted" || !prfSubmissionPeriodOpen
+      ? "text-italic"
+      : "";
+
+  const prfUrl = `/prf/2024/${_bap_rebate_id}`;
+
+  return (
+    <tr
+      className={
+        prfNeedsEdits || prfApprovedButNoCRF
+          ? highlightedTableRowClassNames
+          : defaultTableRowClassNames
+      }
+    >
+      <th scope="row" className={statusTableCellClassNames}>
+        {frfNeedsEdits ? (
+          <FormLink type="view" to={prfUrl} />
+        ) : prfNeedsEdits ? (
+          <FormLink type="edit" to={prfUrl} />
+        ) : prf.formio.state === "submitted" || !prfSubmissionPeriodOpen ? (
+          <FormLink type="view" to={prfUrl} />
+        ) : prf.formio.state === "draft" ? (
+          <FormLink type="edit" to={prfUrl} />
+        ) : null}
+      </th>
+
+      <td className={statusTableCellClassNames}>&nbsp;</td>
+
+      <td className={statusTableCellClassNames}>
+        <span>Payment Request</span>
+        <br />
+        <span className="display-flex flex-align-center font-sans-2xs">
+          {prfStatus === "Needs Clarification" ? (
+            <TextWithTooltip
+              text={prfStatus}
+              tooltip="Check your email for instructions on what needs clarification"
+              iconClassNames="text-base-darkest"
+            />
+          ) : (
+            <>
+              <svg
+                className={clsx("usa-icon", prfApproved && "text-primary")}
+                aria-hidden="true"
+                focusable="false"
+                role="img"
+              >
+                <use href={`${icons}#${statusIconMap.get(prfStatus)}`} />
+              </svg>
+              <span className="margin-left-05">{prfStatus}</span>
+            </>
+          )}
+        </span>
+      </td>
+
+      <td className={statusTableCellClassNames}>&nbsp;</td>
+
+      <td className={statusTableCellClassNames}>&nbsp;</td>
+
+      <td className={statusTableCellClassNames}>
+        {_user_email}
+        <br />
+        <span title={`${date} ${time}`}>{date}</span>
+      </td>
+
+      <td className={clsx("!tw-text-right")}>
+        <ChangeRequest2024Button
+          data={{
+            formType: "prf",
+            comboKey: _bap_entity_combo_key,
+            rebateId: _bap_rebate_id,
+            mongoId: prf.formio._id,
+            state: prf.formio.state,
+            email,
+            title,
+            name,
+          }}
+        />
+      </td>
+    </tr>
+  );
+}
 
 // function CRF2024Submission(props: { rebate: Rebate2024 }) {
 //   //
@@ -1945,7 +2165,7 @@ function Submissions2024() {
               return rebate.rebateYear === "2024" ? (
                 <Fragment key={rebate.rebateId}>
                   <FRF2024Submission rebate={rebate} />
-                  {/* <PRF2024Submission rebate={rebate} /> */}
+                  <PRF2024Submission rebate={rebate} />
                   {/* <CRF2024Submission rebate={rebate} /> */}
                   {/* blank row after all submissions but the last one */}
                   {index !== submissions.length - 1 && (

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -34,6 +34,7 @@ export type ConfigData = {
 };
 
 export type BapSamEntity = {
+  attributes: { type: "Data_Staging__c"; url: string };
   Id: string;
   ENTITY_COMBO_KEY__c: string;
   UNIQUE_ENTITY_ID__c: string;
@@ -48,24 +49,18 @@ export type BapSamEntity = {
   PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c: string;
   PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c: string;
   PHYSICAL_ADDRESS_ZIP_CODE_4__c: string;
-  // contacts
   ELEC_BUS_POC_EMAIL__c: string | null;
   ELEC_BUS_POC_NAME__c: string | null;
   ELEC_BUS_POC_TITLE__c: string | null;
-  //
   ALT_ELEC_BUS_POC_EMAIL__c: string | null;
   ALT_ELEC_BUS_POC_NAME__c: string | null;
   ALT_ELEC_BUS_POC_TITLE__c: string | null;
-  //
   GOVT_BUS_POC_EMAIL__c: string | null;
   GOVT_BUS_POC_NAME__c: string | null;
   GOVT_BUS_POC_TITLE__c: string | null;
-  //
   ALT_GOVT_BUS_POC_EMAIL__c: string | null;
   ALT_GOVT_BUS_POC_NAME__c: string | null;
   ALT_GOVT_BUS_POC_TITLE__c: string | null;
-  //
-  attributes: { type: string; url: string };
 };
 
 export type BapSamData =
@@ -73,6 +68,8 @@ export type BapSamData =
   | { results: true; entities: BapSamEntity[] };
 
 export type BapFormSubmission = {
+  attributes: { type: "Order_Request__c"; url: string };
+  Id: string;
   UEI_EFTI_Combo_Key__c: string; // UEI + EFTI combo key
   CSB_Form_ID__c: string; // MongoDB ObjectId string
   CSB_Modified_Full_String__c: string; // ISO 8601 date time string
@@ -91,9 +88,9 @@ export type BapFormSubmission = {
     | "CSB Funding Request 2023"
     | "CSB Payment Request 2023"
     | "CSB Close Out Request 2023"
-    | "CSB Funding Request 2024" // TODO: confirm with BAP team
-    | "CSB Payment Request 2024" // TODO: confirm with BAP team
-    | "CSB Close Out Request 2024"; // TODO: confirm with BAP team
+    | "CSB Funding Request 2024"
+    | "CSB Payment Request 2024"
+    | "CSB Close Out Request 2024";
   Rebate_Program_Year__c: null | RebateYear;
   Parent_CSB_Rebate__r: {
     CSB_Funding_Request_Status__c: string;
@@ -102,7 +99,6 @@ export type BapFormSubmission = {
     Reimbursement_Needed__c: boolean;
     attributes: { type: string; url: string };
   };
-  attributes: { type: string; url: string };
 };
 
 export type BapFormSubmissions = {
@@ -178,11 +174,42 @@ type FormioPRF2022Data = {
   [field: string]: unknown;
   // fields injected upon a new draft PRF submission creation:
   bap_hidden_entity_combo_key: string;
-  hidden_application_form_modified: string; // ISO 8601 date time string
+  hidden_application_form_modified: string; // ISO 8601 date time string,
   hidden_current_user_email: string;
   hidden_current_user_title: string;
   hidden_current_user_name: string;
+  hidden_sam_uei: string;
+  hidden_sam_efti: string;
+  hidden_sam_elec_bus_poc_email: string | null;
+  hidden_sam_alt_elec_bus_poc_email: string | null;
+  hidden_sam_govt_bus_poc_email: string | null;
+  hidden_sam_alt_govt_bus_poc_email: string | null;
   hidden_bap_rebate_id: string;
+  hidden_bap_district_id: string;
+  hidden_bap_primary_name: string;
+  hidden_bap_primary_title: string;
+  hidden_bap_primary_phone_number: string;
+  hidden_bap_primary_email: string;
+  hidden_bap_alternate_name: string;
+  hidden_bap_alternate_title: string;
+  hidden_bap_alternate_phone_number: string;
+  hidden_bap_alternate_email: string;
+  hidden_bap_org_name: string;
+  hidden_bap_district_name: string;
+  hidden_bap_fleet_name: string | null;
+  hidden_bap_prioritized: boolean;
+  hidden_bap_requested_funds: number;
+  hidden_bap_infra_max_rebate: number;
+  busInfo: {
+    busNum: number;
+    oldBusNcesDistrictId: string;
+    oldBusVin: string;
+    oldBusModelYear: string;
+    oldBusFuelType: string;
+    newBusFuelType: string;
+    hidden_bap_max_rebate: number;
+  }[];
+  purchaseOrders: [];
   // fields set by form definition (among others):
   applicantName: string;
 };
@@ -196,6 +223,74 @@ type FormioCRF2022Data = {
   hidden_current_user_title: string;
   hidden_current_user_name: string;
   hidden_bap_rebate_id: string;
+  hidden_sam_uei: string;
+  hidden_sam_efti: string;
+  hidden_sam_elec_bus_poc_email: string | null;
+  hidden_sam_alt_elec_bus_poc_email: string | null;
+  hidden_sam_govt_bus_poc_email: string | null;
+  hidden_sam_alt_govt_bus_poc_email: string | null;
+  hidden_bap_district_id: string;
+  hidden_bap_district_name: string;
+  hidden_bap_primary_fname: string;
+  hidden_bap_primary_lname: string;
+  hidden_bap_primary_title: string;
+  hidden_bap_primary_phone_number: string;
+  hidden_bap_primary_email: string;
+  hidden_bap_alternate_fname: string;
+  hidden_bap_alternate_lname: string;
+  hidden_bap_alternate_title: string;
+  hidden_bap_alternate_phone_number: string;
+  hidden_bap_alternate_email: string;
+  hidden_bap_org_name: string;
+  hidden_bap_fleet_name: string;
+  hidden_bap_fleet_address: string;
+  hidden_bap_fleet_city: string;
+  hidden_bap_fleet_state: string;
+  hidden_bap_fleet_zip: string;
+  hidden_bap_fleet_contact_name: string;
+  hidden_bap_fleet_contact_title: string;
+  hidden_bap_fleet_phone: string;
+  hidden_bap_fleet_email: string;
+  hidden_bap_prioritized: boolean;
+  hidden_bap_requested_funds: number;
+  hidden_bap_received_funds: number;
+  hidden_bap_prf_infra_max_rebate: number | null;
+  hidden_bap_buses_requested_app: number;
+  hidden_bap_total_bus_costs_prf: number;
+  hidden_bap_total_bus_rebate_received: number;
+  hidden_bap_total_infra_costs_prf: number | null;
+  hidden_bap_total_infra_rebate_received: number | null;
+  hidden_bap_total_infra_level2_charger: number | null;
+  hidden_bap_total_infra_dc_fast_charger: number | null;
+  hidden_bap_total_infra_other_costs: number | null;
+  hidden_bap_district_contact_fname: string;
+  hidden_bap_district_contact_lname: string;
+  busInfo: {
+    busNum: number;
+    oldBusNcesDistrictId: string;
+    oldBusVin: string;
+    oldBusModelYear: string;
+    oldBusFuelType: string;
+    oldBusEstimatedRemainingLife: number;
+    oldBusExclude: boolean;
+    hidden_prf_oldBusExclude: boolean;
+    newBusDealer: string;
+    newBusFuelType: string;
+    hidden_prf_newBusFuelType: string;
+    newBusMake: string;
+    hidden_prf_newBusMake: string;
+    newBusMakeOther: string | null;
+    hidden_prf_newBusMakeOther: string | null;
+    newBusModel: string;
+    hidden_prf_newBusModel: string;
+    newBusModelYear: string;
+    hidden_prf_newBusModelYear: string;
+    newBusGvwr: number;
+    hidden_prf_newBusGvwr: number;
+    newBusPurchasePrice: number;
+    hidden_prf_newBusPurchasePrice: number;
+    hidden_prf_rebate: number;
+  }[];
   // fields set by form definition (among others):
   signatureName: string;
 };
@@ -227,17 +322,124 @@ type FormioFRF2023Data = {
 
 type FormioPRF2023Data = {
   [field: string]: unknown;
-  // fields injected upon a new draft FRF submission creation:
+  // fields injected upon a new draft PRF submission creation:
+  _application_form_modified: string;
+  _bap_entity_combo_key: string;
+  _bap_rebate_id: string;
   _user_email: string;
   _user_title: string;
   _user_name: string;
-  _bap_entity_combo_key: string;
-  _bap_rebate_id: string;
+  _bap_applicant_email: string;
+  _bap_applicant_title: string;
+  _bap_applicant_name: string;
+  _bap_applicant_efti: string;
+  _bap_applicant_uei: string;
+  _bap_applicant_organization_id: string;
+  _bap_applicant_organization_name: string;
+  _bap_applicant_street_address_1: string;
+  _bap_applicant_street_address_2: string;
+  _bap_applicant_county: string;
+  _bap_applicant_city: string;
+  _bap_applicant_state: string;
+  _bap_applicant_zip: string;
+  _bap_elec_bus_poc_email: string | null;
+  _bap_alt_elec_bus_poc_email: string | null;
+  _bap_govt_bus_poc_email: string | null;
+  _bap_alt_govt_bus_poc_email: string | null;
+  _bap_primary_id: string;
+  _bap_primary_fname: string;
+  _bap_primary_lname: string;
+  _bap_primary_title: string;
+  _bap_primary_email: string;
+  _bap_primary_phone: string;
+  _bap_alternate_id: string | null;
+  _bap_alternate_fname: string | null;
+  _bap_alternate_lname: string | null;
+  _bap_alternate_title: string | null;
+  _bap_alternate_email: string | null;
+  _bap_alternate_phone: string | null;
+  _bap_district_id: string;
+  _bap_district_nces_id: string;
+  _bap_district_name: string;
+  _bap_district_address_1: string;
+  _bap_district_address_2: string;
+  _bap_district_city: string;
+  _bap_district_state: string;
+  _bap_district_zip: string;
+  _bap_district_priority: string;
+  _bap_district_priority_reason: {
+    highNeed: boolean;
+    tribal: boolean;
+    rural: boolean;
+  };
+  _bap_district_self_certify: string;
+  _bap_district_contact_id: string;
+  _bap_district_contact_fname: string;
+  _bap_district_contact_lname: string;
+  _bap_district_contact_title: string;
+  _bap_district_contact_email: string;
+  _bap_district_contact_phone: string;
+  org_organizations: {
+    org_number: number;
+    org_type: {
+      existingBusOwner: boolean;
+      newBusOwner: boolean;
+      privateFleet: boolean;
+    };
+    _org_id: string;
+    org_name: string;
+    _org_contact_id: string;
+    org_contact_fname: string;
+    org_contact_lname: string;
+    org_contact_title: string;
+    org_contact_email: string;
+    org_contact_phone: string;
+    org_address_1: string;
+    org_address_2: string;
+    org_county: string;
+    org_city: string;
+    org_state: { name: string };
+    org_zip: string;
+  }[];
+  bus_buses: {
+    bus_busNumber: number;
+    bus_existingOwner: {
+      org_id: string;
+      org_name: string;
+      org_contact_id: string;
+      org_contact_fname: string;
+      org_contact_lname: string;
+    };
+    bus_existingVin: string;
+    bus_existingFuelType: string;
+    bus_existingGvwr: number;
+    bus_existingOdometer: number;
+    bus_existingModel: string;
+    bus_existingModelYear: string;
+    bus_existingNcesId: string;
+    bus_existingManufacturer: string;
+    bus_existingManufacturerOther: string | null;
+    bus_existingAnnualFuelConsumption: number;
+    bus_existingAnnualMileage: number;
+    bus_existingRemainingLife: number;
+    bus_existingIdlingHours: number;
+    bus_newOwner: {
+      org_id: string;
+      org_name: string;
+      org_contact_id: string;
+      org_contact_fname: string;
+      org_contact_lname: string;
+    };
+    bus_newFuelType: string;
+    bus_newGvwr: number;
+    _bus_maxRebate: number;
+    _bus_newADAfromFRF: boolean;
+  }[];
 };
 
 type FormioCRF2023Data = {
   [field: string]: unknown;
-  // fields injected upon a new draft FRF submission creation:
+  // fields injected upon a new draft CRF submission creation:
   _user_email: string;
   _user_title: string;
   _user_name: string;
@@ -286,17 +488,124 @@ type FormioFRF2024Data = {
 
 type FormioPRF2024Data = {
   [field: string]: unknown;
-  // fields injected upon a new draft FRF submission creation:
+  // fields injected upon a new draft PRF submission creation:
+  _application_form_modified: string;
+  _bap_entity_combo_key: string;
+  _bap_rebate_id: string;
   _user_email: string;
   _user_title: string;
   _user_name: string;
-  _bap_entity_combo_key: string;
-  _bap_rebate_id: string;
+  _bap_applicant_email: string;
+  _bap_applicant_title: string;
+  _bap_applicant_name: string;
+  _bap_applicant_efti: string;
+  _bap_applicant_uei: string;
+  _bap_applicant_organization_id: string;
+  _bap_applicant_organization_name: string;
+  _bap_applicant_street_address_1: string;
+  _bap_applicant_street_address_2: string;
+  _bap_applicant_county: string;
+  _bap_applicant_city: string;
+  _bap_applicant_state: string;
+  _bap_applicant_zip: string;
+  _bap_elec_bus_poc_email: string | null;
+  _bap_alt_elec_bus_poc_email: string | null;
+  _bap_govt_bus_poc_email: string | null;
+  _bap_alt_govt_bus_poc_email: string | null;
+  _bap_primary_id: string;
+  _bap_primary_fname: string;
+  _bap_primary_lname: string;
+  _bap_primary_title: string;
+  _bap_primary_email: string;
+  _bap_primary_phone: string;
+  _bap_alternate_id: string | null;
+  _bap_alternate_fname: string | null;
+  _bap_alternate_lname: string | null;
+  _bap_alternate_title: string | null;
+  _bap_alternate_email: string | null;
+  _bap_alternate_phone: string | null;
+  _bap_district_id: string;
+  _bap_district_nces_id: string;
+  _bap_district_name: string;
+  _bap_district_address_1: string;
+  _bap_district_address_2: string;
+  _bap_district_city: string;
+  _bap_district_state: string;
+  _bap_district_zip: string;
+  _bap_district_priority: string;
+  _bap_district_priority_reason: {
+    highNeed: boolean;
+    tribal: boolean;
+    rural: boolean;
+  };
+  _bap_district_self_certify: string;
+  _bap_district_contact_id: string;
+  _bap_district_contact_fname: string;
+  _bap_district_contact_lname: string;
+  _bap_district_contact_title: string;
+  _bap_district_contact_email: string;
+  _bap_district_contact_phone: string;
+  org_organizations: {
+    org_number: number;
+    org_type: {
+      existingBusOwner: boolean;
+      newBusOwner: boolean;
+      privateFleet: boolean;
+    };
+    _org_id: string;
+    org_name: string;
+    _org_contact_id: string;
+    org_contact_fname: string;
+    org_contact_lname: string;
+    org_contact_title: string;
+    org_contact_email: string;
+    org_contact_phone: string;
+    org_address_1: string;
+    org_address_2: string;
+    org_county: string;
+    org_city: string;
+    org_state: { name: string };
+    org_zip: string;
+  }[];
+  bus_buses: {
+    bus_busNumber: number;
+    bus_existingOwner: {
+      org_id: string;
+      org_name: string;
+      org_contact_id: string;
+      org_contact_fname: string;
+      org_contact_lname: string;
+    };
+    bus_existingVin: string;
+    bus_existingFuelType: string;
+    bus_existingGvwr: number;
+    bus_existingOdometer: number;
+    bus_existingModel: string;
+    bus_existingModelYear: string;
+    bus_existingNcesId: string;
+    bus_existingManufacturer: string;
+    bus_existingManufacturerOther: string | null;
+    bus_existingAnnualFuelConsumption: number;
+    bus_existingAnnualMileage: number;
+    bus_existingRemainingLife: number;
+    bus_existingIdlingHours: number;
+    bus_newOwner: {
+      org_id: string;
+      org_name: string;
+      org_contact_id: string;
+      org_contact_fname: string;
+      org_contact_lname: string;
+    };
+    bus_newFuelType: string;
+    bus_newGvwr: number;
+    _bus_maxRebate: number;
+    _bus_newADAfromFRF: boolean;
+  }[];
 };
 
 type FormioCRF2024Data = {
   [field: string]: unknown;
-  // fields injected upon a new draft FRF submission creation:
+  // fields injected upon a new draft CRF submission creation:
   _user_email: string;
   _user_title: string;
   _user_name: string;

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -489,7 +489,7 @@ type FormioFRF2024Data = {
 type FormioPRF2024Data = {
   [field: string]: unknown;
   // fields injected upon a new draft PRF submission creation:
-  _application_form_modified: string;
+  _frf_modified: string;
   _bap_entity_combo_key: string;
   _bap_rebate_id: string;
   _user_email: string;
@@ -546,60 +546,61 @@ type FormioPRF2024Data = {
   _bap_district_contact_email: string;
   _bap_district_contact_phone: string;
   org_organizations: {
+    _bap_org_frf: boolean;
     org_number: number;
     org_type: {
-      existingBusOwner: boolean;
-      newBusOwner: boolean;
-      privateFleet: boolean;
+      existing_bus_owner: boolean;
+      new_bus_owner: boolean;
+      private_fleet: boolean;
     };
-    _org_id: string;
-    org_name: string;
-    _org_contact_id: string;
-    org_contact_fname: string;
-    org_contact_lname: string;
-    org_contact_title: string;
-    org_contact_email: string;
-    org_contact_phone: string;
-    org_address_1: string;
-    org_address_2: string;
-    org_county: string;
-    org_city: string;
-    org_state: { name: string };
-    org_zip: string;
+    _bap_org_id: string;
+    _bap_org_name: string;
+    _bap_org_contact_id: string;
+    _bap_org_contact_fname: string;
+    _bap_org_contact_lname: string;
+    _bap_org_contact_title: string;
+    _bap_org_contact_email: string;
+    _bap_org_contact_phone: string;
+    _bap_org_address_1: string;
+    _bap_org_address_2: string;
+    _bap_org_county: string;
+    _bap_org_city: string;
+    _bap_org_state: { name: string };
+    _bap_org_zip: string;
   }[];
   bus_buses: {
-    bus_busNumber: number;
-    bus_existingOwner: {
+    bus_number: number;
+    bus_existing_owner: {
       org_id: string;
       org_name: string;
       org_contact_id: string;
       org_contact_fname: string;
       org_contact_lname: string;
     };
-    bus_existingVin: string;
-    bus_existingFuelType: string;
-    bus_existingGvwr: number;
-    bus_existingOdometer: number;
-    bus_existingModel: string;
-    bus_existingModelYear: string;
-    bus_existingNcesId: string;
-    bus_existingManufacturer: string;
-    bus_existingManufacturerOther: string | null;
-    bus_existingAnnualFuelConsumption: number;
-    bus_existingAnnualMileage: number;
-    bus_existingRemainingLife: number;
-    bus_existingIdlingHours: number;
-    bus_newOwner: {
+    bus_existing_vin: string;
+    bus_existing_fuel_type: string;
+    bus_existing_gvwr: number;
+    bus_existing_odometer: number;
+    bus_existing_model: string;
+    bus_existing_model_year: string;
+    bus_existing_nces_id: string;
+    bus_existing_manufacturer: string;
+    bus_existing_manufacturer_other: string | null;
+    bus_existing_annual_fuel_consumption: number;
+    bus_existing_annual_mileage: number;
+    bus_existing_remaining_life: number;
+    bus_existing_idling_hours: number;
+    bus_new_owner: {
       org_id: string;
       org_name: string;
       org_contact_id: string;
       org_contact_fname: string;
       org_contact_lname: string;
     };
-    bus_newFuelType: string;
-    bus_newGvwr: number;
-    _bus_maxRebate: number;
-    _bus_newADAfromFRF: boolean;
+    bus_new_fuel_type: string;
+    bus_new_gvwr: number;
+    _bus_new_max_rebate: number;
+    _bus_new_ada_from_frf: boolean;
   }[];
 };
 

--- a/app/server/app/routes/formio2022.js
+++ b/app/server/app/routes/formio2022.js
@@ -90,7 +90,7 @@ router.post("/prf-submission", storeBapComboKeys, (req, res) => {
 });
 
 // --- get an existing 2022 PRF's schema and submission data from Formio
-router.get("/prf-submission/:rebateId", storeBapComboKeys, async (req, res) => {
+router.get("/prf-submission/:rebateId", storeBapComboKeys, (req, res) => {
   fetchPRFSubmission({ rebateYear, req, res });
 });
 
@@ -115,7 +115,7 @@ router.post("/crf-submission", storeBapComboKeys, (req, res) => {
 });
 
 // --- get an existing 2022 CRF's schema and submission data from Formio
-router.get("/crf-submission/:rebateId", storeBapComboKeys, async (req, res) => {
+router.get("/crf-submission/:rebateId", storeBapComboKeys, (req, res) => {
   fetchCRFSubmission({ rebateYear, req, res });
 });
 

--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -102,7 +102,7 @@ router.post("/prf-submission", storeBapComboKeys, (req, res) => {
 });
 
 // --- get an existing 2023 PRF's schema and submission data from Formio
-router.get("/prf-submission/:rebateId", storeBapComboKeys, async (req, res) => {
+router.get("/prf-submission/:rebateId", storeBapComboKeys, (req, res) => {
   fetchPRFSubmission({ rebateYear, req, res });
 });
 
@@ -127,7 +127,7 @@ router.get("/crf-submissions", storeBapComboKeys, (req, res) => {
 // });
 
 // --- get an existing 2023 CRF's schema and submission data from Formio
-// router.get("/crf-submission/:rebateId", storeBapComboKeys, async (req, res) => {
+// router.get("/crf-submission/:rebateId", storeBapComboKeys, (req, res) => {
 //   fetchCRFSubmission({ rebateYear, req, res });
 // });
 
@@ -152,7 +152,7 @@ router.post("/change", storeBapComboKeys, (req, res) => {
 });
 
 // --- get an existing 2023 Change Request form's schema and submission data from Formio
-router.get("/change/:mongoId", storeBapComboKeys, async (req, res) => {
+router.get("/change/:mongoId", storeBapComboKeys, (req, res) => {
   fetchChangeRequest({ rebateYear, req, res });
 });
 

--- a/app/server/app/routes/formio2024.js
+++ b/app/server/app/routes/formio2024.js
@@ -16,11 +16,11 @@ const {
   fetchFRFSubmission,
   updateFRFSubmission,
   //
-  // fetchPRFSubmissions,
-  // createPRFSubmission,
-  // fetchPRFSubmission,
-  // updatePRFSubmission,
-  // deletePRFSubmission,
+  fetchPRFSubmissions,
+  createPRFSubmission,
+  fetchPRFSubmission,
+  updatePRFSubmission,
+  deletePRFSubmission,
   //
   // fetchCRFSubmissions,
   // createCRFSubmission,
@@ -93,28 +93,28 @@ router.post(
 
 // --- get user's 2024 PRF submissions from Formio
 router.get("/prf-submissions", storeBapComboKeys, (req, res) => {
-  res.json([]); // TODO: replace with `fetchPRFSubmissions({ rebateYear, req, res })` when PRF is ready
+  fetchPRFSubmissions({ rebateYear, req, res });
 });
 
 // --- post a new 2024 PRF submission to Formio
-// router.post("/prf-submission", storeBapComboKeys, (req, res) => {
-//   createPRFSubmission({ rebateYear, req, res });
-// });
+router.post("/prf-submission", storeBapComboKeys, (req, res) => {
+  createPRFSubmission({ rebateYear, req, res });
+});
 
 // --- get an existing 2024 PRF's schema and submission data from Formio
-// router.get("/prf-submission/:rebateId", storeBapComboKeys, (req, res) => {
-//   fetchPRFSubmission({ rebateYear, req, res });
-// });
+router.get("/prf-submission/:rebateId", storeBapComboKeys, (req, res) => {
+  fetchPRFSubmission({ rebateYear, req, res });
+});
 
 // --- post an update to an existing draft 2024 PRF submission to Formio
-// router.post("/prf-submission/:rebateId", storeBapComboKeys, (req, res) => {
-//   updatePRFSubmission({ rebateYear, req, res });
-// });
+router.post("/prf-submission/:rebateId", storeBapComboKeys, (req, res) => {
+  updatePRFSubmission({ rebateYear, req, res });
+});
 
 // --- delete an existing 2024 PRF submission from Formio
-// router.post("/delete-prf-submission", storeBapComboKeys, (req, res) => {
-//   deletePRFSubmission({ rebateYear, req, res });
-// });
+router.post("/delete-prf-submission", storeBapComboKeys, (req, res) => {
+  deletePRFSubmission({ rebateYear, req, res });
+});
 
 // --- get user's 2024 CRF submissions from Formio
 router.get("/crf-submissions", storeBapComboKeys, (req, res) => {

--- a/app/server/app/routes/formio2024.js
+++ b/app/server/app/routes/formio2024.js
@@ -102,7 +102,7 @@ router.get("/prf-submissions", storeBapComboKeys, (req, res) => {
 // });
 
 // --- get an existing 2024 PRF's schema and submission data from Formio
-// router.get("/prf-submission/:rebateId", storeBapComboKeys, async (req, res) => {
+// router.get("/prf-submission/:rebateId", storeBapComboKeys, (req, res) => {
 //   fetchPRFSubmission({ rebateYear, req, res });
 // });
 
@@ -127,7 +127,7 @@ router.get("/crf-submissions", storeBapComboKeys, (req, res) => {
 // });
 
 // --- get an existing 2024 CRF's schema and submission data from Formio
-// router.get("/crf-submission/:rebateId", storeBapComboKeys, async (req, res) => {
+// router.get("/crf-submission/:rebateId", storeBapComboKeys, (req, res) => {
 //   fetchCRFSubmission({ rebateYear, req, res });
 // });
 
@@ -152,7 +152,7 @@ router.post("/change", storeBapComboKeys, (req, res) => {
 });
 
 // --- get an existing 2024 Change Request form's schema and submission data from Formio
-router.get("/change/:mongoId", storeBapComboKeys, async (req, res) => {
+router.get("/change/:mongoId", storeBapComboKeys, (req, res) => {
   fetchChangeRequest({ rebateYear, req, res });
 });
 

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -340,7 +340,7 @@ const { submissionPeriodOpen } = require("../config/formio");
  */
 
 /**
- * @typedef {Object} BapDataForFor2022CRF
+ * @typedef {Object} BapDataFor2022CRF
  * @property {{
  *  attributes: { type: "Order_Request__c", url: string }
  *  Id: string
@@ -398,8 +398,8 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  Total_Bus_And_Infrastructure_Rebate__c: number
  *  Total_Infrastructure_Funds__c: number | null
  *  Num_Of_Buses_Requested_From_Application__c: number
- *  Total_Price_All_Buses__c: string
- *  Total_Bus_Rebate_Amount__c: string
+ *  Total_Price_All_Buses__c: number
+ *  Total_Bus_Rebate_Amount__c: number
  *  Total_All_Eligible_Infrastructure_Costs__c: number | null
  *  Total_Infrastructure_Rebate__c: number | null
  *  Total_Level_2_Charger_Costs__c: number | null
@@ -1586,7 +1586,7 @@ async function queryBapFor2024PRFData(req, frfReviewItemId) {
  * @param {express.Request} req
  * @param {string} frfReviewItemId CSB Rebate ID with the form/version ID (9 digits)
  * @param {string} prfReviewItemId CSB Rebate ID with the form/version ID (9 digits)
- * @returns {Promise<BapDataForFor2022CRF>} 2022 FRF and 2022 PRF submission fields
+ * @returns {Promise<BapDataFor2022CRF>} 2022 FRF and 2022 PRF submission fields
  */
 async function queryBapFor2022CRFData(req, frfReviewItemId, prfReviewItemId) {
   const logMessage =

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -573,22 +573,27 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               ).split("\n");
 
               array.push({
+                _bap_org_frf: true,
                 org_number: jsonOrg.org_number,
-                org_type: jsonOrg.org_type,
-                _org_id: orgId,
-                org_name: orgName,
-                _org_contact_id: contactId,
-                org_contact_fname: FirstName,
-                org_contact_lname: LastName,
-                org_contact_title: Title,
-                org_contact_email: Email,
-                org_contact_phone: Phone,
-                org_address_1: orgStreetAddress1,
-                org_address_2: orgStreetAddress2,
-                org_county: County__c,
-                org_city: BillingCity,
-                org_state: { name: BillingState },
-                org_zip: BillingPostalCode,
+                org_type: {
+                  existing_bus_owner: jsonOrg.org_type.existingBusOwner,
+                  new_bus_owner: jsonOrg.org_type.newBusOwner,
+                  private_fleet: jsonOrg.org_type.privateFleet,
+                },
+                _bap_org_id: orgId,
+                _bap_org_name: orgName,
+                _bap_org_contact_id: contactId,
+                _bap_org_contact_fname: FirstName,
+                _bap_org_contact_lname: LastName,
+                _bap_org_contact_title: Title,
+                _bap_org_contact_email: Email,
+                _bap_org_contact_phone: Phone,
+                _bap_org_address_1: orgStreetAddress1,
+                _bap_org_address_2: orgStreetAddress2,
+                _bap_org_county: County__c,
+                _bap_org_city: BillingCity,
+                _bap_org_state: { name: BillingState },
+                _bap_org_zip: BillingPostalCode,
               });
             }
 
@@ -633,44 +638,44 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
           );
 
           return {
-            bus_busNumber: Rebate_Item_num__c,
-            bus_existingOwner: {
+            bus_number: Rebate_Item_num__c,
+            bus_existing_owner: {
               org_id: existingOwnerRecord?.Contact__r?.Account?.Id,
               org_name: existingOwnerRecord?.Contact__r?.Account?.Name,
               org_contact_id: existingOwnerRecord?.Contact__r?.Id,
               org_contact_fname: existingOwnerRecord?.Contact__r?.FirstName,
               org_contact_lname: existingOwnerRecord?.Contact__r?.LastName,
             },
-            bus_existingVin: CSB_VIN__c,
-            bus_existingFuelType: CSB_Fuel_Type__c,
-            bus_existingGvwr: CSB_GVWR__c,
-            bus_existingOdometer: Old_Bus_Odometer_miles__c,
-            bus_existingModel: CSB_Model__c,
-            bus_existingModelYear: CSB_Model_Year__c,
-            bus_existingNcesId: Old_Bus_NCES_District_ID__c,
-            bus_existingManufacturer: CSB_Manufacturer__c,
-            bus_existingManufacturerOther: CSB_Manufacturer_if_Other__c,
-            bus_existingAnnualFuelConsumption: CSB_Annual_Fuel_Consumption__c,
-            bus_existingAnnualMileage: Annual_Mileage__c,
-            bus_existingRemainingLife: Old_Bus_Estimated_Remaining_Life__c,
-            bus_existingIdlingHours: Old_Bus_Annual_Idling_Hours__c,
-            bus_newOwner: {
+            bus_existing_vin: CSB_VIN__c,
+            bus_existing_fuel_type: CSB_Fuel_Type__c,
+            bus_existing_gvwr: CSB_GVWR__c,
+            bus_existing_odometer: Old_Bus_Odometer_miles__c,
+            bus_existing_model: CSB_Model__c,
+            bus_existing_model_year: CSB_Model_Year__c,
+            bus_existing_nces_id: Old_Bus_NCES_District_ID__c,
+            bus_existing_manufacturer: CSB_Manufacturer__c,
+            bus_existing_manufacturer_other: CSB_Manufacturer_if_Other__c,
+            bus_existing_annual_fuel_consumption: CSB_Annual_Fuel_Consumption__c, // prettier-ignore
+            bus_existing_annual_mileage: Annual_Mileage__c,
+            bus_existing_remaining_life: Old_Bus_Estimated_Remaining_Life__c,
+            bus_existing_idling_hours: Old_Bus_Annual_Idling_Hours__c,
+            bus_new_owner: {
               org_id: newOwnerRecord?.Contact__r?.Account?.Id,
               org_name: newOwnerRecord?.Contact__r?.Account?.Name,
               org_contact_id: newOwnerRecord?.Contact__r?.Id,
               org_contact_fname: newOwnerRecord?.Contact__r?.FirstName,
               org_contact_lname: newOwnerRecord?.Contact__r?.LastName,
             },
-            bus_newFuelType: New_Bus_Fuel_Type__c,
-            bus_newGvwr: New_Bus_GVWR__c,
-            _bus_maxRebate: New_Bus_Infra_Rebate_Requested__c,
-            _bus_newADAfromFRF: New_Bus_ADA_Compliant__c,
+            bus_new_fuel_type: New_Bus_Fuel_Type__c,
+            bus_new_gvwr: New_Bus_GVWR__c,
+            _bus_new_max_rebate: New_Bus_Infra_Rebate_Requested__c,
+            _bus_new_ada_from_frf: New_Bus_ADA_Compliant__c,
           };
         });
 
         return {
           data: {
-            _application_form_modified: frfModified,
+            _frf_modified: frfModified,
             _bap_entity_combo_key: comboKey,
             _bap_rebate_id: rebateId,
             _user_email: email,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-488

## Main Changes:
* Add initial support for 2024 PRF.

NOTE: We're waiting on the BAP team's 2024 FRF ETL/orchestrator work to complete, before we can test these changes. As soon as that's done and the BAP is processing 2024 FRF submissions, we can test perform the testing steps below.

## Steps To Test:
1. Navigate to the dashboard.
2. Ensure at least one of your 2024 FRF submissions' status is set to "Accepted" in the BAP.
3. Click the "New Payment Request" button.
4. Ensure a new 2024 PRF submission has been created, and you're redirected to the page to continue with filling in the form.
5. Fill in the form fields, submit it, and ensure you're taken back to the dashboard.
