### PR TITLE
Feature/update rebate year context state logic

### DIFF
--- a/app/client/src/contexts/rebateYear.tsx
+++ b/app/client/src/contexts/rebateYear.tsx
@@ -15,7 +15,7 @@ type Props = {
 };
 
 type State = {
-  rebateYear: RebateYear;
+  rebateYear: RebateYear | null;
 };
 
 type Action = {
@@ -45,12 +45,12 @@ function reducer(state: State, action: Action): State {
 }
 
 export function RebateYearProvider({ children }: Props) {
-  // NOTE: current year as initial value – will be re-defined from `/api/config`
-  const date = new Date();
-  const year = date.getFullYear().toString() as RebateYear;
-
+  /**
+   * NOTE: `rebateYear` initialized as null, but will be redefined after the
+   * initial config data fetch (see `useConfigQuery` in `utilities.ts`).
+   */
   const initialState: State = {
-    rebateYear: year,
+    rebateYear: null,
   };
 
   const [state, dispatch] = useReducer(reducer, initialState);

--- a/app/client/src/routes/frfNew.tsx
+++ b/app/client/src/routes/frfNew.tsx
@@ -139,7 +139,7 @@ export function FRFNew() {
    */
   const [postingDataId, setPostingDataId] = useState("0");
 
-  if (!configData || !bapSamData) {
+  if (!configData || !bapSamData || !rebateYear) {
     return <Loading />;
   }
 

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -185,6 +185,10 @@ function ResultTableRow(props: {
     }
   }, [pdfQuery.status, pdfQuery.data, formio._id]);
 
+  if (!rebateYear) {
+    return null;
+  }
+
   const date = formatDate(formio.modified);
   const time = formatTime(formio.modified);
 
@@ -470,7 +474,7 @@ export function Helpdesk() {
     bap: null,
   };
 
-  if (helpdeskAccess === "pending") {
+  if (helpdeskAccess === "pending" || !rebateYear) {
     return <Loading />;
   }
 

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -2204,6 +2204,10 @@ export function Submissions() {
   const { rebateYear } = useRebateYearState();
   const { setRebateYear } = useRebateYearActions();
 
+  if (!rebateYear) {
+    return <Loading />;
+  }
+
   const frfSubmissionPeriodOpen = configData?.submissionPeriodOpen[rebateYear]
     ? configData.submissionPeriodOpen[rebateYear].frf
     : false;

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -37,7 +37,10 @@ import {
   type Rebate2024,
 } from "@/types";
 import { serverUrl, formioBapRebateIdField } from "@/config";
-import { useRebateYearActions } from "@/contexts/rebateYear";
+import {
+  useRebateYearState,
+  useRebateYearActions,
+} from "@/contexts/rebateYear";
 
 /** Formio Change Request submissions by rebate year. */
 /* prettier-ignore */
@@ -152,6 +155,7 @@ export function useHelpdeskAccess() {
 
 /** Custom hook to fetch CSB config and set Formio URLs and rebate year. */
 export function useConfigQuery() {
+  const state = useRebateYearState();
   const { setRebateYear } = useRebateYearActions();
 
   const query = useQuery({
@@ -172,9 +176,15 @@ export function useConfigQuery() {
     }
 
     if (query.status === "success" && rebateYear) {
-      setRebateYear(rebateYear);
+      /**
+       * NOTE: `state.rebateYear` is initialized as null, so only redefine it on
+       * the initial config data fetch.
+       */
+      if (state.rebateYear === null) {
+        setRebateYear(rebateYear);
+      }
     }
-  }, [query.status, query.data, setRebateYear]);
+  }, [query.status, query.data, state.rebateYear, setRebateYear]);
 
   return query;
 }


### PR DESCRIPTION
## Related Issues:
* CSBAPP-499

## Main Changes:
* Another update to #548 – ensures rebate year state behaves as it did before the package updates (is properly set on initial config API fetch, and any time the user changes the rebate year select menu).

## Steps To Test:
1. Navigate to the dashboard.
2. Change the rebate year to something other than 2024 (for example, 2022).
3. Click the "New Application" button and select a SAM.gov entity to start a new application for that rebate year (2022).
4. Ensure the new application is created for that rebate year (2022) and you're redirected to the new submission's page to continue filling out the form.
