### PR TITLE
Feature/update logging

### DIFF
--- a/app/server/app/index.js
+++ b/app/server/app/index.js
@@ -78,13 +78,6 @@ function fetchNcesData() {
       const localFilePath = resolve(__dirname, "./content", filename);
       const s3FileUrl = `${s3BucketUrl}/content/${filename}`;
 
-      const logMessage =
-        NODE_ENV === "development"
-          ? `Reading ${filename} file from disk.`
-          : `Fetching ${filename} from S3 bucket.`;
-
-      log({ level: "info", message: logMessage });
-
       /**
        * local development: read files directly from disk
        * Cloud.gov: fetch files from the public s3 bucket
@@ -95,14 +88,19 @@ function fetchNcesData() {
     }),
   )
     .then((data) => {
+      const logMessage =
+        NODE_ENV === "development"
+          ? `Read ${filenames.length} NCES files from disk.`
+          : `Fetched ${filenames.length} NCES files from S3 bucket.`;
+
+      log({ level: "info", message: logMessage });
+
       return {
         2023: data[0],
         2024: data[1],
       };
     })
     .catch((error) => {
-      console.log(error);
-
       const errorStatus = error.response?.status || 500;
       const errorMethod = error.response?.config?.method?.toUpperCase();
       const errorUrl = error.response?.config?.url;
@@ -125,7 +123,7 @@ fetchNcesData().then((ncesData) => {
   app.use(helmet.hsts({ maxAge: 31536000 }));
 
   /** Instruct web browsers to disable caching. */
-  app.use((req, res, next) => {
+  app.use((_req, res, next) => {
     res.setHeader("Surrogate-Control", "no-store");
     res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate"); // prettier-ignore
     res.setHeader("Pragma", "no-cache");
@@ -164,7 +162,7 @@ fetchNcesData().then((ncesData) => {
    * (required when using sub path).
    */
   const pathRegex = new RegExp(`^\\${SERVER_BASE_PATH || ""}$`);
-  app.all(pathRegex, (req, res) => res.redirect(`${basePath}`));
+  app.all(pathRegex, (_req, res) => res.redirect(`${basePath}`));
 
   /**
    * Serve client app's static built files.
@@ -180,7 +178,7 @@ fetchNcesData().then((ncesData) => {
   app.use(protectClientRoutes);
 
   /** Serve client-side routes. */
-  app.get("*", (req, res) => {
+  app.get("*", (_req, res) => {
     res.sendFile(resolve(__dirname, "public/index.html"));
   });
 

--- a/app/server/app/routes/content.js
+++ b/app/server/app/routes/content.js
@@ -34,13 +34,6 @@ router.get("/", (req, res) => {
       const localFilePath = resolve(__dirname, "../content", filename);
       const s3FileUrl = `${s3BucketUrl}/content/${filename}`;
 
-      const logMessage =
-        NODE_ENV === "development"
-          ? `Reading ${filename} file from disk.`
-          : `Fetching ${filename} from S3 bucket.`;
-
-      log({ level: "info", message: logMessage });
-
       /**
        * local development: read files directly from disk
        * Cloud.gov: fetch files from the public s3 bucket
@@ -51,6 +44,13 @@ router.get("/", (req, res) => {
     }),
   )
     .then((data) => {
+      const logMessage =
+        NODE_ENV === "development"
+          ? `Read ${filenames.length} content files from disk.`
+          : `Fetched ${filenames.length} content files from S3 bucket.`;
+
+      log({ level: "info", message: logMessage });
+
       return res.json({
         siteAlert: data[0],
         helpdeskIntro: data[1],


### PR DESCRIPTION
## Related Issues:
* CSBAPP-495

## Main Changes:
* Log when a helpdesk user changes a Formio form submission's status back to 'draft' state. Also consolidate individual logs for NCES and Markdown content files into a single log for each as there's no need to log them separately.

## Steps To Test:
1. Navigate to the helpdesk page.
2. Search for a submitted form submission that has not yet been picked up by the BAP (e.g., a new 2024 FRF)
3. Click the "Draft" button beside the submission's status shown in the table of results, and in the modal dialog, confirm you want to change the submission's status back to draft.
4. Look at the server APP logs and ensure a message was logged indicating your email updated the submission with "(status: 'draft')" in the message.
5. Also, in the server APP logs, ensure the NCES and Markdown file logs are consolidated:
  - When the app starts, the two NCES files will be fetched resulting in only one log message now.
  - When the /api/content endpoint is hit the markdown content files will be fetched resulting on only one log message now.
