### PR TITLE
Feature/fix helpdesk frf rebate id search

### DIFF
--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -276,8 +276,8 @@ router.get("/formio/submission/:rebateYear/:formType/:id", async (req, res) => {
     result.formio = await fetchFormioSubmissionData({
       formioFormUrl,
       rebateIdFieldName,
-      rebateId,
-      mongoId,
+      rebateId: null,
+      mongoId: result.bap.mongoId,
       req,
     });
   }


### PR DESCRIPTION
## Related Issues:
* CSBAPP-487

## Main Changes:
Follow-up to #547: Update helpdesk API to properly search for FRF submissions via CSB Rebate Id (NOTE: the commit message was incorrect – this would only occur if the BAP's ETL has already picked up the submission, as that's the only way it would be given a CSB Rebate Id).

## Steps To Test:
1. Navigate to the helpdesk page.
2. Search for a FRF submission via it's CSB Rebate Id.
3. Ensure you're shown the form submission.
