### PR TITLE
Feature/update 2024 frf record type field

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -250,7 +250,7 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  Primary_Applicant__r: {
  *    attributes: { type: "Contact", url: string }
  *    Id: string
- *    RecordTypeId: string
+ *    Record_Type_Name__c: string
  *    FirstName: string
  *    LastName: string
  *    Title: string
@@ -260,7 +260,7 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  Alternate_Applicant__r: {
  *    attributes: { type: "Contact", url: string }
  *    Id: string
- *    RecordTypeId: string
+ *    Record_Type_Name__c: string
  *    FirstName: string
  *    LastName: string
  *    Title: string
@@ -279,7 +279,7 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  School_District_Contact__r: {
  *    attributes: { type: "Contact", url: string }
  *    Id: string
- *    RecordTypeId: string
+ *    Record_Type_Name__c: string
  *    FirstName: string
  *    LastName: string
  *    Title: string
@@ -323,7 +323,7 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  Contact__r: {
  *    attributes: { type: "Contact", url: string }
  *    Id: string
- *    RecordTypeId: string
+ *    Record_Type_Name__c: string
  *    FirstName: string
  *    LastName: string
  *    Title: string
@@ -341,12 +341,6 @@ const { submissionPeriodOpen } = require("../config/formio");
  *    }
  *  }
  * }[]} frf2024BusRecordsContactsQueries
