### PR TITLE
Feature/update cf app memory config

### DIFF
--- a/app/manifest-dev.yml
+++ b/app/manifest-dev.yml
@@ -5,7 +5,7 @@ applications:
       - route: app-dev.app.cloud.gov/csb
     instances: 1
     memory: 256M
-    disk_quota: 512MB
+    disk_quota: 512M
     timeout: 180
     buildpacks:
       - nodejs_buildpack

--- a/app/manifest-dev.yml
+++ b/app/manifest-dev.yml
@@ -4,7 +4,7 @@ applications:
     routes:
       - route: app-dev.app.cloud.gov/csb
     instances: 1
-    memory: 192M
+    memory: 256M
     disk_quota: 512MB
     timeout: 180
     buildpacks:

--- a/app/manifest-production.yml
+++ b/app/manifest-production.yml
@@ -6,7 +6,7 @@ applications:
       - route: app.epa.gov/csb
     instances: 8
     memory: 256M
-    disk_quota: 512MB
+    disk_quota: 512M
     timeout: 180
     buildpacks:
       - nodejs_buildpack

--- a/app/manifest-production.yml
+++ b/app/manifest-production.yml
@@ -5,7 +5,7 @@ applications:
       - route: app-prod.app.cloud.gov/csb
       - route: app.epa.gov/csb
     instances: 8
-    memory: 192M
+    memory: 256M
     disk_quota: 512MB
     timeout: 180
     buildpacks:

--- a/app/manifest-staging.yml
+++ b/app/manifest-staging.yml
@@ -5,7 +5,7 @@ applications:
       - route: app-stage.app.cloud.gov/csb
     instances: 2
     memory: 256M
-    disk_quota: 512MB
+    disk_quota: 512M
     timeout: 180
     buildpacks:
       - nodejs_buildpack

--- a/app/manifest-staging.yml
+++ b/app/manifest-staging.yml
@@ -4,7 +4,7 @@ applications:
     routes:
       - route: app-stage.app.cloud.gov/csb
     instances: 2
-    memory: 192M
+    memory: 256M
     disk_quota: 512MB
     timeout: 180
     buildpacks:


### PR DESCRIPTION
## Related Issues:
* CSBAPP-559

## Main Changes:
Update the `manifest.yml` files (for all three environments) to reflect the memory allowance change made to the production application after the v7.0.0 release via the command line.

## Steps To Test:
1. Navigate to the application. The app should still function normally with no changes, as this config change will either result in no change at all (if the app's memory was already configured to 256MB per instance for the given environment), or will increase the memory allowance (if the app's memory was configured to a lower amount per instance).
