### PR TITLE
Feature/update 2022 frf posted data

### DIFF
--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -73,13 +73,10 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
         const data = { ...res.submission?.data };
 
-        // remove `ncesDataSource` and `ncesDataLookup` fields
+        // remove `ncesDataSource` field
         // (https://eslint.org/docs/latest/rules/no-prototype-builtins)
         if (Object.prototype.hasOwnProperty.call(data, "ncesDataSource")) {
           delete data.ncesDataSource;
-        }
-        if (Object.prototype.hasOwnProperty.call(data, "ncesDataLookup")) {
-          delete data.ncesDataLookup;
         }
 
         return Promise.resolve({
@@ -469,13 +466,10 @@ function FundingRequestForm(props: { email: string }) {
 
             const data = { ...onSubmitParam.data };
 
-            // remove `ncesDataSource` and `ncesDataLookup` fields
+            // remove `ncesDataSource` field
             // (https://eslint.org/docs/latest/rules/no-prototype-builtins)
             if (Object.prototype.hasOwnProperty.call(data, "ncesDataSource")) {
               delete data.ncesDataSource;
-            }
-            if (Object.prototype.hasOwnProperty.call(data, "ncesDataLookup")) {
-              delete data.ncesDataLookup;
             }
 
             const updatedSubmission = {
@@ -567,13 +561,10 @@ function FundingRequestForm(props: { email: string }) {
 
             const data = { ...onNextPageParams.submission.data };
 
-            // remove `ncesDataSource` and `ncesDataLookup` fields
+            // remove `ncesDataSource` field
             // (https://eslint.org/docs/latest/rules/no-prototype-builtins)
             if (Object.prototype.hasOwnProperty.call(data, "ncesDataSource")) {
               delete data.ncesDataSource;
-            }
-            if (Object.prototype.hasOwnProperty.call(data, "ncesDataLookup")) {
-              delete data.ncesDataLookup;
             }
 
             // "dirty check" – don't post an update if no changes have been made


### PR DESCRIPTION
## Related Issues:
* CSBAPP-499

## Main Changes:
Follow up to #548 – Applies an update to the 2022 FRF to pass the `ncesDataSource` field, as it's now needed due to the formiojs update (along with a calculated value change in the Formio form for that field)

## Steps To Test:
1. Navigate to a 2022 FRF draft.
2. Advance through the form, and enter in an NCES ID.
3. Ensure the school district fields populate (as they did before).
4. Continue advancing through the form, and ensure you're able to submit.
