### PR TITLE
Feature/update submission data passed to formio forms

### DIFF
--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -297,20 +297,28 @@ function CloseOutRequestForm(props: { email: string }) {
         <Form
           src={formSchema.json}
           url={formSchema.url}
-          submission={
-            submission.state === "submitted"
-              ? submission
-              : {
-                  data: {
-                    ...submission.data,
-                    last_updated_by: email,
-                    hidden_current_user_email: email,
-                    hidden_current_user_title: title,
-                    hidden_current_user_name: name,
-                    ...pendingSubmissionData.current,
-                  },
-                }
-          }
+          submission={{
+            /**
+             * NOTE: The `csb-form-submission-state` metadata field's value is
+             * used in the Formio signature component's calculateValue config:
+             * on "Next" and "Previous" page events, if the form's current
+             * submission state is "draft", the signature component's value will
+             * be cleared, ensuring the user always signs their submission each
+             * time before submitting.
+             */
+            metadata: {
+              ...submission.metadata,
+              "csb-form-submission-state": submission.state,
+            },
+            data: {
+              ...submission.data,
+              last_updated_by: email,
+              hidden_current_user_email: email,
+              hidden_current_user_title: title,
+              hidden_current_user_name: name,
+              ...pendingSubmissionData.current,
+            },
+          }}
           options={{
             readOnly: formIsReadOnly,
             noAlerts: true,
@@ -330,6 +338,10 @@ function CloseOutRequestForm(props: { email: string }) {
               mongoId: submission._id,
               submission: {
                 ...onSubmitParam,
+                metadata: {
+                  ...onSubmitParam.metadata,
+                  "csb-form-submission-state": onSubmitParam.state,
+                },
                 data,
               },
             };

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -441,20 +441,28 @@ function FundingRequestForm(props: { email: string }) {
         <Form
           src={formSchema.json}
           url={formSchema.url}
-          submission={
-            submission.state === "submitted"
-              ? submission
-              : {
-                  data: {
-                    ...submission.data,
-                    last_updated_by: email,
-                    hidden_current_user_email: email,
-                    hidden_current_user_title: title,
-                    hidden_current_user_name: name,
-                    ...pendingSubmissionData.current,
-                  },
-                }
-          }
+          submission={{
+            /**
+             * NOTE: The `csb-form-submission-state` metadata field's value is
+             * used in the Formio signature component's calculateValue config:
+             * on "Next" and "Previous" page events, if the form's current
+             * submission state is "draft", the signature component's value will
+             * be cleared, ensuring the user always signs their submission each
+             * time before submitting.
+             */
+            metadata: {
+              ...submission.metadata,
+              "csb-form-submission-state": submission.state,
+            },
+            data: {
+              ...submission.data,
+              last_updated_by: email,
+              hidden_current_user_email: email,
+              hidden_current_user_title: title,
+              hidden_current_user_name: name,
+              ...pendingSubmissionData.current,
+            },
+          }}
           options={{
             readOnly: formIsReadOnly,
             noAlerts: true,
@@ -478,6 +486,10 @@ function FundingRequestForm(props: { email: string }) {
 
             const updatedSubmission = {
               ...onSubmitParam,
+              metadata: {
+                ...onSubmitParam.metadata,
+                "csb-form-submission-state": onSubmitParam.state,
+              },
               data,
             };
 

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -429,19 +429,27 @@ function FundingRequestForm(props: { email: string }) {
         <Form
           src={formSchema.json}
           url={formSchema.url}
-          submission={
-            submission.state === "submitted"
-              ? submission
-              : {
-                  data: {
-                    ...submission.data,
-                    _user_email: email,
-                    _user_title: title,
-                    _user_name: name,
-                    ...pendingSubmissionData.current,
-                  },
-                }
-          }
+          submission={{
+            /**
+             * NOTE: The `csb-form-submission-state` metadata field's value is
+             * used in the Formio signature component's calculateValue config:
+             * on "Next" and "Previous" page events, if the form's current
+             * submission state is "draft", the signature component's value will
+             * be cleared, ensuring the user always signs their submission each
+             * time before submitting.
+             */
+            metadata: {
+              ...submission.metadata,
+              "csb-form-submission-state": submission.state,
+            },
+            data: {
+              ...submission.data,
+              _user_email: email,
+              _user_title: title,
+              _user_name: name,
+              ...pendingSubmissionData.current,
+            },
+          }}
           options={{
             readOnly: formIsReadOnly,
             noAlerts: true,
@@ -459,6 +467,10 @@ function FundingRequestForm(props: { email: string }) {
 
             const updatedSubmission = {
               ...onSubmitParam,
+              metadata: {
+                ...onSubmitParam.metadata,
+                "csb-form-submission-state": onSubmitParam.state,
+              },
               data,
             };
 

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -429,19 +429,27 @@ function FundingRequestForm(props: { email: string }) {
         <Form
           src={formSchema.json}
           url={formSchema.url}
-          submission={
-            submission.state === "submitted"
-              ? submission
-              : {
-                  data: {
-                    ...submission.data,
-                    _user_email: email,
-                    _user_title: title,
-                    _user_name: name,
-                    ...pendingSubmissionData.current,
-                  },
-                }
-          }
+          submission={{
+            /**
+             * NOTE: The `csb-form-submission-state` metadata field's value is
+             * used in the Formio signature component's calculateValue config:
+             * on "Next" and "Previous" page events, if the form's current
+             * submission state is "draft", the signature component's value will
+             * be cleared, ensuring the user always signs their submission each
+             * time before submitting.
+             */
+            metadata: {
+              ...submission.metadata,
+              "csb-form-submission-state": submission.state,
+            },
+            data: {
+              ...submission.data,
+              _user_email: email,
+              _user_title: title,
+              _user_name: name,
+              ...pendingSubmissionData.current,
+            },
+          }}
           options={{
             readOnly: formIsReadOnly,
             noAlerts: true,
@@ -459,6 +467,10 @@ function FundingRequestForm(props: { email: string }) {
 
             const updatedSubmission = {
               ...onSubmitParam,
+              metadata: {
+                ...onSubmitParam.metadata,
+                "csb-form-submission-state": onSubmitParam.state,
+              },
               data,
             };
 

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -318,26 +318,34 @@ function PaymentRequestForm(props: { email: string }) {
         <Form
           src={formSchema.json}
           url={formSchema.url}
-          submission={
-            submission.state === "submitted"
-              ? submission
-              : {
-                  data: {
-                    ...submission.data,
-                    last_updated_by: email,
-                    hidden_current_user_email: email,
-                    hidden_current_user_title: title,
-                    hidden_current_user_name: name,
-                    hidden_sam_uei: UNIQUE_ENTITY_ID__c,
-                    hidden_sam_efti: ENTITY_EFT_INDICATOR__c || "0000",
-                    hidden_sam_elec_bus_poc_email: ELEC_BUS_POC_EMAIL__c,
-                    hidden_sam_alt_elec_bus_poc_email: ALT_ELEC_BUS_POC_EMAIL__c, // prettier-ignore
-                    hidden_sam_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
-                    hidden_sam_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c, // prettier-ignore
-                    ...pendingSubmissionData.current,
-                  },
-                }
-          }
+          submission={{
+            /**
+             * NOTE: The `csb-form-submission-state` metadata field's value is
+             * used in the Formio signature component's calculateValue config:
+             * on "Next" and "Previous" page events, if the form's current
+             * submission state is "draft", the signature component's value will
+             * be cleared, ensuring the user always signs their submission each
+             * time before submitting.
+             */
+            metadata: {
+              ...submission.metadata,
+              "csb-form-submission-state": submission.state,
+            },
+            data: {
+              ...submission.data,
+              last_updated_by: email,
+              hidden_current_user_email: email,
+              hidden_current_user_title: title,
+              hidden_current_user_name: name,
+              hidden_sam_uei: UNIQUE_ENTITY_ID__c,
+              hidden_sam_efti: ENTITY_EFT_INDICATOR__c || "0000",
+              hidden_sam_elec_bus_poc_email: ELEC_BUS_POC_EMAIL__c,
+              hidden_sam_alt_elec_bus_poc_email: ALT_ELEC_BUS_POC_EMAIL__c,
+              hidden_sam_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
+              hidden_sam_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
+              ...pendingSubmissionData.current,
+            },
+          }}
           options={{
             readOnly: formIsReadOnly,
             noAlerts: true,
@@ -357,6 +365,10 @@ function PaymentRequestForm(props: { email: string }) {
               mongoId: submission._id,
               submission: {
                 ...onSubmitParam,
+                metadata: {
+                  ...onSubmitParam.metadata,
+                  "csb-form-submission-state": onSubmitParam.state,
+                },
                 data,
               },
             };

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -316,23 +316,31 @@ function PaymentRequestForm(props: { email: string }) {
         <Form
           src={formSchema.json}
           url={formSchema.url}
-          submission={
-            submission.state === "submitted"
-              ? submission
-              : {
-                  data: {
-                    ...submission.data,
-                    _user_email: email,
-                    _user_title: title,
-                    _user_name: name,
-                    _bap_elec_bus_poc_email: ELEC_BUS_POC_EMAIL__c,
-                    _bap_alt_elec_bus_poc_email: ALT_ELEC_BUS_POC_EMAIL__c,
-                    _bap_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
-                    _bap_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
-                    ...pendingSubmissionData.current,
-                  },
-                }
-          }
+          submission={{
+            /**
+             * NOTE: The `csb-form-submission-state` metadata field's value is
+             * used in the Formio signature component's calculateValue config:
+             * on "Next" and "Previous" page events, if the form's current
+             * submission state is "draft", the signature component's value will
+             * be cleared, ensuring the user always signs their submission each
+             * time before submitting.
+             */
+            metadata: {
+              ...submission.metadata,
+              "csb-form-submission-state": submission.state,
+            },
+            data: {
+              ...submission.data,
+              _user_email: email,
+              _user_title: title,
+              _user_name: name,
+              _bap_elec_bus_poc_email: ELEC_BUS_POC_EMAIL__c,
+              _bap_alt_elec_bus_poc_email: ALT_ELEC_BUS_POC_EMAIL__c,
+              _bap_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
+              _bap_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
+              ...pendingSubmissionData.current,
+            },
+          }}
           options={{
             readOnly: formIsReadOnly,
             noAlerts: true,
@@ -352,6 +360,10 @@ function PaymentRequestForm(props: { email: string }) {
               mongoId: submission._id,
               submission: {
                 ...onSubmitParam,
+                metadata: {
+                  ...onSubmitParam.metadata,
+                  "csb-form-submission-state": onSubmitParam.state,
+                },
                 data,
               },
             };

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -316,23 +316,31 @@ function PaymentRequestForm(props: { email: string }) {
         <Form
           src={formSchema.json}
           url={formSchema.url}
-          submission={
-            submission.state === "submitted"
-              ? submission
-              : {
-                  data: {
-                    ...submission.data,
-                    _user_email: email,
-                    _user_title: title,
-                    _user_name: name,
-                    _bap_elec_bus_poc_email: ELEC_BUS_POC_EMAIL__c,
-                    _bap_alt_elec_bus_poc_email: ALT_ELEC_BUS_POC_EMAIL__c,
-                    _bap_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
-                    _bap_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
-                    ...pendingSubmissionData.current,
-                  },
-                }
-          }
+          submission={{
+            /**
+             * NOTE: The `csb-form-submission-state` metadata field's value is
+             * used in the Formio signature component's calculateValue config:
+             * on "Next" and "Previous" page events, if the form's current
+             * submission state is "draft", the signature component's value will
+             * be cleared, ensuring the user always signs their submission each
+             * time before submitting.
+             */
+            metadata: {
+              ...submission.metadata,
+              "csb-form-submission-state": submission.state,
+            },
+            data: {
+              ...submission.data,
+              _user_email: email,
+              _user_title: title,
+              _user_name: name,
+              _bap_elec_bus_poc_email: ELEC_BUS_POC_EMAIL__c,
+              _bap_alt_elec_bus_poc_email: ALT_ELEC_BUS_POC_EMAIL__c,
+              _bap_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
+              _bap_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
+              ...pendingSubmissionData.current,
+            },
+          }}
           options={{
             readOnly: formIsReadOnly,
             noAlerts: true,
@@ -352,6 +360,10 @@ function PaymentRequestForm(props: { email: string }) {
               mongoId: submission._id,
               submission: {
                 ...onSubmitParam,
+                metadata: {
+                  ...onSubmitParam.metadata,
+                  "csb-form-submission-state": onSubmitParam.state,
+                },
                 data,
               },
             };


### PR DESCRIPTION
## Related Issues:
* CSBAPP-499

## Main Changes:
Follow up to #548: Updates the data passed to the `submission` prop of Formio `Form` components to include a new metadata field containing the form submission's submission state (for use in the form's calculated value logic on the signature component to determine if the signature field should be cleared). It would be ideal to just include the form state in the `submission` prop (as we previously did before the package updates), but doing so now prevents the forms from being submitted as the state is never updated to "submitted" when the submit button is clicked (it stays as "draft" which came from the initial submission data fetched from the server).

Separate from this the form definitions for each form are being updated to use the new metadata field in the calculated value logic for each form's signature component.

## Steps To Test:
1. Navigate to a draft form.
2. Advance through to the last page and sign the form.
3. Click the "Previous" button to go back a page. Then click the "Next" button to advance to the last page again.
4. Ensure the signature has been cleared.
5. Navigate to a submitted form.
6. Advance through the form and ensure the signature is not cleared.
