### PR TITLE
Feature/remove 2024 prf

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -38,7 +38,7 @@ import { PRF2023 } from "@/routes/prf2023";
 // import { CRF2023 } from "@/routes/crf2023";
 import { Change2024 } from "@/routes/change2024";
 import { FRF2024 } from "@/routes/frf2024";
-import { PRF2024 } from "@/routes/prf2024";
+// import { PRF2024 } from "@/routes/prf2024";
 // import { CRF2024 } from "@/routes/crf2024";
 import { useDialogState, useDialogActions } from "@/contexts/dialog";
 
@@ -267,7 +267,7 @@ export function App() {
 
         <Route path="/change/2024/:id" element={<Change2024 />} />
         <Route path="frf/2024/:id" element={<FRF2024 />} />
-        <Route path="prf/2024/:id" element={<PRF2024 />} />
+        {/* <Route path="prf/2024/:id" element={<PRF2024 />} /> */}
         {/* <Route path="crf/2024/:id" element={<CRF2024 />} /> */}
 
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -1924,240 +1924,240 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
   );
 }
 
-function PRF2024Submission(props: { rebate: Rebate2024 }) {
-  const { rebate } = props;
-  const { frf, prf, crf } = rebate;
+// function PRF2024Submission(props: { rebate: Rebate2024 }) {
+//   const { rebate } = props;
+//   const { frf, prf, crf } = rebate;
 
-  const navigate = useNavigate();
-  const { email } = useOutletContext<{ email: string }>();
+//   const navigate = useNavigate();
+//   const { email } = useOutletContext<{ email: string }>();
 
-  const configData = useConfigData();
-  const bapSamData = useBapSamData();
-  const { displayErrorNotification } = useNotificationsActions();
+//   const configData = useConfigData();
+//   const bapSamData = useBapSamData();
+//   const { displayErrorNotification } = useNotificationsActions();
 
-  /**
-   * Stores when data is being posted to the server, so a loading indicator can
-   * be rendered inside the "New Payment Request" button, and we can prevent
-   * double submits/creations of new PRF submissions.
-   */
-  const [dataIsPosting, setDataIsPosting] = useState(false);
+//   /**
+//    * Stores when data is being posted to the server, so a loading indicator can
+//    * be rendered inside the "New Payment Request" button, and we can prevent
+//    * double submits/creations of new PRF submissions.
+//    */
+//   const [dataIsPosting, setDataIsPosting] = useState(false);
 
-  if (!configData || !bapSamData) return null;
+//   if (!configData || !bapSamData) return null;
 
-  /** matched SAM.gov entity for the FRF submission */
-  const entity = bapSamData.entities.find((entity) => {
-    const comboKey = frf.formio.data._bap_entity_combo_key;
-    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
-  });
+//   /** matched SAM.gov entity for the FRF submission */
+//   const entity = bapSamData.entities.find((entity) => {
+//     const comboKey = frf.formio.data._bap_entity_combo_key;
+//     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+//   });
 
-  if (!entity) return null;
+//   if (!entity) return null;
 
-  const { title, name } = getUserInfo(email, entity);
+//   const { title, name } = getUserInfo(email, entity);
 
-  const prfSubmissionPeriodOpen = configData.submissionPeriodOpen["2024"].prf;
+//   const prfSubmissionPeriodOpen = configData.submissionPeriodOpen["2024"].prf;
 
-  const frfSelected = frf.bap?.status === "Accepted";
-  const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
+//   const frfSelected = frf.bap?.status === "Accepted";
+//   const frfSelectedButNoPRF = frfSelected && !Boolean(prf.formio);
 
-  if (frfSelectedButNoPRF) {
-    return (
-      <tr className={highlightedTableRowClassNames}>
-        <th scope="row" colSpan={7}>
-          <button
-            className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
-            disabled={!prfSubmissionPeriodOpen}
-            onClick={(_ev) => {
-              if (!prfSubmissionPeriodOpen) return;
-              if (!frf.bap) return;
+//   if (frfSelectedButNoPRF) {
+//     return (
+//       <tr className={highlightedTableRowClassNames}>
+//         <th scope="row" colSpan={7}>
+//           <button
+//             className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+//             disabled={!prfSubmissionPeriodOpen}
+//             onClick={(_ev) => {
+//               if (!prfSubmissionPeriodOpen) return;
+//               if (!frf.bap) return;
 
-              // account for when data is posting to prevent double submits
-              if (dataIsPosting) return;
-              setDataIsPosting(true);
+//               // account for when data is posting to prevent double submits
+//               if (dataIsPosting) return;
+//               setDataIsPosting(true);
 
-              // create a new draft PRF submission
-              postData(`${serverUrl}/api/formio/2024/prf-submission/`, {
-                email,
-                title,
-                name,
-                entity,
-                comboKey: frf.bap.comboKey,
-                rebateId: frf.bap.rebateId, // CSB Rebate ID (6 digits)
-                frfReviewItemId: frf.bap.reviewItemId, // CSB Rebate ID with form/version ID (9 digits)
-                frfModified: frf.bap.modified,
-              })
-                .then((_res) => {
-                  navigate(`/prf/2024/${frf.bap?.rebateId}`);
-                })
-                .catch((_err) => {
-                  displayErrorNotification({
-                    id: Date.now(),
-                    body: (
-                      <>
-                        <p
-                          className={clsx(
-                            "tw:text-sm tw:font-medium tw:text-gray-900",
-                          )}
-                        >
-                          Error creating Payment Request{" "}
-                          <em>{frf.bap?.rebateId}</em>.
-                        </p>
-                        <p
-                          className={clsx(
-                            "tw:mt-1 tw:text-sm tw:text-gray-500",
-                          )}
-                        >
-                          Please try again.
-                        </p>
-                      </>
-                    ),
-                  });
-                })
-                .finally(() => {
-                  setDataIsPosting(false);
-                });
-            }}
-          >
-            <span className="display-flex flex-align-center">
-              <svg
-                className="usa-icon"
-                aria-hidden="true"
-                focusable="false"
-                role="img"
-              >
-                <use href={`${icons}#add_circle`} />
-              </svg>
-              <span className="margin-left-1">New Payment Request</span>
-              {dataIsPosting && <LoadingButtonIcon position="end" />}
-            </span>
-          </button>
-        </th>
-      </tr>
-    );
-  }
+//               // create a new draft PRF submission
+//               postData(`${serverUrl}/api/formio/2024/prf-submission/`, {
+//                 email,
+//                 title,
+//                 name,
+//                 entity,
+//                 comboKey: frf.bap.comboKey,
+//                 rebateId: frf.bap.rebateId, // CSB Rebate ID (6 digits)
+//                 frfReviewItemId: frf.bap.reviewItemId, // CSB Rebate ID with form/version ID (9 digits)
+//                 frfModified: frf.bap.modified,
+//               })
+//                 .then((_res) => {
+//                   navigate(`/prf/2024/${frf.bap?.rebateId}`);
+//                 })
+//                 .catch((_err) => {
+//                   displayErrorNotification({
+//                     id: Date.now(),
+//                     body: (
+//                       <>
+//                         <p
+//                           className={clsx(
+//                             "tw:text-sm tw:font-medium tw:text-gray-900",
+//                           )}
+//                         >
+//                           Error creating Payment Request{" "}
+//                           <em>{frf.bap?.rebateId}</em>.
+//                         </p>
+//                         <p
+//                           className={clsx(
+//                             "tw:mt-1 tw:text-sm tw:text-gray-500",
+//                           )}
+//                         >
+//                           Please try again.
+//                         </p>
+//                       </>
+//                     ),
+//                   });
+//                 })
+//                 .finally(() => {
+//                   setDataIsPosting(false);
+//                 });
+//             }}
+//           >
+//             <span className="display-flex flex-align-center">
+//               <svg
+//                 className="usa-icon"
+//                 aria-hidden="true"
+//                 focusable="false"
+//                 role="img"
+//               >
+//                 <use href={`${icons}#add_circle`} />
+//               </svg>
+//               <span className="margin-left-1">New Payment Request</span>
+//               {dataIsPosting && <LoadingButtonIcon position="end" />}
+//             </span>
+//           </button>
+//         </th>
+//       </tr>
+//     );
+//   }
 
-  // return if a Payment Request submission has not been created for this rebate
-  if (!prf.formio) return null;
+//   // return if a Payment Request submission has not been created for this rebate
+//   if (!prf.formio) return null;
 
-  const {
-    _user_email,
-    _bap_entity_combo_key,
-    _bap_rebate_id,
-    _bap_applicant_name,
-    _bap_district_name,
-    _bap_district_state,
-  } = prf.formio.data;
+//   const {
+//     _user_email,
+//     _bap_entity_combo_key,
+//     _bap_rebate_id,
+//     _bap_applicant_name,
+//     _bap_district_name,
+//     _bap_district_state,
+//   } = prf.formio.data;
 
-  const date = new Date(prf.formio.modified).toLocaleDateString();
-  const time = new Date(prf.formio.modified).toLocaleTimeString();
+//   const date = new Date(prf.formio.modified).toLocaleDateString();
+//   const time = new Date(prf.formio.modified).toLocaleTimeString();
 
-  const frfNeedsEdits = submissionNeedsEdits({
-    formio: frf.formio,
-    bap: frf.bap,
-  });
+//   const frfNeedsEdits = submissionNeedsEdits({
+//     formio: frf.formio,
+//     bap: frf.bap,
+//   });
 
-  const prfNeedsEdits = submissionNeedsEdits({
-    formio: prf.formio,
-    bap: prf.bap,
-  });
+//   const prfNeedsEdits = submissionNeedsEdits({
+//     formio: prf.formio,
+//     bap: prf.bap,
+//   });
 
-  const prfBapInternalStatus = prf.bap?.status || "";
-  const prfBapStatus = bapStatusMap["2024"].prf.get(prfBapInternalStatus);
-  const prfFormioStatus = formioStatusMap.get(prf.formio.state || "");
+//   const prfBapInternalStatus = prf.bap?.status || "";
+//   const prfBapStatus = bapStatusMap["2024"].prf.get(prfBapInternalStatus);
+//   const prfFormioStatus = formioStatusMap.get(prf.formio.state || "");
 
-  const prfStatus = prfNeedsEdits
-    ? "Edits Requested"
-    : prfBapStatus || prfFormioStatus || "";
+//   const prfStatus = prfNeedsEdits
+//     ? "Edits Requested"
+//     : prfBapStatus || prfFormioStatus || "";
 
-  const prfApproved = prfStatus === "Funding Approved";
-  const prfApprovedButNoCRF = prfApproved && !Boolean(crf.formio);
+//   const prfApproved = prfStatus === "Funding Approved";
+//   const prfApprovedButNoCRF = prfApproved && !Boolean(crf.formio);
 
-  const statusTableCellClassNames =
-    prf.formio.state === "submitted" || !prfSubmissionPeriodOpen
-      ? "text-italic"
-      : "";
+//   const statusTableCellClassNames =
+//     prf.formio.state === "submitted" || !prfSubmissionPeriodOpen
+//       ? "text-italic"
+//       : "";
 
-  const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
+//   const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
 
-  const prfUrl = `/prf/2024/${_bap_rebate_id}`;
+//   const prfUrl = `/prf/2024/${_bap_rebate_id}`;
 
-  return (
-    <tr
-      className={
-        prfNeedsEdits || prfApprovedButNoCRF
-          ? highlightedTableRowClassNames
-          : defaultTableRowClassNames
-      }
-    >
-      <th scope="row" className={statusTableCellClassNames}>
-        {frfNeedsEdits ? (
-          <FormLink type="view" to={prfUrl} />
-        ) : prfNeedsEdits ? (
-          <FormLink type="edit" to={prfUrl} />
-        ) : prf.formio.state === "submitted" || !prfSubmissionPeriodOpen ? (
-          <FormLink type="view" to={prfUrl} />
-        ) : prf.formio.state === "draft" ? (
-          <FormLink type="edit" to={prfUrl} />
-        ) : null}
-      </th>
+//   return (
+//     <tr
+//       className={
+//         prfNeedsEdits || prfApprovedButNoCRF
+//           ? highlightedTableRowClassNames
+//           : defaultTableRowClassNames
+//       }
+//     >
+//       <th scope="row" className={statusTableCellClassNames}>
+//         {frfNeedsEdits ? (
+//           <FormLink type="view" to={prfUrl} />
+//         ) : prfNeedsEdits ? (
+//           <FormLink type="edit" to={prfUrl} />
+//         ) : prf.formio.state === "submitted" || !prfSubmissionPeriodOpen ? (
+//           <FormLink type="view" to={prfUrl} />
+//         ) : prf.formio.state === "draft" ? (
+//           <FormLink type="edit" to={prfUrl} />
+//         ) : null}
+//       </th>
 
-      <td className={hiddenTableCellClassNames}>&nbsp;</td>
+//       <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
-      <td className={statusTableCellClassNames}>
-        <span>Payment Request</span>
-        <br />
-        <span className="display-flex flex-align-center font-sans-2xs">
-          {prfStatus === "Needs Clarification" ? (
-            <TextWithTooltip
-              text={prfStatus}
-              tooltip="Check your email for instructions on what needs clarification"
-              iconClassNames="text-base-darkest"
-            />
-          ) : (
-            <>
-              <svg
-                className={clsx("usa-icon", prfApproved && "text-primary")}
-                aria-hidden="true"
-                focusable="false"
-                role="img"
-              >
-                <use href={`${icons}#${statusIconMap.get(prfStatus)}`} />
-              </svg>
-              <span className="margin-left-05">{prfStatus}</span>
-            </>
-          )}
-        </span>
-      </td>
+//       <td className={statusTableCellClassNames}>
+//         <span>Payment Request</span>
+//         <br />
+//         <span className="display-flex flex-align-center font-sans-2xs">
+//           {prfStatus === "Needs Clarification" ? (
+//             <TextWithTooltip
+//               text={prfStatus}
+//               tooltip="Check your email for instructions on what needs clarification"
+//               iconClassNames="text-base-darkest"
+//             />
+//           ) : (
+//             <>
+//               <svg
+//                 className={clsx("usa-icon", prfApproved && "text-primary")}
+//                 aria-hidden="true"
+//                 focusable="false"
+//                 role="img"
+//               >
+//                 <use href={`${icons}#${statusIconMap.get(prfStatus)}`} />
+//               </svg>
+//               <span className="margin-left-05">{prfStatus}</span>
+//             </>
+//           )}
+//         </span>
+//       </td>
 
-      <td className={hiddenTableCellClassNames}>&nbsp;</td>
+//       <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
-      <td className={hiddenTableCellClassNames}>&nbsp;</td>
+//       <td className={hiddenTableCellClassNames}>&nbsp;</td>
 
-      <td className={statusTableCellClassNames}>
-        {_user_email}
-        <br />
-        <span title={`${date} ${time}`}>{date}</span>
-      </td>
+//       <td className={statusTableCellClassNames}>
+//         {_user_email}
+//         <br />
+//         <span title={`${date} ${time}`}>{date}</span>
+//       </td>
 
-      <td className={clsx("tw:min-[30rem]:text-right")}>
-        <ChangeRequest2024Button
-          data={{
-            formType: "prf",
-            comboKey: _bap_entity_combo_key,
-            rebateId: _bap_rebate_id,
-            mongoId: prf.formio._id,
-            state: prf.formio.state || "",
-            email,
-            title,
-            name,
-            applicantName: _bap_applicant_name,
-            districtName: _bap_district_name,
-            districtState: _bap_district_state,
-          }}
-        />
-      </td>
-    </tr>
-  );
-}
+//       <td className={clsx("tw:min-[30rem]:text-right")}>
+//         <ChangeRequest2024Button
+//           data={{
+//             formType: "prf",
+//             comboKey: _bap_entity_combo_key,
+//             rebateId: _bap_rebate_id,
+//             mongoId: prf.formio._id,
+//             state: prf.formio.state || "",
+//             email,
+//             title,
+//             name,
+//             applicantName: _bap_applicant_name,
+//             districtName: _bap_district_name,
+//             districtState: _bap_district_state,
+//           }}
+//         />
+//       </td>
+//     </tr>
+//   );
+// }
 
 // function CRF2024Submission(props: { rebate: Rebate2024 }) {
 //   //
