### PR TITLE
Feature/update 2024 prf data

### DIFF
--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -552,16 +552,20 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               County__c,
             } = Account || {};
 
-            const jsonOrg = frf2024RecordJson.data.organizations.find((org) => {
-              const matchedName = org?.org_orgName?.trim() === orgName?.trim();
-              const matchedEmail =
-                org.org_contactEmail?.trim()?.toLowerCase() ===
-                Email?.trim()?.toLowerCase();
+            const jsonOrg = frf2024RecordJson.data.org_organizations.find(
+              (org) => {
+                const matchedName = org?.org_name?.trim() === orgName?.trim();
+                const matchedEmail =
+                  org.org_contact_email?.trim()?.toLowerCase() ===
+                  Email?.trim()?.toLowerCase();
 
-              return matchedName && matchedEmail;
-            });
+                return matchedName && matchedEmail;
+              },
+            );
 
-            const orgAlreadyAdded = array.some((org) => org._org_id === orgId);
+            const orgAlreadyAdded = array.some(
+              (org) => org._bap_org_id === orgId,
+            );
 
             /**
              * Ensure the org exists in the 2024 FRF submission's


### PR DESCRIPTION
## Related Issues:
* CSBAPP-488

## Main Changes:
* Follow up to #503: Update server app's parsing of 2024 FRF data in `fetchDataForPRFSubmission()` to account for updated structure of 2024 FRF.

## Steps To Test:
Same steps as #503:
1. Navigate to the dashboard.
2. Ensure at least one of your 2024 FRF submissions' status is set to "Accepted" in the BAP.
3. Click the "New Payment Request" button.
4. Ensure a new 2024 PRF submission has been created, and you're redirected to the page to continue with filling in the form.
5. Fill in the form fields, submit it, and ensure you're taken back to the dashboard.
