### PR TITLE
Feature/update 2024 prf fields

### DIFF
--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -587,7 +587,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
                 },
                 _bap_org_id: orgId,
                 _bap_org_name: orgName,
-                _bap_org_contact_id: contactId,
+                _bap_org_contact_id_frf: contactId,
                 _bap_org_contact_fname: FirstName,
                 _bap_org_contact_lname: LastName,
                 _bap_org_contact_title: Title,
@@ -597,7 +597,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
                 _bap_org_address_2: orgStreetAddress2,
                 _bap_org_county: County__c,
                 _bap_org_city: BillingCity,
-                _bap_org_state: { name: BillingState },
+                _bap_org_state: BillingState,
                 _bap_org_zip: BillingPostalCode,
               });
             }


### PR DESCRIPTION
## Related Issues:
* CSBAPP-488

## Main Changes:
Follow up to #508, #507, and #503 – Update new 2024 PRF data fields within the `org_organizations` array: rename org contact id field to `_bap_org_contact_id_frf`, update value passed to `_bap_org_state` to no longer be an object with property of name, but just the value of `BillingState` returned in BAP 2024 bus records contacts query.

## Steps To Test:
1. Create a new 2024 PRF.
2. Ensure the two new/modified fields in the `org_organizations` array include the expected values.