- * @property {{
- *  attributes: { type: "RecordType", url: string }
- *  Id: string
- *  Name: string
- *  Description: string
- * }[]} frf2024ContactsRecordTypesQuery
  */
 
 /**
@@ -1351,14 +1345,14 @@ async function queryBapFor2024PRFData(req, frfReviewItemId) {
   //   Applicant_Organization__r.Id
   //   Applicant_Organization__r.County__c
   //   Primary_Applicant__r.Id,
-  //   Primary_Applicant__r.RecordTypeId,
+  //   Primary_Applicant__r.Record_Type_Name__c,
   //   Primary_Applicant__r.FirstName,
   //   Primary_Applicant__r.LastName,
   //   Primary_Applicant__r.Title,
   //   Primary_Applicant__r.Email,
   //   Primary_Applicant__r.Phone,
   //   Alternate_Applicant__r.Id,
-  //   Alternate_Applicant__r.RecordTypeId,
+  //   Alternate_Applicant__r.Record_Type_Name__c,
   //   Alternate_Applicant__r.FirstName,
   //   Alternate_Applicant__r.LastName,
   //   Alternate_Applicant__r.Title,
@@ -1371,7 +1365,7 @@ async function queryBapFor2024PRFData(req, frfReviewItemId) {
   //   CSB_School_District__r.BillingState,
   //   CSB_School_District__r.BillingPostalCode,
   //   School_District_Contact__r.Id,
-  //   School_District_Contact__r.RecordTypeId
+  //   School_District_Contact__r.Record_Type_Name__c
   //   School_District_Contact__r.FirstName,
   //   School_District_Contact__r.LastName,
   //   School_District_Contact__r.Title,
@@ -1406,14 +1400,14 @@ async function queryBapFor2024PRFData(req, frfReviewItemId) {
         "Applicant_Organization__r.Id": 1,
         "Applicant_Organization__r.County__c": 1,
         "Primary_Applicant__r.Id": 1,
-        "Primary_Applicant__r.RecordTypeId": 1,
+        "Primary_Applicant__r.Record_Type_Name__c": 1,
         "Primary_Applicant__r.FirstName": 1,
         "Primary_Applicant__r.LastName": 1,
         "Primary_Applicant__r.Title": 1,
         "Primary_Applicant__r.Email": 1,
         "Primary_Applicant__r.Phone": 1,
         "Alternate_Applicant__r.Id": 1,
-        "Alternate_Applicant__r.RecordTypeId": 1,
+        "Alternate_Applicant__r.Record_Type_Name__c": 1,
         "Alternate_Applicant__r.FirstName": 1,
         "Alternate_Applicant__r.LastName": 1,
         "Alternate_Applicant__r.Title": 1,
@@ -1426,7 +1420,7 @@ async function queryBapFor2024PRFData(req, frfReviewItemId) {
         "CSB_School_District__r.BillingState": 1,
         "CSB_School_District__r.BillingPostalCode": 1,
         "School_District_Contact__r.Id": 1,
-        "School_District_Contact__r.RecordTypeId": 1,
+        "School_District_Contact__r.Record_Type_Name__c": 1,
         "School_District_Contact__r.FirstName": 1,
         "School_District_Contact__r.LastName": 1,
         "School_District_Contact__r.Title": 1,
@@ -1442,8 +1436,7 @@ async function queryBapFor2024PRFData(req, frfReviewItemId) {
     )
     .execute(async (err, records) => ((await err) ? err : records));
 
-  const frf2024Record = frf2024RecordQuery["0"];
-  const frf2024RecordId = frf2024Record.Id;
+  const frf2024RecordId = frf2024RecordQuery["0"].Id;
 
   // `SELECT
   //   Id
@@ -1541,7 +1534,7 @@ async function queryBapFor2024PRFData(req, frfReviewItemId) {
         //   Related_Line_Item__c,
         //   Relationship_Type__c,
         //   Contact__r.Id,
-        //   Contant__r.RecordTypeId,
+        //   Contant__r.Record_Type_Name__c,
         //   Contact__r.FirstName,
         //   Contact__r.LastName
         //   Contact__r.Title,
@@ -1575,7 +1568,7 @@ async function queryBapFor2024PRFData(req, frfReviewItemId) {
               Related_Line_Item__c: 1,
               Relationship_Type__c: 1,
               "Contact__r.Id": 1,
-              "Contact__r.RecordTypeId": 1,
+              "Contact__r.Record_Type_Name__c": 1,
               "Contact__r.FirstName": 1,
               "Contact__r.LastName": 1,
               "Contact__r.Title": 1,
@@ -1595,51 +1588,10 @@ async function queryBapFor2024PRFData(req, frfReviewItemId) {
     )
   ).flat();
 
-  const recordTypeIds = [];
-
-  recordTypeIds.push(frf2024Record?.Primary_Applicant__r?.RecordTypeId);
-  recordTypeIds.push(frf2024Record?.Alternate_Applicant__r?.RecordTypeId);
-  recordTypeIds.push(frf2024Record?.School_District_Contact__r?.RecordTypeId);
-
-  for (const busRecordsContactsQuery of frf2024BusRecordsContactsQueries) {
-    const { Contact__r } = busRecordsContactsQuery;
-    recordTypeIds.push(Contact__r?.RecordTypeId);
-  }
-
-  const uniqueRecordTypeIds = [...new Set(recordTypeIds)].filter(Boolean);
-
-  // `SELECT
-  //   Id,
-  //   Name,
-  //   Description
-  // FROM
-  //   RecordType
-  // WHERE
-  //   Id IN(${uniqueRecordTypeIds.map((id) => `'${id}'`)})`
-
-  const frf2024ContactsRecordTypesQuery =
-    uniqueRecordTypeIds.length === 0
-      ? []
-      : await bapConnection
-          .sobject("RecordType")
-          .find(
-            {
-              Id: { $in: uniqueRecordTypeIds },
-            },
-            {
-              // "*": 1,
-              Id: 1, // Salesforce record ID
-              Name: 1,
-              Description: 1,
-            },
-          )
-          .execute(async (err, records) => ((await err) ? err : records));
-
   return {
     frf2024RecordQuery,
     frf2024BusRecordsQuery,
     frf2024BusRecordsContactsQueries,
-    frf2024ContactsRecordTypesQuery,
   };
 }
 

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -503,7 +503,6 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
           frf2024RecordQuery,
           frf2024BusRecordsQuery,
           frf2024BusRecordsContactsQueries,
-          frf2024ContactsRecordTypesQuery,
         } = results;
 
         const existingBusOwnerType = "Old Bus Private Fleet Owner (if changed)";
@@ -536,7 +535,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
 
             const {
               Id: contactId,
-              RecordTypeId,
+              Record_Type_Name__c,
               FirstName,
               LastName,
               Title,
@@ -579,10 +578,6 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
                 BillingStreet ?? "\n"
               ).split("\n");
 
-              const orgContactRecordType = frf2024ContactsRecordTypesQuery.find(
-                (item) => item.Id === RecordTypeId,
-              );
-
               array.push({
                 _bap_org_frf: true,
                 org_number: jsonOrg.org_number,
@@ -594,7 +589,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
                 _bap_org_id: orgId,
                 _bap_org_name: orgName,
                 _bap_org_contact_id_frf: contactId,
-                _bap_org_contact_recordtype: orgContactRecordType?.Name || "",
+                _bap_org_contact_recordtype: Record_Type_Name__c,
                 _bap_org_contact_fname: FirstName,
                 _bap_org_contact_lname: LastName,
                 _bap_org_contact_title: Title,
@@ -649,13 +644,13 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               item.Relationship_Type__c === newBusOwnerType,
           );
 
-          const existingOwnerRecordType = frf2024ContactsRecordTypesQuery.find(
-            (item) => item.Id === existingOwnerRecord?.Contact__r?.RecordTypeId,
-          );
+          // const existingOwnerRecordType = frf2024ContactsRecordTypesQuery.find(
+          //   (item) => item.Id === existingOwnerRecord?.Contact__r?.RecordTypeId,
+          // );
 
-          const newOwnerRecordType = frf2024ContactsRecordTypesQuery.find(
-            (item) => item.Id === newOwnerRecord?.Contact__r?.RecordTypeId,
-          );
+          // const newOwnerRecordType = frf2024ContactsRecordTypesQuery.find(
+          //   (item) => item.Id === newOwnerRecord?.Contact__r?.RecordTypeId,
+          // );
 
           return {
             bus_number: Rebate_Item_num__c,
@@ -663,7 +658,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               org_id: existingOwnerRecord?.Contact__r?.Account?.Id,
               org_name: existingOwnerRecord?.Contact__r?.Account?.Name,
               org_contact_id: existingOwnerRecord?.Contact__r?.Id,
-              org_contact_recordtype: existingOwnerRecordType?.Name || "",
+              org_contact_recordtype: existingOwnerRecord?.Contact__r?.Record_Type_Name__c, // prettier-ignore
               org_contact_fname: existingOwnerRecord?.Contact__r?.FirstName,
               org_contact_lname: existingOwnerRecord?.Contact__r?.LastName,
             },
@@ -684,7 +679,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               org_id: newOwnerRecord?.Contact__r?.Account?.Id,
               org_name: newOwnerRecord?.Contact__r?.Account?.Name,
               org_contact_id: newOwnerRecord?.Contact__r?.Id,
-              org_contact_recordtype: newOwnerRecordType?.Name || "",
+              org_contact_recordtype: newOwnerRecord?.Contact__r?.Record_Type_Name__c, // prettier-ignore
               org_contact_fname: newOwnerRecord?.Contact__r?.FirstName,
               org_contact_lname: newOwnerRecord?.Contact__r?.LastName,
             },
@@ -694,18 +689,6 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             _bus_new_ada_from_frf: New_Bus_ADA_Compliant__c,
           };
         });
-
-        const primaryContactRecordType = frf2024ContactsRecordTypesQuery.find(
-          (item) => item.Id === Primary_Applicant__r?.RecordTypeId,
-        );
-
-        const alternateContactRecordType = frf2024ContactsRecordTypesQuery.find(
-          (item) => item.Id === Alternate_Applicant__r?.RecordTypeId,
-        );
-
-        const districtContactRecordType = frf2024ContactsRecordTypesQuery.find(
-          (item) => item.Id === School_District_Contact__r?.RecordTypeId,
-        );
 
         return {
           data: {
@@ -733,14 +716,14 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             _bap_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
             _bap_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
             _bap_primary_id: Primary_Applicant__r?.Id,
-            _bap_primary_recordtype: primaryContactRecordType?.Name || "",
+            _bap_primary_recordtype: Primary_Applicant__r?.Record_Type_Name__c,
             _bap_primary_fname: Primary_Applicant__r?.FirstName,
             _bap_primary_lname: Primary_Applicant__r?.LastName,
             _bap_primary_title: Primary_Applicant__r?.Title,
             _bap_primary_email: Primary_Applicant__r?.Email,
             _bap_primary_phone: Primary_Applicant__r?.Phone,
             _bap_alternate_id: Alternate_Applicant__r?.Id,
-            _bap_alternate_recordtype: alternateContactRecordType?.Name,
+            _bap_alternate_recordtype: Alternate_Applicant__r?.Record_Type_Name__c, // prettier-ignore
             _bap_alternate_fname: Alternate_Applicant__r?.FirstName,
             _bap_alternate_lname: Alternate_Applicant__r?.LastName,
             _bap_alternate_title: Alternate_Applicant__r?.Title,
@@ -762,7 +745,7 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
             },
             _bap_district_self_certify: Self_Certification_Category__c,
             _bap_district_contact_id: School_District_Contact__r?.Id,
-            _bap_district_contact_recordtype: districtContactRecordType?.Name || "", // prettier-ignore
+            _bap_district_contact_recordtype: School_District_Contact__r?.Record_Type_Name__c, // prettier-ignore
             _bap_district_contact_fname: School_District_Contact__r?.FirstName,
             _bap_district_contact_lname: School_District_Contact__r?.LastName,
             _bap_district_contact_title: School_District_Contact__r?.Title,

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -644,14 +644,6 @@ function fetchDataForPRFSubmission({ rebateYear, req, res }) {
               item.Relationship_Type__c === newBusOwnerType,
           );
 
-          // const existingOwnerRecordType = frf2024ContactsRecordTypesQuery.find(
-          //   (item) => item.Id === existingOwnerRecord?.Contact__r?.RecordTypeId,
-          // );
-
-          // const newOwnerRecordType = frf2024ContactsRecordTypesQuery.find(
-          //   (item) => item.Id === newOwnerRecord?.Contact__r?.RecordTypeId,
-          // );
-
           return {
             bus_number: Rebate_Item_num__c,
             bus_existing_owner: {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-513

## Main Changes:
* Follow up to #535 after receiving guidance from the BAP team: simplifies the 2024 FRF submission BAP queries to get each contact's Salesforce record type name via the `Record_Type_Name__c` custom field, instead of fetching the contact's `RecordTypeId` and the additional query to get all record type names associated with all record type ids for all contacts within the submission.

## Steps To Test:
Same steps as before:
1. Navigate to the dashboard.
2. Create a new 2024 PRF submission.
3. Ensure the submission data includes any BAP contact's record types in the submission data.
4. Any further testing of form logic can be done as well (e.g., if contact fields are editable) but that's outside the scope of the wrapper app's code – the wrapper app just provides the Salesforce record types for each contact.

