### PR TITLE
Feature/reorder frf logic check

### DIFF
--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -204,7 +204,31 @@ function FundingRequestForm(props: { email: string }) {
         bap: rebate.frf.bap,
       });
 
-  const frfNeedsEditsAndPRFExists = frfNeedsEdits && !!rebate?.prf.formio;
+  const frfSubmissionPeriodOpen = configData.submissionPeriodOpen["2022"].frf;
+
+  const formIsReadOnly =
+    (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
+    !frfNeedsEdits;
+
+  /** matched SAM.gov entity for the Application submission */
+  const entity = bapSamData.entities.find((entity) => {
+    const { ENTITY_COMBO_KEY__c } = entity;
+    return ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key;
+  });
+
+  if (!entity) {
+    return <Message type="error" text={messages.formSubmissionError} />;
+  }
+
+  const isActive = entityIsActive(entity);
+  const hasExclusionStatus = entityHasExclusionStatus(entity);
+  const hasDebtSubjectToOffset = entityHasDebtSubjectToOffset(entity);
+
+  if (!isActive || hasExclusionStatus || hasDebtSubjectToOffset) {
+    return <Message type="error" text={messages.bapSamIneligible} />;
+  }
+
+  const { title, name } = getUserInfo(email, entity);
 
   /**
    * NOTE: If the FRF submission needs edits and there's a corresponding PRF
@@ -212,6 +236,8 @@ function FundingRequestForm(props: { email: string }) {
    * PRF submission, as it's data will no longer valid when the FRF submission's
    * data is changed.
    */
+  const frfNeedsEditsAndPRFExists = frfNeedsEdits && !!rebate?.prf.formio;
+
   if (frfNeedsEditsAndPRFExists) {
     displayDialog({
       dismissable: true,
@@ -325,32 +351,6 @@ function FundingRequestForm(props: { email: string }) {
 
     return null;
   }
-
-  const frfSubmissionPeriodOpen = configData.submissionPeriodOpen["2022"].frf;
-
-  const formIsReadOnly =
-    (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
-    !frfNeedsEdits;
-
-  /** matched SAM.gov entity for the Application submission */
-  const entity = bapSamData.entities.find((entity) => {
-    const { ENTITY_COMBO_KEY__c } = entity;
-    return ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key;
-  });
-
-  if (!entity) {
-    return <Message type="error" text={messages.formSubmissionError} />;
-  }
-
-  const isActive = entityIsActive(entity);
-  const hasExclusionStatus = entityHasExclusionStatus(entity);
-  const hasDebtSubjectToOffset = entityHasDebtSubjectToOffset(entity);
-
-  if (!isActive || hasExclusionStatus || hasDebtSubjectToOffset) {
-    return <Message type="error" text={messages.bapSamIneligible} />;
-  }
-
-  const { title, name } = getUserInfo(email, entity);
 
   return (
     <div className="margin-top-2">

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -192,7 +192,31 @@ function FundingRequestForm(props: { email: string }) {
         bap: rebate.frf.bap,
       });
 
-  const frfNeedsEditsAndPRFExists = frfNeedsEdits && !!rebate?.prf.formio;
+  const frfSubmissionPeriodOpen = configData.submissionPeriodOpen["2023"].frf;
+
+  const formIsReadOnly =
+    (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
+    !frfNeedsEdits;
+
+  /** matched SAM.gov entity for the Application submission */
+  const entity = bapSamData.entities.find((entity) => {
+    const { ENTITY_COMBO_KEY__c } = entity;
+    return ENTITY_COMBO_KEY__c === submission.data._bap_entity_combo_key;
+  });
+
+  if (!entity) {
+    return <Message type="error" text={messages.formSubmissionError} />;
+  }
+
+  const isActive = entityIsActive(entity);
+  const hasExclusionStatus = entityHasExclusionStatus(entity);
+  const hasDebtSubjectToOffset = entityHasDebtSubjectToOffset(entity);
+
+  if (!isActive || hasExclusionStatus || hasDebtSubjectToOffset) {
+    return <Message type="error" text={messages.bapSamIneligible} />;
+  }
+
+  const { title, name } = getUserInfo(email, entity);
 
   /**
    * NOTE: If the FRF submission needs edits and there's a corresponding PRF
@@ -200,6 +224,8 @@ function FundingRequestForm(props: { email: string }) {
    * PRF submission, as it's data will no longer valid when the FRF submission's
    * data is changed.
    */
+  const frfNeedsEditsAndPRFExists = frfNeedsEdits && !!rebate?.prf.formio;
+
   if (frfNeedsEditsAndPRFExists) {
     displayDialog({
       dismissable: true,
@@ -313,32 +339,6 @@ function FundingRequestForm(props: { email: string }) {
 
     return null;
   }
-
-  const frfSubmissionPeriodOpen = configData.submissionPeriodOpen["2023"].frf;
-
-  const formIsReadOnly =
-    (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
-    !frfNeedsEdits;
-
-  /** matched SAM.gov entity for the Application submission */
-  const entity = bapSamData.entities.find((entity) => {
-    const { ENTITY_COMBO_KEY__c } = entity;
-    return ENTITY_COMBO_KEY__c === submission.data._bap_entity_combo_key;
-  });
-
-  if (!entity) {
-    return <Message type="error" text={messages.formSubmissionError} />;
-  }
-
-  const isActive = entityIsActive(entity);
-  const hasExclusionStatus = entityHasExclusionStatus(entity);
-  const hasDebtSubjectToOffset = entityHasDebtSubjectToOffset(entity);
-
-  if (!isActive || hasExclusionStatus || hasDebtSubjectToOffset) {
-    return <Message type="error" text={messages.bapSamIneligible} />;
-  }
-
-  const { title, name } = getUserInfo(email, entity);
 
   return (
     <div className="margin-top-2">

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -192,7 +192,31 @@ function FundingRequestForm(props: { email: string }) {
         bap: rebate.frf.bap,
       });
 
-  const frfNeedsEditsAndPRFExists = frfNeedsEdits && !!rebate?.prf.formio;
+  const frfSubmissionPeriodOpen = configData.submissionPeriodOpen["2024"].frf;
+
+  const formIsReadOnly =
+    (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
+    !frfNeedsEdits;
+
+  /** matched SAM.gov entity for the Application submission */
+  const entity = bapSamData.entities.find((entity) => {
+    const { ENTITY_COMBO_KEY__c } = entity;
+    return ENTITY_COMBO_KEY__c === submission.data._bap_entity_combo_key;
+  });
+
+  if (!entity) {
+    return <Message type="error" text={messages.formSubmissionError} />;
+  }
+
+  const isActive = entityIsActive(entity);
+  const hasExclusionStatus = entityHasExclusionStatus(entity);
+  const hasDebtSubjectToOffset = entityHasDebtSubjectToOffset(entity);
+
+  if (!isActive || hasExclusionStatus || hasDebtSubjectToOffset) {
+    return <Message type="error" text={messages.bapSamIneligible} />;
+  }
+
+  const { title, name } = getUserInfo(email, entity);
 
   /**
    * NOTE: If the FRF submission needs edits and there's a corresponding PRF
@@ -200,6 +224,8 @@ function FundingRequestForm(props: { email: string }) {
    * PRF submission, as it's data will no longer valid when the FRF submission's
    * data is changed.
    */
+  const frfNeedsEditsAndPRFExists = frfNeedsEdits && !!rebate?.prf.formio;
+
   if (frfNeedsEditsAndPRFExists) {
     displayDialog({
       dismissable: true,
@@ -313,32 +339,6 @@ function FundingRequestForm(props: { email: string }) {
 
     return null;
   }
-
-  const frfSubmissionPeriodOpen = configData.submissionPeriodOpen["2024"].frf;
-
-  const formIsReadOnly =
-    (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
-    !frfNeedsEdits;
-
-  /** matched SAM.gov entity for the Application submission */
-  const entity = bapSamData.entities.find((entity) => {
-    const { ENTITY_COMBO_KEY__c } = entity;
-    return ENTITY_COMBO_KEY__c === submission.data._bap_entity_combo_key;
-  });
-
-  if (!entity) {
-    return <Message type="error" text={messages.formSubmissionError} />;
-  }
-
-  const isActive = entityIsActive(entity);
-  const hasExclusionStatus = entityHasExclusionStatus(entity);
-  const hasDebtSubjectToOffset = entityHasDebtSubjectToOffset(entity);
-
-  if (!isActive || hasExclusionStatus || hasDebtSubjectToOffset) {
-    return <Message type="error" text={messages.bapSamIneligible} />;
-  }
-
-  const { title, name } = getUserInfo(email, entity);
 
   return (
     <div className="margin-top-2">


### PR DESCRIPTION
## Related Issues:
* CSBAPP-371

## Main Changes:
Follow-up to #460: Move 'SAM.gov active, exclusion status, and debt subject to offset' check above 'FRF needs edits and a PRF exists' logic in FRF components.

## Steps To Test:
1. Create a FRF and PRF.
2. Request the BAP team to set the FRF's status to "Edits Requested"
3. Request the BAP team change the FRF and PRF's SAM.gov entity exclusion status or debt subject to offset flag for that SAM.gov entity record in the BAP.
4. Attempt to edit the FRF and ensure the "Your SAM.gov account is either currently not active or ineligible due to an exclusion status or a debt subject to offset. Please visit SAM.gov to resolve any issues and regain access to this submission." message is displayed and not the confirmation popup indicating the related PRF will need to be deleted.
5. Once the exclusion/debt subject to offset status is fixed (e.g. ask the BAP team to change the SAM.gov entity's statuses back), when you attempt to edit the FRF again, you should see the confirmation popup again indicating the related PRF will need to be deleted.