### PR TITLE
Feature/fix s3 file url

### DIFF
--- a/app/client/src/components/change2023New.tsx
+++ b/app/client/src/components/change2023New.tsx
@@ -40,7 +40,7 @@ type ChangeRequestData = {
   districtState: string;
 };
 
-type Response = { url: string; json: FormType };
+type Response = FormType;
 
 /** Custom hook to fetch Formio schema */
 function useFormioSchemaQuery() {
@@ -295,7 +295,7 @@ function ChangeRequest2023Form(props: {
 
       <div className="csb-form">
         <Form
-          src={formSchema.json}
+          src={formSchema}
           submission={{
             data: {
               _request_form: formType,

--- a/app/client/src/components/change2023New.tsx
+++ b/app/client/src/components/change2023New.tsx
@@ -296,7 +296,6 @@ function ChangeRequest2023Form(props: {
       <div className="csb-form">
         <Form
           src={formSchema.json}
-          url={formSchema.url}
           submission={{
             data: {
               _request_form: formType,

--- a/app/client/src/components/change2024New.tsx
+++ b/app/client/src/components/change2024New.tsx
@@ -296,7 +296,6 @@ function ChangeRequest2024Form(props: {
       <div className="csb-form">
         <Form
           src={formSchema.json}
-          url={formSchema.url}
           submission={{
             data: {
               _request_form: formType,

--- a/app/client/src/components/change2024New.tsx
+++ b/app/client/src/components/change2024New.tsx
@@ -40,7 +40,7 @@ type ChangeRequestData = {
   districtState: string;
 };
 
-type Response = { url: string; json: FormType };
+type Response = FormType;
 
 /** Custom hook to fetch Formio schema */
 function useFormioSchemaQuery() {
@@ -295,7 +295,7 @@ function ChangeRequest2024Form(props: {
 
       <div className="csb-form">
         <Form
-          src={formSchema.json}
+          src={formSchema}
           submission={{
             data: {
               _request_form: formType,

--- a/app/client/src/routes/change2023.tsx
+++ b/app/client/src/routes/change2023.tsx
@@ -74,7 +74,7 @@ export function Change2023() {
 
       <div className="csb-form">
         <Form
-          src={formSchema.json}
+          src={formSchema}
           submission={submission}
           options={{
             readOnly: true,

--- a/app/client/src/routes/change2023.tsx
+++ b/app/client/src/routes/change2023.tsx
@@ -75,7 +75,6 @@ export function Change2023() {
       <div className="csb-form">
         <Form
           src={formSchema.json}
-          url={formSchema.url}
           submission={submission}
           options={{
             readOnly: true,

--- a/app/client/src/routes/change2024.tsx
+++ b/app/client/src/routes/change2024.tsx
@@ -74,7 +74,7 @@ export function Change2024() {
 
       <div className="csb-form">
         <Form
-          src={formSchema.json}
+          src={formSchema}
           submission={submission}
           options={{
             readOnly: true,

--- a/app/client/src/routes/change2024.tsx
+++ b/app/client/src/routes/change2024.tsx
@@ -75,7 +75,6 @@ export function Change2024() {
       <div className="csb-form">
         <Form
           src={formSchema.json}
-          url={formSchema.url}
           submission={submission}
           options={{
             readOnly: true,

--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -273,7 +273,7 @@ function CloseOutRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema.json}
+          src={formSchema}
           url={`${serverUrl}/api/formio/2022/s3/crf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { Formio } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -48,31 +47,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   const query = useQuery({
     queryKey: ["formio/2022/crf-submission", { id: rebateId }],
-    queryFn: () => {
-      return getData<Response>(url).then((res) => {
-        const mongoId = res.submission?._id;
-        const comboKey = res.submission?.data.bap_hidden_entity_combo_key;
-
-        /**
-         * Change the formUrl the File component uses, so the s3 requests are
-         * routed through the CSB server app.
-         *
-         * https://github.com/formio/formio.js/blob/master/src/providers/storage/s3.js
-         */
-        const s3 = Formio.Providers.providers.storage.s3;
-
-        Formio.Providers.providers.storage.s3 = function (param: {
-          formUrl: string;
-          [key: string]: unknown;
-        }) {
-          const updatedParam = cloneDeep(param);
-          updatedParam.formUrl = `${serverUrl}/api/formio/2022/s3/crf/${mongoId}/${comboKey}`;
-          return s3.call(this, updatedParam);
-        };
-
-        return Promise.resolve(res);
-      });
-    },
+    queryFn: () => getData<Response>(url),
     refetchOnWindowFocus: false,
   });
 
@@ -126,6 +101,9 @@ function CloseOutRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const mongoId = submission?._id || "";
+  const comboKey = submission?.data.bap_hidden_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear: "2022",
@@ -296,7 +274,7 @@ function CloseOutRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={formSchema.json}
-          url={formSchema.url}
+          url={`${serverUrl}/api/formio/2022/s3/crf/${mongoId}/${comboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { Formio } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -52,25 +51,6 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
     queryKey: ["formio/2022/frf-submission", { id: mongoId }],
     queryFn: () => {
       return getData<Response>(url).then((res) => {
-        const comboKey = res.submission?.data.bap_hidden_entity_combo_key;
-
-        /**
-         * Change the formUrl the File component uses, so the s3 requests are
-         * routed through the CSB server app.
-         *
-         * https://github.com/formio/formio.js/blob/master/src/providers/storage/s3.js
-         */
-        const s3 = Formio.Providers.providers.storage.s3;
-
-        Formio.Providers.providers.storage.s3 = function (param: {
-          formUrl: string;
-          [key: string]: unknown;
-        }) {
-          const updatedParam = cloneDeep(param);
-          updatedParam.formUrl = `${serverUrl}/api/formio/2022/s3/frf/${mongoId}/${comboKey}`;
-          return s3.call(this, updatedParam);
-        };
-
         const data = { ...res.submission?.data };
 
         // remove `ncesDataSource` field
@@ -137,6 +117,8 @@ function FundingRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const comboKey = submission?.data.bap_hidden_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear: "2022",
@@ -440,7 +422,7 @@ function FundingRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={formSchema.json}
-          url={formSchema.url}
+          url={`${serverUrl}/api/formio/2022/s3/frf/${mongoId}/${comboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -421,7 +421,7 @@ function FundingRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema.json}
+          src={formSchema}
           url={`${serverUrl}/api/formio/2022/s3/frf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { Formio } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -49,30 +48,7 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
   const query = useQuery({
     queryKey: ["formio/2023/frf-submission", { id: mongoId }],
-    queryFn: () => {
-      return getData<Response>(url).then((res) => {
-        const comboKey = res.submission?.data._bap_entity_combo_key;
-
-        /**
-         * Change the formUrl the File component uses, so the s3 requests are
-         * routed through the CSB server app.
-         *
-         * https://github.com/formio/formio.js/blob/master/src/providers/storage/s3.js
-         */
-        const s3 = Formio.Providers.providers.storage.s3;
-
-        Formio.Providers.providers.storage.s3 = function (param: {
-          formUrl: string;
-          [key: string]: unknown;
-        }) {
-          const updatedParam = cloneDeep(param);
-          updatedParam.formUrl = `${serverUrl}/api/formio/2023/s3/frf/${mongoId}/${comboKey}`;
-          return s3.call(this, updatedParam);
-        };
-
-        return Promise.resolve(res);
-      });
-    },
+    queryFn: () => getData<Response>(url),
     refetchOnWindowFocus: false,
   });
 
@@ -125,6 +101,8 @@ function FundingRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const comboKey = submission?.data._bap_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear: "2023",
@@ -428,7 +406,7 @@ function FundingRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={formSchema.json}
-          url={formSchema.url}
+          url={`${serverUrl}/api/formio/2023/s3/frf/${mongoId}/${comboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -405,7 +405,7 @@ function FundingRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema.json}
+          src={formSchema}
           url={`${serverUrl}/api/formio/2023/s3/frf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { Formio } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -49,30 +48,7 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
   const query = useQuery({
     queryKey: ["formio/2024/frf-submission", { id: mongoId }],
-    queryFn: () => {
-      return getData<Response>(url).then((res) => {
-        const comboKey = res.submission?.data._bap_entity_combo_key;
-
-        /**
-         * Change the formUrl the File component uses, so the s3 requests are
-         * routed through the CSB server app.
-         *
-         * https://github.com/formio/formio.js/blob/master/src/providers/storage/s3.js
-         */
-        const s3 = Formio.Providers.providers.storage.s3;
-
-        Formio.Providers.providers.storage.s3 = function (param: {
-          formUrl: string;
-          [key: string]: unknown;
-        }) {
-          const updatedParam = cloneDeep(param);
-          updatedParam.formUrl = `${serverUrl}/api/formio/2024/s3/frf/${mongoId}/${comboKey}`;
-          return s3.call(this, updatedParam);
-        };
-
-        return Promise.resolve(res);
-      });
-    },
+    queryFn: () => getData<Response>(url),
     refetchOnWindowFocus: false,
   });
 
@@ -125,6 +101,8 @@ function FundingRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const comboKey = submission?.data._bap_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear: "2024",
@@ -428,7 +406,7 @@ function FundingRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={formSchema.json}
-          url={formSchema.url}
+          url={`${serverUrl}/api/formio/2024/s3/frf/${mongoId}/${comboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -405,7 +405,7 @@ function FundingRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema.json}
+          src={formSchema}
           url={`${serverUrl}/api/formio/2024/s3/frf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -52,7 +52,7 @@ import {
 
 type Response = {
   rebateId: string | null;
-  formSchema: { url: string; json: FormType } | null;
+  formSchema: FormType | null;
   formio:
     | (
         | FormioFRF2022Submission
@@ -814,7 +814,7 @@ export function Helpdesk() {
               </ul>
 
               <Form
-                src={formSchema.json}
+                src={formSchema}
                 submission={formio}
                 options={{ readOnly: true }}
               />

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -815,7 +815,6 @@ export function Helpdesk() {
 
               <Form
                 src={formSchema.json}
-                url={formSchema.url}
                 submission={formio}
                 options={{ readOnly: true }}
               />

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { Formio } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -48,31 +47,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   const query = useQuery({
     queryKey: ["formio/2022/prf-submission", { id: rebateId }],
-    queryFn: () => {
-      return getData<Response>(url).then((res) => {
-        const mongoId = res.submission?._id;
-        const comboKey = res.submission?.data.bap_hidden_entity_combo_key;
-
-        /**
-         * Change the formUrl the File component uses, so the s3 requests are
-         * routed through the CSB server app.
-         *
-         * https://github.com/formio/formio.js/blob/master/src/providers/storage/s3.js
-         */
-        const s3 = Formio.Providers.providers.storage.s3;
-
-        Formio.Providers.providers.storage.s3 = function (param: {
-          formUrl: string;
-          [key: string]: unknown;
-        }) {
-          const updatedParam = cloneDeep(param);
-          updatedParam.formUrl = `${serverUrl}/api/formio/2022/s3/prf/${mongoId}/${comboKey}`;
-          return s3.call(this, updatedParam);
-        };
-
-        return Promise.resolve(res);
-      });
-    },
+    queryFn: () => getData<Response>(url),
     refetchOnWindowFocus: false,
   });
 
@@ -126,6 +101,9 @@ function PaymentRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const mongoId = submission?._id || "";
+  const comboKey = submission?.data.bap_hidden_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear: "2022",
@@ -317,7 +295,7 @@ function PaymentRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={formSchema.json}
-          url={formSchema.url}
+          url={`${serverUrl}/api/formio/2022/s3/prf/${mongoId}/${comboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -294,7 +294,7 @@ function PaymentRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema.json}
+          src={formSchema}
           url={`${serverUrl}/api/formio/2022/s3/prf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -292,7 +292,7 @@ function PaymentRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema.json}
+          src={formSchema}
           url={`${serverUrl}/api/formio/2023/s3/prf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { Formio } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -48,31 +47,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   const query = useQuery({
     queryKey: ["formio/2023/prf-submission", { id: rebateId }],
-    queryFn: () => {
-      return getData<Response>(url).then((res) => {
-        const mongoId = res.submission?._id;
-        const comboKey = res.submission?.data._bap_entity_combo_key;
-
-        /**
-         * Change the formUrl the File component uses, so the s3 requests are
-         * routed through the CSB server app.
-         *
-         * https://github.com/formio/formio.js/blob/master/src/providers/storage/s3.js
-         */
-        const s3 = Formio.Providers.providers.storage.s3;
-
-        Formio.Providers.providers.storage.s3 = function (param: {
-          formUrl: string;
-          [key: string]: unknown;
-        }) {
-          const updatedParam = cloneDeep(param);
-          updatedParam.formUrl = `${serverUrl}/api/formio/2023/s3/prf/${mongoId}/${comboKey}`;
-          return s3.call(this, updatedParam);
-        };
-
-        return Promise.resolve(res);
-      });
-    },
+    queryFn: () => getData<Response>(url),
     refetchOnWindowFocus: false,
   });
 
@@ -126,6 +101,9 @@ function PaymentRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const mongoId = submission?._id || "";
+  const comboKey = submission?.data._bap_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear: "2023",
@@ -315,7 +293,7 @@ function PaymentRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={formSchema.json}
-          url={formSchema.url}
+          url={`${serverUrl}/api/formio/2023/s3/prf/${mongoId}/${comboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -292,7 +292,7 @@ function PaymentRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema.json}
+          src={formSchema}
           url={`${serverUrl}/api/formio/2024/s3/prf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { Formio } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -48,31 +47,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   const query = useQuery({
     queryKey: ["formio/2024/prf-submission", { id: rebateId }],
-    queryFn: () => {
-      return getData<Response>(url).then((res) => {
-        const mongoId = res.submission?._id;
-        const comboKey = res.submission?.data._bap_entity_combo_key;
-
-        /**
-         * Change the formUrl the File component uses, so the s3 requests are
-         * routed through the CSB server app.
-         *
-         * https://github.com/formio/formio.js/blob/master/src/providers/storage/s3.js
-         */
-        const s3 = Formio.Providers.providers.storage.s3;
-
-        Formio.Providers.providers.storage.s3 = function (param: {
-          formUrl: string;
-          [key: string]: unknown;
-        }) {
-          const updatedParam = cloneDeep(param);
-          updatedParam.formUrl = `${serverUrl}/api/formio/2024/s3/prf/${mongoId}/${comboKey}`;
-          return s3.call(this, updatedParam);
-        };
-
-        return Promise.resolve(res);
-      });
-    },
+    queryFn: () => getData<Response>(url),
     refetchOnWindowFocus: false,
   });
 
@@ -126,6 +101,9 @@ function PaymentRequestForm(props: { email: string }) {
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { userAccess, formSchema, submission } = query.data ?? {};
+
+  const mongoId = submission?._id || "";
+  const comboKey = submission?.data._bap_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear: "2024",
@@ -315,7 +293,7 @@ function PaymentRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={formSchema.json}
-          url={formSchema.url}
+          url={`${serverUrl}/api/formio/2024/s3/prf/${mongoId}/${comboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -636,7 +636,7 @@ export type FormioSchemaAndSubmission<FormioFormSubmission> =
     }
   | {
       userAccess: true;
-      formSchema: { url: string; json: FormType };
+      formSchema: FormType;
       submission: FormioFormSubmission;
     };
 

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -45,7 +45,6 @@ function fetchFormioFormSchema({ formioFormUrl, req }) {
   return axiosFormio(req)
     .get(formioFormUrl)
     .then((axiosRes) => axiosRes.data)
-    .then((schema) => ({ url: formioFormUrl, json: schema }))
     .catch((_error) => {
       // NOTE: error is logged in axiosFormio response interceptor
       return null;

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -1426,7 +1426,7 @@ function fetchFRFSubmission({ rebateYear, req, res }) {
       }
 
       /** Modify 2023 and 2024 FRF's NCES API endpoint URL for local development */
-      const formSchemaJson =
+      const formSchema =
         NODE_ENV === "development" &&
         (rebateYear === "2023" || rebateYear === "2024")
           ? modifyDatasourceComponentsUrl({ schema })
@@ -1434,7 +1434,7 @@ function fetchFRFSubmission({ rebateYear, req, res }) {
 
       return res.json({
         userAccess: true,
-        formSchema: { url: formioFormUrl, json: formSchemaJson },
+        formSchema,
         submission,
       });
     })
@@ -1697,7 +1697,7 @@ function fetchPRFSubmission({ rebateYear, req, res }) {
       }
 
       /** Modify 2024 PRF's NCES API endpoint URL for local development */
-      const formSchemaJson =
+      const formSchema =
         NODE_ENV === "development" && rebateYear === "2024"
           ? modifyDatasourceComponentsUrl({ schema })
           : schema;
@@ -1716,7 +1716,7 @@ function fetchPRFSubmission({ rebateYear, req, res }) {
         .then((submission) => {
           return res.json({
             userAccess: true,
-            formSchema: { url: formioFormUrl, json: formSchemaJson },
+            formSchema,
             submission,
           });
         });
@@ -2089,7 +2089,7 @@ function fetchCRFSubmission({ rebateYear, req, res }) {
         .then((submission) => {
           return res.json({
             userAccess: true,
-            formSchema: { url: formioFormUrl, json: schema },
+            formSchema: schema,
             submission,
           });
         });
@@ -2376,7 +2376,7 @@ function fetchChangeRequest({ rebateYear, req, res }) {
 
       return res.json({
         userAccess: true,
-        formSchema: { url: formioFormUrl, json: schema },
+        formSchema: schema,
         submission,
       });
     })

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -1715,16 +1715,7 @@
                     },
                     "formSchema": {
                       "type": "object",
-                      "nullable": true,
-                      "properties": {
-                        "url": {
-                          "type": "string",
-                          "example": "https://base-path/project-name/form-path"
-                        },
-                        "json": {
-                          "type": "object"
-                        }
-                      }
+                      "nullable": true
                     },
                     "formio": {
                       "type": "object",
@@ -2104,15 +2095,7 @@
           },
           "formSchema": {
             "type": "object",
-            "properties": {
-              "url": {
-                "type": "string",
-                "example": "https://base-path/project-name/form-path"
-              },
-              "json": {
-                "type": "object"
-              }
-            }
+            "nullable": true
           },
           "submission": {
             "type": "object"


### PR DESCRIPTION
## Related Issues:
* CSBAPP-554

## Main Changes:
* Greatly simplifies the method of setting the Formio form url used for S3 file uploads/downloads/deletion requests, and importantly, fixes the bug that's preventing some users from uploading documents if the enrollment period is closed for the first form they view after logging (in production, that would be any FRF).

## Steps To Test:
Ensure the form enrollment period is closed for all FRFs (to match production).

1. Navigate to the dashboard.
2. View an existing FRF (any rebate year).
3. Navigate back to the dashboard, and edit any PRF that's still a draft (any rebate year).
4. Advance through the form, and attempt to upload a document in one of the form's file upload components. The request should succeed.
