### PR TITLE
Feature/update dashboard table layout

### DIFF
--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -350,7 +350,7 @@ save the form for the EFT indicator to be displayed. */
         </>
       </td>
 
-      <td className={statusTableCellClassNames}>
+      <td className={clsx(statusTableCellClassNames, "tw:sm:max-w-80")}>
         <>
           {Boolean(applicantOrganizationName) ? (
             applicantOrganizationName
@@ -838,7 +838,12 @@ function Submissions2022() {
           className="usa-table usa-table--stacked usa-table--borderless width-full"
         >
           <SubmissionsTableHeader rebateYear="2022" />
-          <tbody className={clsx("tw:[&_:is(th,td)]:text-[15px]")}>
+          <tbody
+            className={clsx(
+              "tw:[&_:is(th,td)]:text-[15px]",
+              "tw:[&_:is(th,td)]:!whitespace-normal",
+            )}
+          >
             {submissions.map((rebate, index) => {
               return rebate.rebateYear === "2022" ? (
                 <Fragment key={rebate.rebateId}>
@@ -1187,7 +1192,7 @@ handle when it's value is an empty string. */}
         </>
       </td>
 
-      <td className={statusTableCellClassNames}>
+      <td className={clsx(statusTableCellClassNames, "tw:sm:max-w-80")}>
         <>
           {Boolean(appInfo_orgName) ? (
             appInfo_orgName
@@ -1517,7 +1522,12 @@ function Submissions2023() {
           className="usa-table usa-table--stacked usa-table--borderless width-full"
         >
           <SubmissionsTableHeader rebateYear="2023" />
-          <tbody className={clsx("tw:[&_:is(th,td)]:text-[15px]")}>
+          <tbody
+            className={clsx(
+              "tw:[&_:is(th,td)]:text-[15px]",
+              "tw:[&_:is(th,td)]:!whitespace-normal",
+            )}
+          >
             {submissions.map((rebate, index) => {
               return rebate.rebateYear === "2023" ? (
                 <Fragment key={rebate.rebateId}>
@@ -1851,7 +1861,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
         </>
       </td>
 
-      <td className={statusTableCellClassNames}>
+      <td className={clsx(statusTableCellClassNames, "tw:sm:max-w-80")}>
         <>
           {Boolean(appInfo_organization_name) ? (
             appInfo_organization_name
@@ -2181,7 +2191,12 @@ function Submissions2024() {
           className="usa-table usa-table--stacked usa-table--borderless width-full"
         >
           <SubmissionsTableHeader rebateYear="2024" />
-          <tbody className={clsx("tw:[&_:is(th,td)]:text-[15px]")}>
+          <tbody
+            className={clsx(
+              "tw:[&_:is(th,td)]:text-[15px]",
+              "tw:[&_:is(th,td)]:!whitespace-normal",
+            )}
+          >
             {submissions.map((rebate, index) => {
               return rebate.rebateYear === "2024" ? (
                 <Fragment key={rebate.rebateId}>

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -532,6 +532,8 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
       ? "text-italic"
       : "";
 
+  const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
+
   const prfUrl = `/prf/2022/${hidden_bap_rebate_id}`;
 
   return (
@@ -554,7 +556,7 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
         ) : null}
       </th>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
       <td className={statusTableCellClassNames}>
         <span>Payment Request</span>
@@ -582,9 +584,9 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
         </span>
       </td>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
       <td className={statusTableCellClassNames}>
         {hidden_current_user_email}
@@ -742,6 +744,8 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
       ? "text-italic"
       : "";
 
+  const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
+
   const crfUrl = `/crf/2022/${hidden_bap_rebate_id}`;
 
   return (
@@ -762,7 +766,7 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
         ) : null}
       </th>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
       <td className={statusTableCellClassNames}>
         <span>Close Out</span>
@@ -796,9 +800,9 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
         </span>
       </td>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
       <td className={statusTableCellClassNames}>
         {hidden_current_user_email}
@@ -1400,6 +1404,8 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
       ? "text-italic"
       : "";
 
+  const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
+
   const prfUrl = `/prf/2023/${_bap_rebate_id}`;
 
   return (
@@ -1422,7 +1428,7 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
         ) : null}
       </th>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
       <td className={statusTableCellClassNames}>
         <span>Payment Request</span>
@@ -1450,9 +1456,9 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
         </span>
       </td>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
       <td className={statusTableCellClassNames}>
         {_user_email}
@@ -2070,6 +2076,8 @@ function PRF2024Submission(props: { rebate: Rebate2024 }) {
       ? "text-italic"
       : "";
 
+  const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
+
   const prfUrl = `/prf/2024/${_bap_rebate_id}`;
 
   return (
@@ -2092,7 +2100,7 @@ function PRF2024Submission(props: { rebate: Rebate2024 }) {
         ) : null}
       </th>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
       <td className={statusTableCellClassNames}>
         <span>Payment Request</span>
@@ -2120,9 +2128,9 @@ function PRF2024Submission(props: { rebate: Rebate2024 }) {
         </span>
       </td>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
-      <td className={statusTableCellClassNames}>&nbsp;</td>
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
       <td className={statusTableCellClassNames}>
         {_user_email}

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -350,7 +350,13 @@ save the form for the EFT indicator to be displayed. */
         </>
       </td>
 
-      <td className={clsx(statusTableCellClassNames, "tw:sm:max-w-80")}>
+      <td
+        className={clsx(
+          statusTableCellClassNames,
+          "tw:!whitespace-normal",
+          "tw:sm:max-w-80",
+        )}
+      >
         <>
           {Boolean(applicantOrganizationName) ? (
             applicantOrganizationName
@@ -838,12 +844,7 @@ function Submissions2022() {
           className="usa-table usa-table--stacked usa-table--borderless width-full"
         >
           <SubmissionsTableHeader rebateYear="2022" />
-          <tbody
-            className={clsx(
-              "tw:[&_:is(th,td)]:text-[15px]",
-              "tw:[&_:is(th,td)]:!whitespace-normal",
-            )}
-          >
+          <tbody className={clsx("tw:[&_:is(th,td)]:text-[15px]")}>
             {submissions.map((rebate, index) => {
               return rebate.rebateYear === "2022" ? (
                 <Fragment key={rebate.rebateId}>
@@ -1192,7 +1193,13 @@ handle when it's value is an empty string. */}
         </>
       </td>
 
-      <td className={clsx(statusTableCellClassNames, "tw:sm:max-w-80")}>
+      <td
+        className={clsx(
+          statusTableCellClassNames,
+          "tw:!whitespace-normal",
+          "tw:sm:max-w-80",
+        )}
+      >
         <>
           {Boolean(appInfo_orgName) ? (
             appInfo_orgName
@@ -1522,12 +1529,7 @@ function Submissions2023() {
           className="usa-table usa-table--stacked usa-table--borderless width-full"
         >
           <SubmissionsTableHeader rebateYear="2023" />
-          <tbody
-            className={clsx(
-              "tw:[&_:is(th,td)]:text-[15px]",
-              "tw:[&_:is(th,td)]:!whitespace-normal",
-            )}
-          >
+          <tbody className={clsx("tw:[&_:is(th,td)]:text-[15px]")}>
             {submissions.map((rebate, index) => {
               return rebate.rebateYear === "2023" ? (
                 <Fragment key={rebate.rebateId}>
@@ -1861,7 +1863,13 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
         </>
       </td>
 
-      <td className={clsx(statusTableCellClassNames, "tw:sm:max-w-80")}>
+      <td
+        className={clsx(
+          statusTableCellClassNames,
+          "tw:!whitespace-normal",
+          "tw:sm:max-w-80",
+        )}
+      >
         <>
           {Boolean(appInfo_organization_name) ? (
             appInfo_organization_name
@@ -2191,12 +2199,7 @@ function Submissions2024() {
           className="usa-table usa-table--stacked usa-table--borderless width-full"
         >
           <SubmissionsTableHeader rebateYear="2024" />
-          <tbody
-            className={clsx(
-              "tw:[&_:is(th,td)]:text-[15px]",
-              "tw:[&_:is(th,td)]:!whitespace-normal",
-            )}
-          >
+          <tbody className={clsx("tw:[&_:is(th,td)]:text-[15px]")}>
             {submissions.map((rebate, index) => {
               return rebate.rebateYear === "2024" ? (
                 <Fragment key={rebate.rebateId}>

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -1231,7 +1231,7 @@ handle when it's value is an empty string. */}
         <span title={`${date} ${time}`}>{date}</span>
       </td>
 
-      <td className={clsx("tw:text-right")}>
+      <td className={clsx("tw:min-[30rem]:text-right")}>
         <ChangeRequest2023Button
           data={{
             formType: "frf",
@@ -1466,7 +1466,7 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
         <span title={`${date} ${time}`}>{date}</span>
       </td>
 
-      <td className={clsx("tw:text-right")}>
+      <td className={clsx("tw:min-[30rem]:text-right")}>
         <ChangeRequest2023Button
           data={{
             formType: "prf",
@@ -1903,7 +1903,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
         <span title={`${date} ${time}`}>{date}</span>
       </td>
 
-      <td className={clsx("tw:text-right")}>
+      <td className={clsx("tw:min-[30rem]:text-right")}>
         <ChangeRequest2024Button
           data={{
             formType: "frf",
@@ -2138,7 +2138,7 @@ function PRF2024Submission(props: { rebate: Rebate2024 }) {
         <span title={`${date} ${time}`}>{date}</span>
       </td>
 
-      <td className={clsx("tw:text-right")}>
+      <td className={clsx("tw:min-[30rem]:text-right")}>
         <ChangeRequest2024Button
           data={{
             formType: "prf",


### PR DESCRIPTION
## Related Issues:
* CSBAPP-525

## Main Changes:
Update user dashboard table so lengthy applicant org name and school district names don't cause the table width to continually expand. The table will still scroll horizontally as needed, but now the text for applicant org name and school district name will wrap to a more readable length. Also this hides any of the empty table cells for PRFs and CRFs when viewed on narrow screens.

## Steps To Test:
1. Navigate to the dashboard.
2. Ensure the display of any FRF submissions created with a long applicant org name or school district name is more readable.
3. Ensure empty table cells for PRFs and CRFs no longer display when viewed on narrow screens.
