### PR TITLE
Feature/finish 2024 prf support

### DIFF
--- a/app/client/src/config.tsx
+++ b/app/client/src/config.tsx
@@ -159,12 +159,12 @@ export const formioNameField = {
   2023: {
     frf: "_user_name",
     prf: "_user_name",
-    crf: "", // TODO
+    crf: "_user_name", // TODO: confirm when the 2023 CRF is created
   },
   2024: {
     frf: "_user_name",
-    prf: "", // TODO
-    crf: "", // TODO
+    prf: "_user_name",
+    crf: "_user_name", // TODO: confirm when the 2024 CRF is created
   },
 };
 
@@ -180,12 +180,12 @@ export const formioEmailField = {
   2023: {
     frf: "_user_email",
     prf: "_user_email",
-    crf: "", // TODO
+    crf: "_user_email", // TODO: confirm when the 2023 CRF is created
   },
   2024: {
     frf: "_user_email",
-    prf: "", // TODO
-    crf: "", // TODO
+    prf: "_user_email",
+    crf: "_user_email", // TODO: confirm when the 2024 CRF is created
   },
 };
 
@@ -205,7 +205,7 @@ export const formioBapRebateIdField = {
   },
   2024: {
     frf: "", // NOTE: no BAP rebate ID in the FRF
-    prf: "", // TODO
-    crf: "", // TODO
+    prf: "_bap_rebate_id",
+    crf: "_bap_rebate_id",
   },
 };

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -1479,6 +1479,12 @@ function fetchPRFSubmission({ rebateYear, req, res }) {
         return res.status(errorStatus).json({ message: errorMessage });
       }
 
+      /** Modify 2024 PRF's NCES API endpoint URL for local development */
+      const formSchemaJson =
+        NODE_ENV === "development" && rebateYear === "2024"
+          ? modifyDatasourceComponentsUrl(schema)
+          : schema;
+
       /**
        * NOTE: We can't just use the returned submission data here because
        * Formio returns the string literal 'YES' instead of a base64 encoded
@@ -1493,7 +1499,7 @@ function fetchPRFSubmission({ rebateYear, req, res }) {
         .then((submission) => {
           return res.json({
             userAccess: true,
-            formSchema: { url: formioFormUrl, json: schema },
+            formSchema: { url: formioFormUrl, json: formSchemaJson },
             submission,
           });
         });


### PR DESCRIPTION
## Related Issues:
* CSBAPP-488

## Main Changes:
* Follow up to #507 and #503 – Applies further changes to support 2024 PRF submissions being properly displayed in the user's dashboard table.

## Steps To Test:
Once again, same as before:

1. Navigate to the dashboard.
2. Ensure at least one of your 2024 FRF submissions' status is set to "Accepted" in the BAP.
3. Click the "New Payment Request" button.
4. Ensure a new 2024 PRF submission has been created, and you're redirected to the page to continue with filling in the form.
5. Fill in the form fields, submit it, and ensure you're taken back to the dashboard.

