### PR TITLE
Feature/update new 2024 prf data

### DIFF
--- a/app/server/app/routes/config.js
+++ b/app/server/app/routes/config.js
@@ -10,7 +10,7 @@ const router = express.Router();
 router.use(ensureAuthenticated);
 
 // --- get CSB app specific configuration
-router.get("/", (req, res) => {
+router.get("/", (_req, res) => {
   // NOTE: fallback to current year if CSB_REBATE_YEAR is not set
   const date = new Date();
   const year = date.getFullYear().toString();

--- a/app/server/app/routes/status.js
+++ b/app/server/app/routes/status.js
@@ -42,7 +42,7 @@ function verifySchema({ schema, substring }) {
 
 const router = express.Router();
 
-router.get("/app", (req, res) => {
+router.get("/app", (_req, res) => {
   return res.json({ status: true });
 });
 

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -503,6 +503,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
           frf2024RecordQuery,
           frf2024BusRecordsQuery,
           frf2024BusRecordsContactsQueries,
+          frf2024ContactsRecordTypesQuery,
         } = results;
 
         const existingBusOwnerType = "Old Bus Private Fleet Owner (if changed)";
@@ -535,6 +536,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
 
             const {
               Id: contactId,
+              RecordTypeId,
               FirstName,
               LastName,
               Title,
@@ -577,6 +579,10 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
                 BillingStreet ?? "\n"
               ).split("\n");
 
+              const orgContactRecordType = frf2024ContactsRecordTypesQuery.find(
+                (item) => item.Id === RecordTypeId,
+              );
+
               array.push({
                 _bap_org_frf: true,
                 org_number: jsonOrg.org_number,
@@ -588,6 +594,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
                 _bap_org_id: orgId,
                 _bap_org_name: orgName,
                 _bap_org_contact_id_frf: contactId,
+                _bap_org_contact_recordtype: orgContactRecordType?.Name || "",
                 _bap_org_contact_fname: FirstName,
                 _bap_org_contact_lname: LastName,
                 _bap_org_contact_title: Title,
@@ -642,12 +649,21 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               item.Relationship_Type__c === newBusOwnerType,
           );
 
+          const existingOwnerRecordType = frf2024ContactsRecordTypesQuery.find(
+            (item) => item.Id === existingOwnerRecord?.Contact__r?.RecordTypeId,
+          );
+
+          const newOwnerRecordType = frf2024ContactsRecordTypesQuery.find(
+            (item) => item.Id === newOwnerRecord?.Contact__r?.RecordTypeId,
+          );
+
           return {
             bus_number: Rebate_Item_num__c,
             bus_existing_owner: {
               org_id: existingOwnerRecord?.Contact__r?.Account?.Id,
               org_name: existingOwnerRecord?.Contact__r?.Account?.Name,
               org_contact_id: existingOwnerRecord?.Contact__r?.Id,
+              org_contact_recordtype: existingOwnerRecordType?.Name || "",
               org_contact_fname: existingOwnerRecord?.Contact__r?.FirstName,
               org_contact_lname: existingOwnerRecord?.Contact__r?.LastName,
             },
@@ -668,6 +684,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               org_id: newOwnerRecord?.Contact__r?.Account?.Id,
               org_name: newOwnerRecord?.Contact__r?.Account?.Name,
               org_contact_id: newOwnerRecord?.Contact__r?.Id,
+              org_contact_recordtype: newOwnerRecordType?.Name || "",
               org_contact_fname: newOwnerRecord?.Contact__r?.FirstName,
               org_contact_lname: newOwnerRecord?.Contact__r?.LastName,
             },
@@ -677,6 +694,18 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             _bus_new_ada_from_frf: New_Bus_ADA_Compliant__c,
           };
         });
+
+        const primaryContactRecordType = frf2024ContactsRecordTypesQuery.find(
+          (item) => item.Id === Primary_Applicant__r?.RecordTypeId,
+        );
+
+        const alternateContactRecordType = frf2024ContactsRecordTypesQuery.find(
+          (item) => item.Id === Alternate_Applicant__r?.RecordTypeId,
+        );
+
+        const districtContactRecordType = frf2024ContactsRecordTypesQuery.find(
+          (item) => item.Id === School_District_Contact__r?.RecordTypeId,
+        );
 
         return {
           data: {
@@ -704,12 +733,14 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             _bap_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
             _bap_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
             _bap_primary_id: Primary_Applicant__r?.Id,
+            _bap_primary_recordtype: primaryContactRecordType?.Name || "",
             _bap_primary_fname: Primary_Applicant__r?.FirstName,
             _bap_primary_lname: Primary_Applicant__r?.LastName,
             _bap_primary_title: Primary_Applicant__r?.Title,
             _bap_primary_email: Primary_Applicant__r?.Email,
             _bap_primary_phone: Primary_Applicant__r?.Phone,
             _bap_alternate_id: Alternate_Applicant__r?.Id,
+            _bap_alternate_recordtype: alternateContactRecordType?.Name,
             _bap_alternate_fname: Alternate_Applicant__r?.FirstName,
             _bap_alternate_lname: Alternate_Applicant__r?.LastName,
             _bap_alternate_title: Alternate_Applicant__r?.Title,
@@ -731,6 +762,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             },
             _bap_district_self_certify: Self_Certification_Category__c,
             _bap_district_contact_id: School_District_Contact__r?.Id,
+            _bap_district_contact_recordtype: districtContactRecordType?.Name || "", // prettier-ignore
             _bap_district_contact_fname: School_District_Contact__r?.FirstName,
             _bap_district_contact_lname: School_District_Contact__r?.LastName,
             _bap_district_contact_title: School_District_Contact__r?.Title,

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -1999,7 +1999,7 @@ function updateCRFSubmission({ rebateYear, req, res }) {
           return res.status(errorStatus).json({ message: errorMessage });
         });
     })
-    .catch((error) => {
+    .catch((_error) => {
       const logMessage =
         `User with email '${mail}' attempted to update ${rebateYear} CRF ` +
         `submission '${rebateId}' when the CSB CRF enrollment period was closed.`;


### PR DESCRIPTION
## Related Issues:
* CSBAPP-513

## Main Changes:
Update BAP queries for 2024 FRF data to include all contacts' Salesforce record types, and provide that data in new 2024 PRF submissions (for the 2024 PRF form definition to use to determine whether a contact's info is editable or not).

## Steps To Test:
1. Navigate to the dashboard.
2. Create a new 2024 PRF submission.
3. Ensure the submission data includes any BAP contact's record types in the submission data.
4. Any further testing of form logic can be done as well (e.g., if contact fields are editable) but that's outside the scope of the wrapper app's code – the wrapper app just provides the Salesforce record types for each contact.

