### PR TITLE
Feature/add helpdesk s3 support

### DIFF
--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -149,6 +149,31 @@ function fetchBapSubmissionData({
   });
 }
 
+// --- download Formio S3 file metadata
+router.get("/formio/s3/:rebateYear/:formType/storage/s3", (req, res) => {
+  const { query } = req;
+  const { rebateYear, formType } = req.params;
+
+  const formioFormUrl = formUrl[rebateYear][formType];
+
+  if (!formioFormUrl) {
+    const errorStatus = 400;
+    const errorMessage = `Formio form URL does not exist for ${rebateYear} ${formType.toUpperCase()}.`;
+    return res.status(errorStatus).json({ message: errorMessage });
+  }
+
+  axiosFormio(req)
+    .get(`${formioFormUrl}/storage/s3`, { params: query })
+    .then((axiosRes) => axiosRes.data)
+    .then((fileMetadata) => res.json(fileMetadata))
+    .catch((error) => {
+      // NOTE: logged in axiosFormio response interceptor
+      const errorStatus = error.response?.status || 500;
+      const errorMessage = `Error downloading file from S3.`;
+      return res.status(errorStatus).json({ message: errorMessage });
+    });
+});
+
 // --- get an existing form's submission data from Formio and the BAP
 router.get("/formio/submission/:rebateYear/:formType/:id", async (req, res) => {
   const { rebateYear, formType, id } = req.params;


### PR DESCRIPTION
## Related Issues:
* CSBAPP-492

## Main Changes:
* Add s3 route for downloading Formio s3 file metadata to server app's help routes, and update client app's helpdesk component route s3 requests through server app to support file attachment downloads

## Steps To Test:
1. Navigate to the helpdesk page.
2. Search for a 2022 PRF and view the submission.
3. Click on a file attachment and ensure you can download the file properly.
4. Do the same test for a 2022 CRF's file attachments.
