### PR TITLE
Feature/update bap connection error handling

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -1927,13 +1927,12 @@ function verifyBapConnection(req, { name, args }) {
       const logMessage = `BAP Error: ${err}.`;
       log({ level: "error", message: logMessage, req, otherInfo: err });
 
-      // TODO: Handle the following error:
-      // Error: Unable to refresh session due to: No refresh token found in the connection.
+      const errorMessage = err?.message || err;
 
-      if (err?.includes("No refresh token found in the connection.")) {
+      if (errorMessage?.includes("No refresh token found in the connection")) {
         log({ level: "info", message: "Re-establishing BAP connection.", req });
 
-        // Re-establish the BAP connection.
+        return setupConnection(req).then(() => callback());
       }
 
       throw err;


### PR DESCRIPTION
## Related Issues:
* CSBAPP-491

## Main Changes:
* Follow up to #517 – Update verifyBapConnection() to re-establish BAP connection if error message indicates no refresh token was found in the connection.

## Steps To Test:
1. As before, navigate the app normally. Monitor the the logs to see if the logs capture when the BAP connection is re-established.
