### PR TITLE
Feature/add submission download functionality

### DIFF
--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -19,6 +19,7 @@ import {
   useContentData,
   useConfigData,
   useBapSamData,
+  useSubmissionPDFQuery,
   useSubmissionsQueries,
   useSubmissions,
   submissionNeedsEdits,
@@ -27,7 +28,7 @@ import {
   entityHasDebtSubjectToOffset,
   getUserInfo,
 } from "@/utilities";
-import { Loading } from "@/components/loading";
+import { Loading, LoadingButtonIcon } from "@/components/loading";
 import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useNotificationsActions } from "@/contexts/notifications";
@@ -40,6 +41,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2022/crf-submission"] });
+    queryClient.resetQueries({ queryKey: ["formio/2022/crf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2022/crf-submission/${rebateId}`;
@@ -128,6 +130,12 @@ function CloseOutRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const pdfQuery = useSubmissionPDFQuery({
+    rebateYear: "2022",
+    formType: "crf",
+    mongoId: submission?._id || "",
+  });
 
   /**
    * Stores when data is being posted to the server, so a loading overlay can
@@ -242,6 +250,30 @@ function CloseOutRequestForm(props: { email: string }) {
           </div>
         </li>
       </ul>
+
+      {submission?._id && (
+        <p>
+          <button
+            className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+            type="button"
+            disabled={pdfQuery.isFetching}
+            onClick={(_ev) => pdfQuery.refetch()}
+          >
+            <span className="display-flex flex-align-center">
+              <svg
+                className="usa-icon"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
+              >
+                <use href={`${icons}#arrow_downward`} />
+              </svg>
+              <span className="margin-left-1">Download PDF</span>
+              {pdfQuery.isFetching && <LoadingButtonIcon position="end" />}
+            </span>
+          </button>
+        </p>
+      )}
 
       <Dialog as="div" open={dataIsPosting.current} onClose={(_value) => {}}>
         <div className={clsx("tw-fixed tw-inset-0 tw-bg-black/30")} />

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -19,6 +19,7 @@ import {
   useContentData,
   useConfigData,
   useBapSamData,
+  useSubmissionPDFQuery,
   useSubmissionsQueries,
   useSubmissions,
   submissionNeedsEdits,
@@ -27,7 +28,7 @@ import {
   entityHasDebtSubjectToOffset,
   getUserInfo,
 } from "@/utilities";
-import { Loading } from "@/components/loading";
+import { Loading, LoadingButtonIcon } from "@/components/loading";
 import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useDialogActions } from "@/contexts/dialog";
@@ -41,6 +42,7 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2022/frf-submission"] });
+    queryClient.resetQueries({ queryKey: ["formio/2022/frf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2022/frf-submission/${mongoId}`;
@@ -141,6 +143,12 @@ function FundingRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const pdfQuery = useSubmissionPDFQuery({
+    rebateYear: "2022",
+    formType: "frf",
+    mongoId,
+  });
 
   /**
    * Stores when data is being posted to the server, so a loading overlay can
@@ -390,6 +398,28 @@ function FundingRequestForm(props: { email: string }) {
           </li>
         )}
       </ul>
+
+      <p>
+        <button
+          className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+          type="button"
+          disabled={pdfQuery.isFetching}
+          onClick={(_ev) => pdfQuery.refetch()}
+        >
+          <span className="display-flex flex-align-center">
+            <svg
+              className="usa-icon"
+              aria-hidden="true"
+              focusable="false"
+              role="img"
+            >
+              <use href={`${icons}#arrow_downward`} />
+            </svg>
+            <span className="margin-left-1">Download PDF</span>
+            {pdfQuery.isFetching && <LoadingButtonIcon position="end" />}
+          </span>
+        </button>
+      </p>
 
       <Dialog as="div" open={dataIsPosting.current} onClose={(_value) => {}}>
         <div className={clsx("tw-fixed tw-inset-0 tw-bg-black/30")} />

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -19,6 +19,7 @@ import {
   useContentData,
   useConfigData,
   useBapSamData,
+  useSubmissionPDFQuery,
   useSubmissionsQueries,
   useSubmissions,
   submissionNeedsEdits,
@@ -27,7 +28,7 @@ import {
   entityHasDebtSubjectToOffset,
   getUserInfo,
 } from "@/utilities";
-import { Loading } from "@/components/loading";
+import { Loading, LoadingButtonIcon } from "@/components/loading";
 import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useDialogActions } from "@/contexts/dialog";
@@ -41,6 +42,7 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2023/frf-submission"] });
+    queryClient.resetQueries({ queryKey: ["formio/2023/frf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2023/frf-submission/${mongoId}`;
@@ -127,6 +129,12 @@ function FundingRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const pdfQuery = useSubmissionPDFQuery({
+    rebateYear: "2023",
+    formType: "frf",
+    mongoId,
+  });
 
   /**
    * Stores when data is being posted to the server, so a loading overlay can
@@ -376,6 +384,28 @@ function FundingRequestForm(props: { email: string }) {
           </li>
         )}
       </ul>
+
+      <p>
+        <button
+          className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+          type="button"
+          disabled={pdfQuery.isFetching}
+          onClick={(_ev) => pdfQuery.refetch()}
+        >
+          <span className="display-flex flex-align-center">
+            <svg
+              className="usa-icon"
+              aria-hidden="true"
+              focusable="false"
+              role="img"
+            >
+              <use href={`${icons}#arrow_downward`} />
+            </svg>
+            <span className="margin-left-1">Download PDF</span>
+            {pdfQuery.isFetching && <LoadingButtonIcon position="end" />}
+          </span>
+        </button>
+      </p>
 
       <Dialog as="div" open={dataIsPosting.current} onClose={(_value) => {}}>
         <div className={clsx("tw-fixed tw-inset-0 tw-bg-black/30")} />

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -19,6 +19,7 @@ import {
   useContentData,
   useConfigData,
   useBapSamData,
+  useSubmissionPDFQuery,
   useSubmissionsQueries,
   useSubmissions,
   submissionNeedsEdits,
@@ -27,7 +28,7 @@ import {
   entityHasDebtSubjectToOffset,
   getUserInfo,
 } from "@/utilities";
-import { Loading } from "@/components/loading";
+import { Loading, LoadingButtonIcon } from "@/components/loading";
 import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useDialogActions } from "@/contexts/dialog";
@@ -41,6 +42,7 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2024/frf-submission"] });
+    queryClient.resetQueries({ queryKey: ["formio/2024/frf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2024/frf-submission/${mongoId}`;
@@ -127,6 +129,12 @@ function FundingRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const pdfQuery = useSubmissionPDFQuery({
+    rebateYear: "2024",
+    formType: "frf",
+    mongoId,
+  });
 
   /**
    * Stores when data is being posted to the server, so a loading overlay can
@@ -376,6 +384,28 @@ function FundingRequestForm(props: { email: string }) {
           </li>
         )}
       </ul>
+
+      <p>
+        <button
+          className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+          type="button"
+          disabled={pdfQuery.isFetching}
+          onClick={(_ev) => pdfQuery.refetch()}
+        >
+          <span className="display-flex flex-align-center">
+            <svg
+              className="usa-icon"
+              aria-hidden="true"
+              focusable="false"
+              role="img"
+            >
+              <use href={`${icons}#arrow_downward`} />
+            </svg>
+            <span className="margin-left-1">Download PDF</span>
+            {pdfQuery.isFetching && <LoadingButtonIcon position="end" />}
+          </span>
+        </button>
+      </p>
 
       <Dialog as="div" open={dataIsPosting.current} onClose={(_value) => {}}>
         <div className={clsx("tw-fixed tw-inset-0 tw-bg-black/30")} />

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -19,6 +19,7 @@ import {
   useContentData,
   useConfigData,
   useBapSamData,
+  useSubmissionPDFQuery,
   useSubmissionsQueries,
   useSubmissions,
   submissionNeedsEdits,
@@ -27,7 +28,7 @@ import {
   entityHasDebtSubjectToOffset,
   getUserInfo,
 } from "@/utilities";
-import { Loading } from "@/components/loading";
+import { Loading, LoadingButtonIcon } from "@/components/loading";
 import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useNotificationsActions } from "@/contexts/notifications";
@@ -40,6 +41,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2022/prf-submission"] });
+    queryClient.resetQueries({ queryKey: ["formio/2022/prf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2022/prf-submission/${rebateId}`;
@@ -128,6 +130,12 @@ function PaymentRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const pdfQuery = useSubmissionPDFQuery({
+    rebateYear: "2022",
+    formType: "prf",
+    mongoId: submission?._id || "",
+  });
 
   /**
    * Stores when data is being posted to the server, so a loading overlay can
@@ -263,6 +271,30 @@ function PaymentRequestForm(props: { email: string }) {
           </div>
         </li>
       </ul>
+
+      {submission?._id && (
+        <p>
+          <button
+            className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+            type="button"
+            disabled={pdfQuery.isFetching}
+            onClick={(_ev) => pdfQuery.refetch()}
+          >
+            <span className="display-flex flex-align-center">
+              <svg
+                className="usa-icon"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
+              >
+                <use href={`${icons}#arrow_downward`} />
+              </svg>
+              <span className="margin-left-1">Download PDF</span>
+              {pdfQuery.isFetching && <LoadingButtonIcon position="end" />}
+            </span>
+          </button>
+        </p>
+      )}
 
       <Dialog as="div" open={dataIsPosting.current} onClose={(_value) => {}}>
         <div className={clsx("tw-fixed tw-inset-0 tw-bg-black/30")} />

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -19,6 +19,7 @@ import {
   useContentData,
   useConfigData,
   useBapSamData,
+  useSubmissionPDFQuery,
   useSubmissionsQueries,
   useSubmissions,
   submissionNeedsEdits,
@@ -27,7 +28,7 @@ import {
   entityHasDebtSubjectToOffset,
   getUserInfo,
 } from "@/utilities";
-import { Loading } from "@/components/loading";
+import { Loading, LoadingButtonIcon } from "@/components/loading";
 import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useNotificationsActions } from "@/contexts/notifications";
@@ -40,6 +41,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2023/prf-submission"] });
+    queryClient.resetQueries({ queryKey: ["formio/2023/prf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2023/prf-submission/${rebateId}`;
@@ -128,6 +130,12 @@ function PaymentRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const pdfQuery = useSubmissionPDFQuery({
+    rebateYear: "2023",
+    formType: "prf",
+    mongoId: submission?._id || "",
+  });
 
   /**
    * Stores when data is being posted to the server, so a loading overlay can
@@ -261,6 +269,30 @@ function PaymentRequestForm(props: { email: string }) {
           </div>
         </li>
       </ul>
+
+      {submission?._id && (
+        <p>
+          <button
+            className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+            type="button"
+            disabled={pdfQuery.isFetching}
+            onClick={(_ev) => pdfQuery.refetch()}
+          >
+            <span className="display-flex flex-align-center">
+              <svg
+                className="usa-icon"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
+              >
+                <use href={`${icons}#arrow_downward`} />
+              </svg>
+              <span className="margin-left-1">Download PDF</span>
+              {pdfQuery.isFetching && <LoadingButtonIcon position="end" />}
+            </span>
+          </button>
+        </p>
+      )}
 
       <Dialog as="div" open={dataIsPosting.current} onClose={(_value) => {}}>
         <div className={clsx("tw-fixed tw-inset-0 tw-bg-black/30")} />

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -19,6 +19,7 @@ import {
   useContentData,
   useConfigData,
   useBapSamData,
+  useSubmissionPDFQuery,
   useSubmissionsQueries,
   useSubmissions,
   submissionNeedsEdits,
@@ -27,7 +28,7 @@ import {
   entityHasDebtSubjectToOffset,
   getUserInfo,
 } from "@/utilities";
-import { Loading } from "@/components/loading";
+import { Loading, LoadingButtonIcon } from "@/components/loading";
 import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useNotificationsActions } from "@/contexts/notifications";
@@ -40,6 +41,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2024/prf-submission"] });
+    queryClient.resetQueries({ queryKey: ["formio/2024/prf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2024/prf-submission/${rebateId}`;
@@ -128,6 +130,12 @@ function PaymentRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const pdfQuery = useSubmissionPDFQuery({
+    rebateYear: "2024",
+    formType: "prf",
+    mongoId: submission?._id || "",
+  });
 
   /**
    * Stores when data is being posted to the server, so a loading overlay can
@@ -261,6 +269,30 @@ function PaymentRequestForm(props: { email: string }) {
           </div>
         </li>
       </ul>
+
+      {submission?._id && (
+        <p>
+          <button
+            className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+            type="button"
+            disabled={pdfQuery.isFetching}
+            onClick={(_ev) => pdfQuery.refetch()}
+          >
+            <span className="display-flex flex-align-center">
+              <svg
+                className="usa-icon"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
+              >
+                <use href={`${icons}#arrow_downward`} />
+              </svg>
+              <span className="margin-left-1">Download PDF</span>
+              {pdfQuery.isFetching && <LoadingButtonIcon position="end" />}
+            </span>
+          </button>
+        </p>
+      )}
 
       <Dialog as="div" open={dataIsPosting.current} onClose={(_value) => {}}>
         <div className={clsx("tw-fixed tw-inset-0 tw-bg-black/30")} />

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -10,6 +10,7 @@ import { useSearchParams } from "react-router-dom";
 // ---
 import {
   type RebateYear,
+  type FormType,
   type Content,
   type UserData,
   type ConfigData,
@@ -185,6 +186,32 @@ export function useBapSamQuery() {
 export function useBapSamData() {
   const queryClient = useQueryClient();
   return queryClient.getQueryData<BapSamData>(["bap/sam"]);
+}
+
+/** Custom hook to fetch a PDF of a form submission from Formio. */
+export function useSubmissionPDFQuery(options: {
+  rebateYear: RebateYear;
+  formType: FormType;
+  mongoId: string | undefined;
+}) {
+  const { rebateYear, formType, mongoId } = options;
+
+  return useQuery({
+    queryKey: [`formio/${rebateYear}/${formType}-pdf`, { id: mongoId }],
+    queryFn: () => {
+      const url = `${serverUrl}/api/formio/${rebateYear}/pdf/${formType}/${mongoId}`;
+      return getData<string>(url);
+    },
+    onSuccess: (res) => {
+      const link = document.createElement("a");
+      link.setAttribute("href", `data:application/pdf;base64,${res}`);
+      link.setAttribute("download", `${mongoId}.pdf`);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    },
+    enabled: false,
+  });
 }
 
 /** Custom hook to fetch Change Request form submissions from Formio. */

--- a/app/server/app/routes/formio2022.js
+++ b/app/server/app/routes/formio2022.js
@@ -9,6 +9,8 @@ const {
   uploadS3FileMetadata,
   downloadS3FileMetadata,
   //
+  fetchSubmissionPDF,
+  //
   fetchFRFSubmissions,
   createFRFSubmission,
   fetchFRFSubmission,
@@ -48,6 +50,11 @@ router.post(
     uploadS3FileMetadata({ rebateYear, req, res });
   },
 );
+
+// --- get a PDF of a 2022 form submission from Formio
+router.get("/pdf/:formType/:mongoId", fetchBapComboKeys, (req, res) => {
+  fetchSubmissionPDF({ rebateYear, req, res });
+});
 
 // --- get user's 2022 FRF submissions from Formio
 router.get("/frf-submissions", fetchBapComboKeys, (req, res) => {

--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -11,6 +11,8 @@ const {
   uploadS3FileMetadata,
   downloadS3FileMetadata,
   //
+  fetchSubmissionPDF,
+  //
   fetchFRFSubmissions,
   createFRFSubmission,
   fetchFRFSubmission,
@@ -60,6 +62,11 @@ router.post(
     uploadS3FileMetadata({ rebateYear, req, res });
   },
 );
+
+// --- get a PDF of a 2023 form submission from Formio
+router.get("/pdf/:formType/:mongoId", fetchBapComboKeys, (req, res) => {
+  fetchSubmissionPDF({ rebateYear, req, res });
+});
 
 // --- get user's 2023 FRF submissions from Formio
 router.get("/frf-submissions", fetchBapComboKeys, (req, res) => {

--- a/app/server/app/routes/formio2024.js
+++ b/app/server/app/routes/formio2024.js
@@ -11,6 +11,8 @@ const {
   uploadS3FileMetadata,
   downloadS3FileMetadata,
   //
+  fetchSubmissionPDF,
+  //
   fetchFRFSubmissions,
   createFRFSubmission,
   fetchFRFSubmission,
@@ -60,6 +62,11 @@ router.post(
     uploadS3FileMetadata({ rebateYear, req, res });
   },
 );
+
+// --- get a PDF of a 2024 form submission from Formio
+router.get("/pdf/:formType/:mongoId", fetchBapComboKeys, (req, res) => {
+  fetchSubmissionPDF({ rebateYear, req, res });
+});
 
 // --- get user's 2024 FRF submissions from Formio
 router.get("/frf-submissions", fetchBapComboKeys, (req, res) => {

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -373,6 +373,27 @@
         }
       }
     },
+    "/api/formio/2022/pdf/{formType}/{mongoId}": {
+      "get": {
+        "summary": "Download a PDF of a 2022 form submission.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/formType"
+          },
+          {
+            "$ref": "#/components/parameters/mongoId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
     "/api/formio/2022/frf-submissions": {
       "get": {
         "summary": "Get user's 2022 FRF submissions from Formio.",
@@ -732,6 +753,27 @@
           },
           {
             "$ref": "#/components/parameters/comboKey"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/formio/2023/pdf/{formType}/{mongoId}": {
+      "get": {
+        "summary": "Download a PDF of a 2023 form submission.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/formType"
+          },
+          {
+            "$ref": "#/components/parameters/mongoId"
           }
         ],
         "responses": {
@@ -1104,6 +1146,27 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/formio/2024/pdf/{formType}/{mongoId}": {
+      "get": {
+        "summary": "Download a PDF of a 2024 form submission.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/formType"
+          },
+          {
+            "$ref": "#/components/parameters/mongoId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }


### PR DESCRIPTION
## Related Issues:
* CSBAPP-515

## Main Changes:
Allows users to download PDFs of their submissions.

## Steps To Test:
1. Navigate to the dashboard.
2. Click on any submission – works for both drafts and submitted submissions, so click either the "Edit" or "View" button.
3. When on the submission page, scroll up and click the "Download PDF" button to download a PDF of the submission.
4. Repeat test for all forms.

