### PR TITLE
Feature/update helpdesk logic

### DIFF
--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -393,6 +393,12 @@ export function Helpdesk() {
   }>({ fetched: false, results: [] });
 
   useEffect(() => {
+    if (helpdeskAccess === "failure") {
+      navigate("/", { replace: true });
+    }
+  }, [navigate, helpdeskAccess]);
+
+  useEffect(() => {
     queryClient.resetQueries({ queryKey: ["helpdesk/submission"] });
   }, [queryClient]);
 
@@ -456,7 +462,11 @@ export function Helpdesk() {
   }
 
   if (helpdeskAccess === "failure") {
-    navigate("/", { replace: true });
+    /**
+     * NOTE: this is just included for completeness, as before this is rendered,
+     * the user will have been redirected to their dashboard via the useEffect()
+     */
+    return null;
   }
 
   return (

--- a/app/server/app/middleware.js
+++ b/app/server/app/middleware.js
@@ -91,10 +91,8 @@ function ensureHelpdesk(req, res, next) {
   const userRoles = memberof?.split(",") || [];
 
   if (!userRoles.includes("csb_admin") && !userRoles.includes("csb_helpdesk")) {
-    if (!req.originalUrl.includes("/helpdesk-access")) {
-      const logMessage = `User with email ${mail} attempted to perform an admin/helpdesk action without correct privileges.`;
-      log({ level: "error", message: logMessage, req });
-    }
+    const logMessage = `User with email ${mail} attempted to perform an admin/helpdesk action without correct privileges.`;
+    log({ level: "error", message: logMessage, req });
 
     const errorStatus = 401;
     const errorMessage = `Unauthorized.`;


### PR DESCRIPTION
## Related Issues:
* CSBAPP-487

## Main Changes:
Due to API protections that have been in place, prior to this change (and of course after), no users could ever issue helpdesk API requests or view any data without being part of the correct user groups. This just ensures users are redirected back to their dashboard as intended if they ever visited the helpdesk page manually, and ensures we're properly logging any unauthorized helpdesk API requests.

## Steps To Test:
1. As a non-helpdesk user, navigate to the helpdesk page. You should be redirected to your dashboard.
2. As a non-helpdesk user, issue a helpdesk API call. An entry should be logged that your user attempted a non-authorized request.
