### PR TITLE
Feature/update salesforce rest api version

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -466,6 +466,7 @@ const {
  */
 function setupConnection(req) {
   const bapConnection = new jsforce.Connection({
+    version: "62.0",
     oauth2: {
       clientId: BAP_CLIENT_ID,
       clientSecret: BAP_CLIENT_SECRET,
@@ -1913,7 +1914,14 @@ function verifyBapConnection(req, { name, args }) {
       const logMessage = `BAP Error: ${err}.`;
       log({ level: "error", message: logMessage, req, otherInfo: err });
 
+      // TODO: Handle the following error:
       // Error: Unable to refresh session due to: No refresh token found in the connection.
+
+      if (err?.includes("No refresh token found in the connection.")) {
+        log({ level: "info", message: "Re-establishing BAP connection.", req });
+
+        // Re-establish the BAP connection.
+      }
 
       throw err;
     });


### PR DESCRIPTION
## Related Issues:
* CSBAPP-510

## Main Changes:
Provide the latest Salesforce REST API version (v62.0) when setting up the Salesforce connection. Previously, we didn't explicitly provide the Salesforce REST API version, so [jsforce is defaulting to v50.0](https://github.com/jsforce/jsforce/blob/main/src/connection.ts#L111).

## Steps To Test:
1. Navigate to the dashboard.
2. If you're able to, create a new PRF or CRF submission.
3. Navigate to the helpdesk and query for a submission.
4. All of the above use BAP/Salesforce queries, which should confirm everything continues to work as expected.