@@ -2212,7 +2212,7 @@ function Submissions2024() {
               return rebate.rebateYear === "2024" ? (
                 <Fragment key={rebate.rebateId}>
                   <FRF2024Submission rebate={rebate} />
-                  <PRF2024Submission rebate={rebate} />
+                  {/* <PRF2024Submission rebate={rebate} /> */}
                   {/* <CRF2024Submission rebate={rebate} /> */}
                   {/* blank row after all submissions but the last one */}
                   {index !== submissions.length - 1 && (

--- a/app/server/app/routes/formio2024.js
+++ b/app/server/app/routes/formio2024.js
@@ -19,11 +19,11 @@ const {
   fetchFRFSubmission,
   updateFRFSubmission,
   //
-  fetchPRFSubmissions,
-  createPRFSubmission,
-  fetchPRFSubmission,
-  updatePRFSubmission,
-  deletePRFSubmission,
+  // fetchPRFSubmissions,
+  // createPRFSubmission,
+  // fetchPRFSubmission,
+  // updatePRFSubmission,
+  // deletePRFSubmission,
   //
   // fetchCRFSubmissions,
   // createCRFSubmission,
@@ -110,28 +110,28 @@ router.post(
 
 // --- get user's 2024 PRF submissions from Formio
 router.get("/prf-submissions", fetchBapComboKeys, (req, res) => {
-  fetchPRFSubmissions({ rebateYear, req, res });
+  res.json([]); // TODO: replace with `fetchPRFSubmissions({ rebateYear, req, res })` when PRF is ready
 });
 
 // --- post a new 2024 PRF submission to Formio
-router.post("/prf-submission", fetchBapComboKeys, (req, res) => {
-  createPRFSubmission({ rebateYear, req, res });
-});
+// router.post("/prf-submission", fetchBapComboKeys, (req, res) => {
+//   createPRFSubmission({ rebateYear, req, res });
+// });
 
 // --- get an existing 2024 PRF's schema and submission data from Formio
-router.get("/prf-submission/:rebateId", fetchBapComboKeys, (req, res) => {
-  fetchPRFSubmission({ rebateYear, req, res });
-});
+// router.get("/prf-submission/:rebateId", fetchBapComboKeys, (req, res) => {
+//   fetchPRFSubmission({ rebateYear, req, res });
+// });
 
 // --- post an update to an existing draft 2024 PRF submission to Formio
-router.post("/prf-submission/:rebateId", fetchBapComboKeys, (req, res) => {
-  updatePRFSubmission({ rebateYear, req, res });
-});
+// router.post("/prf-submission/:rebateId", fetchBapComboKeys, (req, res) => {
+//   updatePRFSubmission({ rebateYear, req, res });
+// });
 
 // --- delete an existing 2024 PRF submission from Formio
-router.post("/delete-prf-submission", fetchBapComboKeys, (req, res) => {
-  deletePRFSubmission({ rebateYear, req, res });
-});
+// router.post("/delete-prf-submission", fetchBapComboKeys, (req, res) => {
+//   deletePRFSubmission({ rebateYear, req, res });
+// });
 
 // --- get user's 2024 CRF submissions from Formio
 router.get("/crf-submissions", fetchBapComboKeys, (req, res) => {

--- a/app/server/app/routes/status.js
+++ b/app/server/app/routes/status.js
@@ -181,20 +181,20 @@ router.get("/formio/2024/frf", (req, res) => {
     });
 });
 
-router.get("/formio/2024/prf", (req, res) => {
-  const substring = formIntroSubstring["2024"].prf;
+// router.get("/formio/2024/prf", (req, res) => {
+//   const substring = formIntroSubstring["2024"].prf;
 
-  axiosFormio(req)
-    .get(formUrl["2024"].prf)
-    .then((axiosRes) => axiosRes.data)
-    .then((schema) => {
-      return res.json({ status: verifySchema({ schema, substring }) });
-    })
-    .catch((_error) => {
-      // NOTE: error is logged in axiosFormio response interceptor
-      return res.json({ status: false });
-    });
-});
+//   axiosFormio(req)
+//     .get(formUrl["2024"].prf)
+//     .then((axiosRes) => axiosRes.data)
+//     .then((schema) => {
+//       return res.json({ status: verifySchema({ schema, substring }) });
+//     })
+//     .catch((_error) => {
+//       // NOTE: error is logged in axiosFormio response interceptor
+//       return res.json({ status: false });
+//     });
+// });
 
 // router.get("/formio/2024/crf", (req, res) => {
 //   const substring = formIntroSubstring["2024"].crf;

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -1338,113 +1338,6 @@
         }
       }
     },
-    "/api/formio/2024/prf-submissions": {
-      "get": {
-        "summary": "Get user's 2024 PRF submissions from Formio.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "An array of 2024 PRF submissions.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/api/formio/2024/prf-submission": {
-      "post": {
-        "summary": "Post a new 2024 PRF submission to Formio.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "The newly created 2024 PRF submission.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/api/formio/2024/prf-submission/{rebateId}": {
-      "get": {
-        "summary": "Get an existing 2024 PRF's schema and submission data from Formio.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/rebateId"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The 2024 PRF schema, form submission, and user access status.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FormioSchemaAndSubmission"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "summary": "Post an update to an existing draft 2024 PRF submission to Formio.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/rebateId"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The updated 2024 PRF submission.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/api/formio/2024/delete-prf-submission": {
-      "post": {
-        "summary": "Delete an existing 2024 PRF submission from Formio.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
     "/api/formio/2024/changes": {
       "get": {
         "summary": "Get user's 2024 Change Request form submissions from Formio.",
@@ -1838,17 +1731,6 @@
     "/api/status/formio/2024/frf": {
       "get": {
         "summary": "CSB Formio 2024 FRF schema check.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/api/status/formio/2024/prf": {
-      "get": {
-        "summary": "CSB Formio 2024 PRF schema check.",
         "parameters": [],
         "responses": {
           "200": {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-526

## Main Changes:
Remove the 2024 PRF from the wrapping application.

## Steps To Test:
1. Navigate to the applicant dashboard.
2. Request the BAP team set a 2024 FRF's status to "Accepted."
3. Ensure there is not a "New Payment Request" button below the accepted/selected 2024 FRF.
4. Ensure navigating to an existing 2024 PRF's (from previous form testing) redirects to the user's dashboard.
