### PR TITLE
Export getRebateIdFieldName in formio utilities file

### DIFF
--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -2127,6 +2127,7 @@ function fetchChangeRequest({ rebateYear, req, res }) {
 
 module.exports = {
   searchNcesData,
+  getRebateIdFieldName,
   //
   uploadS3FileMetadata,
   downloadS3FileMetadata,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-487

## Main Changes:
* Follow up to #500 – adds missing export to Formio utilities file (`getRebateIdFieldName()` was accidentally not exported in that PR).

## Steps To Test:
Same as in #500:
1. Navigate to the helpdesk page.
2. Search for a form submission that has not yet been picked up by the BAP (e.g., 2022 CRF submission "025648")
3. Ensure the helpdesk page returns results.

