### PR TITLE
Feature/re add formio private repo

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -74,6 +74,7 @@ jobs:
       FORMIO_BASE_URL: ${{ secrets.FORMIO_BASE_URL }}
       FORMIO_PROJECT_NAME: ${{ secrets.FORMIO_PROJECT_NAME }}
       FORMIO_API_KEY: ${{ secrets.FORMIO_API_KEY }}
+      FORMIO_PKG_AUTH_TOKEN: ${{ secrets.FORMIO_PKG_AUTH_TOKEN }}
       FORMIO_PREMIUM_KEY: ${{ secrets.FORMIO_PREMIUM_KEY }}
       BAP_REST_API_VERSION: ${{ secrets.BAP_REST_API_VERSION }}
       BAP_CLIENT_ID: ${{ secrets.BAP_CLIENT_ID }}
@@ -101,6 +102,10 @@ jobs:
           path: ~/client/.npm
           key: v1-npm-client-deps-${{ hashFiles('**/client/package-lock.json') }}
           restore-keys: v1-npm-client-deps-
+
+      - name: Add Formio private package repo auth token
+        run: echo "//pkg.form.io/:_authToken=${FORMIO_PKG_AUTH_TOKEN}" > .npmrc
+        working-directory: app/client
 
       - name: Install client app dependencies
         run: npm install

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,6 +26,7 @@ jobs:
       SERVER_BASE_PATH: /csb
       FORMIO_BASE_URL: ${{ secrets.FORMIO_BASE_URL }}
       FORMIO_PROJECT_NAME: ${{ secrets.FORMIO_PROJECT_NAME }}
+      FORMIO_PKG_AUTH_TOKEN: ${{ secrets.FORMIO_PKG_AUTH_TOKEN }}
       FORMIO_PREMIUM_KEY: ${{ secrets.FORMIO_PREMIUM_KEY }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -54,6 +55,10 @@ jobs:
           path: ~/client/.npm
           key: v1-npm-client-deps-${{ hashFiles('**/client/package-lock.json') }}
           restore-keys: v1-npm-client-deps-
+
+      - name: Add Formio private package repo auth token
+        run: echo "//pkg.form.io/:_authToken=${FORMIO_PKG_AUTH_TOKEN}" > .npmrc
+        working-directory: app/client
 
       - name: Install client app dependencies
         run: npm install

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -74,6 +74,7 @@ jobs:
       FORMIO_BASE_URL: ${{ secrets.FORMIO_BASE_URL }}
       FORMIO_PROJECT_NAME: ${{ secrets.FORMIO_PROJECT_NAME }}
       FORMIO_API_KEY: ${{ secrets.FORMIO_API_KEY }}
+      FORMIO_PKG_AUTH_TOKEN: ${{ secrets.FORMIO_PKG_AUTH_TOKEN }}
       FORMIO_PREMIUM_KEY: ${{ secrets.FORMIO_PREMIUM_KEY }}
       BAP_REST_API_VERSION: ${{ secrets.BAP_REST_API_VERSION }}
       BAP_CLIENT_ID: ${{ secrets.BAP_CLIENT_ID }}
@@ -101,6 +102,10 @@ jobs:
           path: ~/client/.npm
           key: v1-npm-client-deps-${{ hashFiles('**/client/package-lock.json') }}
           restore-keys: v1-npm-client-deps-
+
+      - name: Add Formio private package repo auth token
+        run: echo "//pkg.form.io/:_authToken=${FORMIO_PKG_AUTH_TOKEN}" > .npmrc
+        working-directory: app/client
 
       - name: Install client app dependencies
         run: npm install


### PR DESCRIPTION
## Related Issues:
* CSBAPP-499

## Main Changes:
Follow-up to #548 – Update GitHub Actions workflows to add back Formio private package repo, so the GitHub Actions cache step succeeds.

## Steps To Test:
1. See #548

## TODO:
- [ ] See #548
