### PR TITLE
Feature/fix helpdesk actions and pdf query caching

### DIFF
--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -163,6 +163,10 @@ function ResultTableRow(props: {
   });
 
   useEffect(() => {
+    if (actionsQuery.status === "pending") {
+      setActionsData({ fetched: false, results: [] });
+    }
+
     if (actionsQuery.status === "success") {
       setActionsData({ fetched: true, results: actionsQuery.data });
     }
@@ -182,8 +186,11 @@ function ResultTableRow(props: {
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
+
+      // clear the pdf query cache after the download succeeds
+      queryClient.resetQueries({ queryKey: ["helpdesk/pdf"] });
     }
-  }, [pdfQuery.status, pdfQuery.data, formio._id]);
+  }, [pdfQuery.status, pdfQuery.data, formio._id, queryClient]);
 
   if (!rebateYear) {
     return null;
@@ -444,6 +451,10 @@ export function Helpdesk() {
   });
 
   useEffect(() => {
+    if (submissionQuery.status === "pending") {
+      setResultDisplayed(false);
+    }
+
     if (submissionQuery.status === "success") {
       setResultDisplayed(true);
     }


### PR DESCRIPTION
## Related Issues:
* CSBAPP-499

## Main Changes:
Follow up to #548 – Update helpdesk page to properly clear actions data and pdf data caches after successful actions data fetches/downloads.

## Steps To Test:
1. Navigate to the helpdesk page and search for a submission.
2. Click the "Actions" and "Download" buttons to view the actions for the submission and download a PDF of the submission.
3. Navigate back to the dashboard.
4. From the dashboard, navigate back to the helpdesk page.
5. Search for the same submission as before.
6. Ensure the actions aren't displayed below, and a PDF of the submission isn't re-downloaded, without first clicking those two buttons (that happened previous to this fix, as a result of the package updates, so this fix resolves that issue).
