### PR TITLE
Feature/update verify bap connection

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -1922,12 +1922,7 @@ function verifyBapConnection(req, { name, args }) {
     return setupConnection(req).then(() => callback());
   }
 
-  return bapConnection.identity().then((identityInfo) => {
-    const logMessage = `BAP Connection Info`;
-    log({ level: "info", message: logMessage, req, otherInfo: identityInfo });
-
-    return callback();
-  });
+  return callback();
 }
 
 /**


### PR DESCRIPTION
## Related Issues:
* CSBAPP-491

## Main Changes:
Follow up to #505 – Remove calling the jsforce connection.identity() function before each BAP request.

## Steps To Test:
1. As before, navigate the app normally. The next time the BAP connection breaks, view the logs to see if they point to an issue that needs to be resolved.
