### PR TITLE
Feature/update 2024 frf bus annual mileage query

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -304,7 +304,7 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  CSB_Manufacturer__c: string
  *  CSB_Manufacturer_if_Other__c: string | null
  *  CSB_Annual_Fuel_Consumption__c: number
- *  Annual_Mileage__c: number
+ *  Old_Bus_Average_Annual_Mileage__c: number
  *  Old_Bus_Estimated_Remaining_Life__c: number
  *  Old_Bus_Annual_Idling_Hours__c: number
  *  New_Bus_Infra_Rebate_Requested__c: number
@@ -1465,7 +1465,7 @@ async function queryBapFor2024PRFData(req, frfReviewItemId) {
   //   CSB_Manufacturer__c,
   //   CSB_Manufacturer_if_Other__c,
   //   CSB_Annual_Fuel_Consumption__c,
-  //   Annual_Mileage__c,
+  //   Old_Bus_Average_Annual_Mileage__c,
   //   Old_Bus_Estimated_Remaining_Life__c,
   //   Old_Bus_Annual_Idling_Hours__c,
   //   New_Bus_Infra_Rebate_Requested__c,
@@ -1501,7 +1501,7 @@ async function queryBapFor2024PRFData(req, frfReviewItemId) {
         CSB_Manufacturer__c: 1,
         CSB_Manufacturer_if_Other__c: 1,
         CSB_Annual_Fuel_Consumption__c: 1,
-        Annual_Mileage__c: 1,
+        Old_Bus_Average_Annual_Mileage__c: 1,
         Old_Bus_Estimated_Remaining_Life__c: 1,
         Old_Bus_Annual_Idling_Hours__c: 1,
         New_Bus_Infra_Rebate_Requested__c: 1,

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -621,7 +621,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             CSB_Manufacturer__c,
             CSB_Manufacturer_if_Other__c,
             CSB_Annual_Fuel_Consumption__c,
-            Annual_Mileage__c,
+            Old_Bus_Average_Annual_Mileage__c,
             Old_Bus_Estimated_Remaining_Life__c,
             Old_Bus_Annual_Idling_Hours__c,
             New_Bus_Infra_Rebate_Requested__c,
@@ -661,7 +661,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             bus_existing_manufacturer: CSB_Manufacturer__c,
             bus_existing_manufacturer_other: CSB_Manufacturer_if_Other__c,
             bus_existing_annual_fuel_consumption: CSB_Annual_Fuel_Consumption__c, // prettier-ignore
-            bus_existing_annual_mileage: Annual_Mileage__c,
+            bus_existing_annual_mileage: Old_Bus_Average_Annual_Mileage__c,
             bus_existing_remaining_life: Old_Bus_Estimated_Remaining_Life__c,
             bus_existing_idling_hours: Old_Bus_Annual_Idling_Hours__c,
             bus_new_owner: {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-488

## Main Changes:
* Follow up to #508. Update the BAP field used for the 2024 FRF's old bus average annual mileage.

## Steps To Test:
1. Navigate to the dashboard.
2. Ensure at least one of your 2024 FRF submissions' status is set to "Accepted" in the BAP.
3. Click the "New Payment Request" button.
4. Ensure a new 2024 PRF submission has been created, and in the submission data, each bus' average annual mileage field (`bus_existing_annual_mileage`) has a value.
