### PR TITLE
Feature/add formio s3 delete support

### DIFF
--- a/app/server/app/routes/formio2022.js
+++ b/app/server/app/routes/formio2022.js
@@ -6,8 +6,9 @@ const {
   verifyMongoObjectId,
 } = require("../middleware");
 const {
-  uploadS3FileMetadata,
   downloadS3FileMetadata,
+  uploadS3FileMetadata,
+  deleteS3FileMetadata,
   //
   fetchSubmissionPDF,
   //
@@ -48,6 +49,15 @@ router.post(
   fetchBapComboKeys,
   (req, res) => {
     uploadS3FileMetadata({ rebateYear, req, res });
+  },
+);
+
+// --- delete Formio S3 file metadata
+router.delete(
+  "/s3/:formType/:mongoId/:comboKey/storage/s3",
+  fetchBapComboKeys,
+  (req, res) => {
+    deleteS3FileMetadata({ rebateYear, req, res });
   },
 );
 

--- a/app/server/app/routes/formio2022.js
+++ b/app/server/app/routes/formio2022.js
@@ -6,9 +6,9 @@ const {
   verifyMongoObjectId,
 } = require("../middleware");
 const {
-  downloadS3FileMetadata,
-  uploadS3FileMetadata,
-  deleteS3FileMetadata,
+  downloadFileFromS3,
+  uploadFileToS3,
+  deleteFileFromS3,
   //
   fetchSubmissionPDF,
   //
@@ -34,30 +34,30 @@ const router = express.Router();
 
 router.use(ensureAuthenticated);
 
-// --- download Formio S3 file metadata
+// --- download Formio file attachment from S3
 router.get(
   "/s3/:formType/:mongoId/:comboKey/storage/s3",
   fetchBapComboKeys,
   (req, res) => {
-    downloadS3FileMetadata({ rebateYear, req, res });
+    downloadFileFromS3({ rebateYear, req, res });
   },
 );
 
-// --- upload Formio S3 file metadata
+// --- upload Formio file attachment to S3
 router.post(
   "/s3/:formType/:mongoId/:comboKey/storage/s3",
   fetchBapComboKeys,
   (req, res) => {
-    uploadS3FileMetadata({ rebateYear, req, res });
+    uploadFileToS3({ rebateYear, req, res });
   },
 );
 
-// --- delete Formio S3 file metadata
+// --- delete Formio file attachment from S3
 router.delete(
   "/s3/:formType/:mongoId/:comboKey/storage/s3",
   fetchBapComboKeys,
   (req, res) => {
-    deleteS3FileMetadata({ rebateYear, req, res });
+    deleteFileFromS3({ rebateYear, req, res });
   },
 );
 

--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -8,9 +8,9 @@ const {
 const {
   searchNcesData,
   //
-  downloadS3FileMetadata,
-  uploadS3FileMetadata,
-  deleteS3FileMetadata,
+  downloadFileFromS3,
+  uploadFileToS3,
+  deleteFileFromS3,
   //
   fetchSubmissionPDF,
   //
@@ -46,30 +46,30 @@ router.get("/nces{/:searchText}", (req, res) => {
   searchNcesData({ rebateYear, req, res });
 });
 
-// --- download Formio S3 file metadata
+// --- download Formio file attachment from S3
 router.get(
   "/s3/:formType/:mongoId/:comboKey/storage/s3",
   fetchBapComboKeys,
   (req, res) => {
-    downloadS3FileMetadata({ rebateYear, req, res });
+    downloadFileFromS3({ rebateYear, req, res });
   },
 );
 
-// --- upload Formio S3 file metadata
+// --- upload Formio file attachment to S3
 router.post(
   "/s3/:formType/:mongoId/:comboKey/storage/s3",
   fetchBapComboKeys,
   (req, res) => {
-    uploadS3FileMetadata({ rebateYear, req, res });
+    uploadFileToS3({ rebateYear, req, res });
   },
 );
 
-// --- delete Formio S3 file metadata
+// --- delete Formio file attachment from S3
 router.delete(
   "/s3/:formType/:mongoId/:comboKey/storage/s3",
   fetchBapComboKeys,
   (req, res) => {
-    deleteS3FileMetadata({ rebateYear, req, res });
+    deleteFileFromS3({ rebateYear, req, res });
   },
 );
 

--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -8,8 +8,9 @@ const {
 const {
   searchNcesData,
   //
-  uploadS3FileMetadata,
   downloadS3FileMetadata,
+  uploadS3FileMetadata,
+  deleteS3FileMetadata,
   //
   fetchSubmissionPDF,
   //
@@ -60,6 +61,15 @@ router.post(
   fetchBapComboKeys,
   (req, res) => {
     uploadS3FileMetadata({ rebateYear, req, res });
+  },
+);
+
+// --- delete Formio S3 file metadata
+router.delete(
+  "/s3/:formType/:mongoId/:comboKey/storage/s3",
+  fetchBapComboKeys,
+  (req, res) => {
+    deleteS3FileMetadata({ rebateYear, req, res });
   },
 );
 

--- a/app/server/app/routes/formio2024.js
+++ b/app/server/app/routes/formio2024.js
@@ -8,9 +8,9 @@ const {
 const {
   searchNcesData,
   //
-  downloadS3FileMetadata,
-  uploadS3FileMetadata,
-  deleteS3FileMetadata,
+  downloadFileFromS3,
+  uploadFileToS3,
+  deleteFileFromS3,
   //
   fetchSubmissionPDF,
   //
@@ -46,30 +46,30 @@ router.get("/nces{/:searchText}", (req, res) => {
   searchNcesData({ rebateYear, req, res });
 });
 
-// --- download Formio S3 file metadata
+// --- download Formio file attachment from S3
 router.get(
   "/s3/:formType/:mongoId/:comboKey/storage/s3",
   fetchBapComboKeys,
   (req, res) => {
-    downloadS3FileMetadata({ rebateYear, req, res });
+    downloadFileFromS3({ rebateYear, req, res });
   },
 );
 
-// --- upload Formio S3 file metadata
+// --- upload Formio file attachment to S3
 router.post(
   "/s3/:formType/:mongoId/:comboKey/storage/s3",
   fetchBapComboKeys,
   (req, res) => {
-    uploadS3FileMetadata({ rebateYear, req, res });
+    uploadFileToS3({ rebateYear, req, res });
   },
 );
 
-// --- delete Formio S3 file metadata
+// --- delete Formio file attachment from S3
 router.delete(
   "/s3/:formType/:mongoId/:comboKey/storage/s3",
   fetchBapComboKeys,
   (req, res) => {
-    deleteS3FileMetadata({ rebateYear, req, res });
+    deleteFileFromS3({ rebateYear, req, res });
   },
 );
 

--- a/app/server/app/routes/formio2024.js
+++ b/app/server/app/routes/formio2024.js
@@ -8,8 +8,9 @@ const {
 const {
   searchNcesData,
   //
-  uploadS3FileMetadata,
   downloadS3FileMetadata,
+  uploadS3FileMetadata,
+  deleteS3FileMetadata,
   //
   fetchSubmissionPDF,
   //
@@ -60,6 +61,15 @@ router.post(
   fetchBapComboKeys,
   (req, res) => {
     uploadS3FileMetadata({ rebateYear, req, res });
+  },
+);
+
+// --- delete Formio S3 file metadata
+router.delete(
+  "/s3/:formType/:mongoId/:comboKey/storage/s3",
+  fetchBapComboKeys,
+  (req, res) => {
+    deleteS3FileMetadata({ rebateYear, req, res });
   },
 );
 

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -175,7 +175,7 @@ function fetchBapSubmissionData({
   });
 }
 
-// --- download Formio S3 file metadata
+// --- download Formio file attachment from S3
 router.get("/formio/s3/:rebateYear/:formType/storage/s3", (req, res) => {
   const { query } = req;
   const { rebateYear, formType } = req.params;

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -971,7 +971,7 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
  * @param {express.Request} param.req
  * @param {express.Response} param.res
  */
-function downloadS3FileMetadata({ rebateYear, req, res }) {
+function downloadFileFromS3({ rebateYear, req, res }) {
   const { bapComboKeys, query } = req;
   const { mail } = req.user;
   const { formType, comboKey } = req.params;
@@ -1018,7 +1018,7 @@ function downloadS3FileMetadata({ rebateYear, req, res }) {
  * @param {express.Request} param.req
  * @param {express.Response} param.res
  */
-function uploadS3FileMetadata({ rebateYear, req, res }) {
+function uploadFileToS3({ rebateYear, req, res }) {
   const { bapComboKeys, body } = req;
   const { mail } = req.user;
   const { formType, mongoId, comboKey } = req.params;
@@ -1099,7 +1099,7 @@ function uploadS3FileMetadata({ rebateYear, req, res }) {
  * @param {express.Request} param.req
  * @param {express.Response} param.res
  */
-function deleteS3FileMetadata({ rebateYear, req, res }) {
+function deleteFileFromS3({ rebateYear, req, res }) {
   const { bapComboKeys, query } = req;
   const { mail } = req.user;
   const { formType, mongoId, comboKey } = req.params;
@@ -2392,9 +2392,9 @@ module.exports = {
   searchNcesData,
   getRebateIdFieldName,
   //
-  downloadS3FileMetadata,
-  uploadS3FileMetadata,
-  deleteS3FileMetadata,
+  downloadFileFromS3,
+  uploadFileToS3,
+  deleteFileFromS3,
   //
   fetchSubmissionPDF,
   //

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -1099,6 +1099,81 @@ function downloadS3FileMetadata({ rebateYear, req, res }) {
  * @param {express.Request} param.req
  * @param {express.Response} param.res
  */
+function deleteS3FileMetadata({ rebateYear, req, res }) {
+  const { bapComboKeys, query } = req;
+  const { mail } = req.user;
+  const { formType, mongoId, comboKey } = req.params;
+
+  // NOTE: included to support EPA API scan
+  if (comboKey === formioExampleComboKey) {
+    return res.json({});
+  }
+
+  const formioFormUrl = formUrl[rebateYear][formType];
+
+  if (!formioFormUrl) {
+    const errorStatus = 400;
+    const errorMessage = `Formio form URL does not exist for ${rebateYear} ${formType.toUpperCase()}.`;
+    return res.status(errorStatus).json({ message: errorMessage });
+  }
+
+  checkFormSubmissionPeriodAndBapStatus({
+    rebateYear,
+    formType,
+    mongoId,
+    comboKey,
+    req,
+  })
+    .then(() => {
+      if (!bapComboKeys.includes(comboKey)) {
+        const logMessage =
+          `User with email '${mail}' attempted to delete a file ` +
+          `without a matching BAP combo key.`;
+        log({ level: "error", message: logMessage, req });
+
+        const errorStatus = 401;
+        const errorMessage = `Unauthorized.`;
+        return res.status(errorStatus).json({ message: errorMessage });
+      }
+
+      axiosFormio(req)
+        .delete(`${formioFormUrl}/storage/s3`, { params: query })
+        .then((axiosRes) => axiosRes.data)
+        .then((fileMetadata) => res.json(fileMetadata))
+        .catch((error) => {
+          // NOTE: logged in axiosFormio response interceptor
+          const errorStatus = error.response?.status || 500;
+          const errorMessage = `Error deleting file from S3.`;
+          return res.status(errorStatus).json({ message: errorMessage });
+        });
+    })
+    .catch((_error) => {
+      const formName =
+        formType === "frf"
+          ? "CSB Application"
+          : formType === "prf"
+            ? "CSB Payment Request"
+            : formType === "crf"
+              ? "CSB Close Out"
+              : "CSB";
+
+      const logMessage =
+        `User with email '${mail}' attempted to delete a file when the ` +
+        `${rebateYear} ${formName} form enrollment period was closed.`;
+      log({ level: "error", message: logMessage, req });
+
+      const errorStatus = 400;
+      const errorMessage = `${rebateYear} ${formName} form enrollment period is closed.`;
+      return res.status(errorStatus).json({ message: errorMessage });
+    });
+}
+
+/**
+ * @param {Object} param
+ * @param {RebateYear} param.rebateYear
+ * @param {express.Request} param.req
+ * @param {express.Response} param.res
+ */
 function fetchSubmissionPDF({ rebateYear, req, res }) {
   const { bapComboKeys } = req;
   const { mail } = req.user;
@@ -2317,8 +2392,9 @@ module.exports = {
   searchNcesData,
   getRebateIdFieldName,
   //
-  uploadS3FileMetadata,
   downloadS3FileMetadata,
+  uploadS3FileMetadata,
+  deleteS3FileMetadata,
   //
   fetchSubmissionPDF,
   //

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -971,6 +971,53 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
  * @param {express.Request} param.req
  * @param {express.Response} param.res
  */
+function downloadS3FileMetadata({ rebateYear, req, res }) {
+  const { bapComboKeys, query } = req;
+  const { mail } = req.user;
+  const { formType, comboKey } = req.params;
+
+  // NOTE: included to support EPA API scan
+  if (comboKey === formioExampleComboKey) {
+    return res.json({});
+  }
+
+  const formioFormUrl = formUrl[rebateYear][formType];
+
+  if (!formioFormUrl) {
+    const errorStatus = 400;
+    const errorMessage = `Formio form URL does not exist for ${rebateYear} ${formType.toUpperCase()}.`;
+    return res.status(errorStatus).json({ message: errorMessage });
+  }
+
+  if (!bapComboKeys.includes(comboKey)) {
+    const logMessage =
+      `User with email '${mail}' attempted to download a file ` +
+      `without a matching BAP combo key.`;
+    log({ level: "error", message: logMessage, req });
+
+    const errorStatus = 401;
+    const errorMessage = `Unauthorized.`;
+    return res.status(errorStatus).json({ message: errorMessage });
+  }
+
+  axiosFormio(req)
+    .get(`${formioFormUrl}/storage/s3`, { params: query })
+    .then((axiosRes) => axiosRes.data)
+    .then((fileMetadata) => res.json(fileMetadata))
+    .catch((error) => {
+      // NOTE: logged in axiosFormio response interceptor
+      const errorStatus = error.response?.status || 500;
+      const errorMessage = `Error downloading file from S3.`;
+      return res.status(errorStatus).json({ message: errorMessage });
+    });
+}
+
+/**
+ * @param {Object} param
+ * @param {RebateYear} param.rebateYear
+ * @param {express.Request} param.req
+ * @param {express.Response} param.res
+ */
 function uploadS3FileMetadata({ rebateYear, req, res }) {
   const { bapComboKeys, body } = req;
   const { mail } = req.user;
@@ -1042,53 +1089,6 @@ function uploadS3FileMetadata({ rebateYear, req, res }) {
 
       const errorStatus = 400;
       const errorMessage = `${rebateYear} ${formName} form enrollment period is closed.`;
-      return res.status(errorStatus).json({ message: errorMessage });
-    });
-}
-
-/**
- * @param {Object} param
- * @param {RebateYear} param.rebateYear
- * @param {express.Request} param.req
- * @param {express.Response} param.res
- */
-function downloadS3FileMetadata({ rebateYear, req, res }) {
-  const { bapComboKeys, query } = req;
-  const { mail } = req.user;
-  const { formType, comboKey } = req.params;
-
-  // NOTE: included to support EPA API scan
-  if (comboKey === formioExampleComboKey) {
-    return res.json({});
-  }
-
-  const formioFormUrl = formUrl[rebateYear][formType];
-
-  if (!formioFormUrl) {
-    const errorStatus = 400;
-    const errorMessage = `Formio form URL does not exist for ${rebateYear} ${formType.toUpperCase()}.`;
-    return res.status(errorStatus).json({ message: errorMessage });
-  }
-
-  if (!bapComboKeys.includes(comboKey)) {
-    const logMessage =
-      `User with email '${mail}' attempted to download a file ` +
-      `without a matching BAP combo key.`;
-    log({ level: "error", message: logMessage, req });
-
-    const errorStatus = 401;
-    const errorMessage = `Unauthorized.`;
-    return res.status(errorStatus).json({ message: errorMessage });
-  }
-
-  axiosFormio(req)
-    .get(`${formioFormUrl}/storage/s3`, { params: query })
-    .then((axiosRes) => axiosRes.data)
-    .then((fileMetadata) => res.json(fileMetadata))
-    .catch((error) => {
-      // NOTE: logged in axiosFormio response interceptor
-      const errorStatus = error.response?.status || 500;
-      const errorMessage = `Error downloading file from S3.`;
       return res.status(errorStatus).json({ message: errorMessage });
     });
 }

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -337,7 +337,7 @@
     },
     "/api/formio/2022/s3/{formType}/{mongoId}/{comboKey}/storage/s3": {
       "get": {
-        "summary": "Download Formio S3 file metadata for a 2022 submission.",
+        "summary": "Download Formio file attachment from S3 for a 2022 submission.",
         "parameters": [
           {
             "$ref": "#/components/parameters/formType"
@@ -359,7 +359,29 @@
         }
       },
       "post": {
-        "summary": "Upload Formio S3 file metadata for a 2022 submission.",
+        "summary": "Upload Formio file attachment to S3 for a 2022 submission.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/formType"
+          },
+          {
+            "$ref": "#/components/parameters/mongoId"
+          },
+          {
+            "$ref": "#/components/parameters/comboKey"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Formio file attachment from S3 for a 2022 submission.",
         "parameters": [
           {
             "$ref": "#/components/parameters/formType"
@@ -729,7 +751,7 @@
     },
     "/api/formio/2023/s3/{formType}/{mongoId}/{comboKey}/storage/s3": {
       "get": {
-        "summary": "Download Formio S3 file metadata for a 2023 submission.",
+        "summary": "Download Formio file attachment from S3 for a 2023 submission.",
         "parameters": [
           {
             "$ref": "#/components/parameters/formType"
@@ -751,7 +773,29 @@
         }
       },
       "post": {
-        "summary": "Upload Formio S3 file metadata for a 2023 submission.",
+        "summary": "Upload Formio file attachment to S3 for a 2023 submission.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/formType"
+          },
+          {
+            "$ref": "#/components/parameters/mongoId"
+          },
+          {
+            "$ref": "#/components/parameters/comboKey"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Formio file attachment from S3 for a 2023 submission.",
         "parameters": [
           {
             "$ref": "#/components/parameters/formType"
@@ -1117,7 +1161,7 @@
     },
     "/api/formio/2024/s3/{formType}/{mongoId}/{comboKey}/storage/s3": {
       "get": {
-        "summary": "Download Formio S3 file metadata for a 2024 submission.",
+        "summary": "Download Formio file attachment from S3 for a 2024 submission.",
         "parameters": [
           {
             "$ref": "#/components/parameters/formType"
@@ -1139,7 +1183,7 @@
         }
       },
       "post": {
-        "summary": "Upload Formio S3 file metadata for a 2024 submission.",
+        "summary": "Upload Formio file attachment to S3 for a 2024 submission.",
         "parameters": [
           {
             "$ref": "#/components/parameters/formType"
@@ -1154,6 +1198,28 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Formio file attachment from S3 for a 2024 submission.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/formType"
+          },
+          {
+            "$ref": "#/components/parameters/mongoId"
+          },
+          {
+            "$ref": "#/components/parameters/comboKey"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
@@ -1470,7 +1536,7 @@
     },
     "/api/help/formio/s3/{rebateYear}/{formType}/storage/s3": {
       "get": {
-        "summary": "Download Formio S3 file metadata for a submission.",
+        "summary": "Download Formio file attachment from S3 for a submission.",
         "parameters": [
           {
             "$ref": "#/components/parameters/rebateYear"


### PR DESCRIPTION
## Related Issues:
* CSBAPP-499

## Main Changes:
Another follow-up to #548 – Since the latest version of Formio now supports deleting previously uploaded file attachments to S3/Minio, this updates the wrapping application's server API to support sending those DELETE request to the Formio server (which are routed to the corresponding S3/Minio bucket).

## Steps To Test:
1. Navigate to a draft submission or create a new one.
2. Delete a previously uploaded file attachment in the form. Ensure it's deleted properly.
3. Upload a new file attachment.
4. Repeat for all forms to ensure the HTTP DELETE requests succeed.
