### PR TITLE
Feature/update bap helpdesk query

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -659,6 +659,8 @@ async function queryForBapFormSubmissionData(
     .limit(1)
     .execute(async (err, records) => ((await err) ? err : records));
 
+  if (formRecordTypeIdQuery.length === 0) return null;
+
   const formRecordTypeId = formRecordTypeIdQuery["0"].Id;
 
   // `SELECT
@@ -1909,7 +1911,9 @@ function verifyBapConnection(req, { name, args }) {
   function callback() {
     return name(...args).catch((err) => {
       const logMessage = `BAP Error: ${err}.`;
-      log({ level: "error", message: logMessage, req });
+      log({ level: "error", message: logMessage, req, otherInfo: err });
+
+      // Error: Unable to refresh session due to: No refresh token found in the connection.
 
       throw err;
     });


### PR DESCRIPTION
## Related Issues:
* CSBAPP-487

## Main Changes:
* Follow up to #500 – Update `queryForBapFormSubmissionData()` (used on helpdesk page) to return null if the record type id query returns no results which will be the case if the record type does not yet exist in the BAP (e.g., the 2024 PRF ETL is still being developed by the BAP)

## Steps To Test:
1. Navigate to the helpdesk page.
2. Search for a form submission that has not yet been picked up by the BAP (e.g., 2024 PRF submission "029544" on staging)
3. Ensure the helpdesk page returns results

