### PR TITLE
Feature/update formio api data shape

### DIFF
--- a/app/client/src/components/change2023New.tsx
+++ b/app/client/src/components/change2023New.tsx
@@ -229,7 +229,7 @@ function ChangeRequest2023Form(props: {
   const { query } = useFormioSchemaQuery();
   const { mutation } = useFormioSubmissionMutation();
 
-  const formSchema = query.data;
+  const schema = query.data;
 
   /**
    * Stores when data is being posted to the server, so a loading overlay can
@@ -257,7 +257,7 @@ function ChangeRequest2023Form(props: {
     return <Loading />;
   }
 
-  if (query.isError || !formSchema) {
+  if (query.isError || !schema) {
     return <Message type="error" text={messages.formSchemaError} />;
   }
 
@@ -295,7 +295,7 @@ function ChangeRequest2023Form(props: {
 
       <div className="csb-form">
         <Form
-          src={formSchema}
+          src={schema}
           submission={{
             data: {
               _request_form: formType,

--- a/app/client/src/components/change2024New.tsx
+++ b/app/client/src/components/change2024New.tsx
@@ -229,7 +229,7 @@ function ChangeRequest2024Form(props: {
   const { query } = useFormioSchemaQuery();
   const { mutation } = useFormioSubmissionMutation();
 
-  const formSchema = query.data;
+  const schema = query.data;
 
   /**
    * Stores when data is being posted to the server, so a loading overlay can
@@ -257,7 +257,7 @@ function ChangeRequest2024Form(props: {
     return <Loading />;
   }
 
-  if (query.isError || !formSchema) {
+  if (query.isError || !schema) {
     return <Message type="error" text={messages.formSchemaError} />;
   }
 
@@ -295,7 +295,7 @@ function ChangeRequest2024Form(props: {
 
       <div className="csb-form">
         <Form
-          src={formSchema}
+          src={schema}
           submission={{
             data: {
               _request_form: formType,

--- a/app/client/src/routes/change2023.tsx
+++ b/app/client/src/routes/change2023.tsx
@@ -41,13 +41,13 @@ export function Change2023() {
   const content = useContentData();
 
   const { query } = useFormioSubmissionQuery(mongoId);
-  const { userAccess, formSchema, submission } = query.data ?? {};
+  const { access, schema, submission } = query.data ?? {};
 
   if (query.isInitialLoading) {
     return <Loading />;
   }
 
-  if (query.isError || !userAccess || !formSchema || !submission) {
+  if (query.isError || !access || !schema || !submission) {
     return <Message type="error" text={messages.formSubmissionError} />;
   }
 
@@ -74,7 +74,7 @@ export function Change2023() {
 
       <div className="csb-form">
         <Form
-          src={formSchema}
+          src={schema}
           submission={submission}
           options={{
             readOnly: true,

--- a/app/client/src/routes/change2024.tsx
+++ b/app/client/src/routes/change2024.tsx
@@ -41,13 +41,13 @@ export function Change2024() {
   const content = useContentData();
 
   const { query } = useFormioSubmissionQuery(mongoId);
-  const { userAccess, formSchema, submission } = query.data ?? {};
+  const { access, schema, submission } = query.data ?? {};
 
   if (query.isInitialLoading) {
     return <Loading />;
   }
 
-  if (query.isError || !userAccess || !formSchema || !submission) {
+  if (query.isError || !access || !schema || !submission) {
     return <Message type="error" text={messages.formSubmissionError} />;
   }
 
@@ -74,7 +74,7 @@ export function Change2024() {
 
       <div className="csb-form">
         <Form
-          src={formSchema}
+          src={schema}
           submission={submission}
           options={{
             readOnly: true,

--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -100,7 +100,7 @@ function CloseOutRequestForm(props: { email: string }) {
   const submissions = useSubmissions("2022");
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
-  const { userAccess, formSchema, submission } = query.data ?? {};
+  const { access, schema, submission } = query.data ?? {};
 
   const mongoId = submission?._id || "";
   const comboKey = submission?.data.bap_hidden_entity_combo_key || "";
@@ -158,7 +158,7 @@ function CloseOutRequestForm(props: { email: string }) {
     return <Loading />;
   }
 
-  if (query.isError || !userAccess || !formSchema || !submission) {
+  if (query.isError || !access || !schema || !submission) {
     return <Message type="error" text={messages.formSubmissionError} />;
   }
 
@@ -273,7 +273,7 @@ function CloseOutRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema}
+          src={schema}
           url={`${serverUrl}/api/formio/2022/s3/crf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -116,7 +116,7 @@ function FundingRequestForm(props: { email: string }) {
   const submissions = useSubmissions("2022");
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
-  const { userAccess, formSchema, submission } = query.data ?? {};
+  const { access, schema, submission } = query.data ?? {};
 
   const comboKey = submission?.data.bap_hidden_entity_combo_key || "";
 
@@ -173,7 +173,7 @@ function FundingRequestForm(props: { email: string }) {
     return <Loading />;
   }
 
-  if (query.isError || !userAccess || !formSchema || !submission) {
+  if (query.isError || !access || !schema || !submission) {
     return <Message type="error" text={messages.formSubmissionError} />;
   }
 
@@ -421,7 +421,7 @@ function FundingRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema}
+          src={schema}
           url={`${serverUrl}/api/formio/2022/s3/frf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -100,7 +100,7 @@ function FundingRequestForm(props: { email: string }) {
   const submissions = useSubmissions("2023");
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
-  const { userAccess, formSchema, submission } = query.data ?? {};
+  const { access, schema, submission } = query.data ?? {};
 
   const comboKey = submission?.data._bap_entity_combo_key || "";
 
@@ -157,7 +157,7 @@ function FundingRequestForm(props: { email: string }) {
     return <Loading />;
   }
 
-  if (query.isError || !userAccess || !formSchema || !submission) {
+  if (query.isError || !access || !schema || !submission) {
     return <Message type="error" text={messages.formSubmissionError} />;
   }
 
@@ -405,7 +405,7 @@ function FundingRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema}
+          src={schema}
           url={`${serverUrl}/api/formio/2023/s3/frf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -100,7 +100,7 @@ function FundingRequestForm(props: { email: string }) {
   const submissions = useSubmissions("2024");
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
-  const { userAccess, formSchema, submission } = query.data ?? {};
+  const { access, schema, submission } = query.data ?? {};
 
   const comboKey = submission?.data._bap_entity_combo_key || "";
 
@@ -157,7 +157,7 @@ function FundingRequestForm(props: { email: string }) {
     return <Loading />;
   }
 
-  if (query.isError || !userAccess || !formSchema || !submission) {
+  if (query.isError || !access || !schema || !submission) {
     return <Message type="error" text={messages.formSubmissionError} />;
   }
 
@@ -405,7 +405,7 @@ function FundingRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema}
+          src={schema}
           url={`${serverUrl}/api/formio/2024/s3/frf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -52,7 +52,7 @@ import {
 
 type Response = {
   rebateId: string | null;
-  formSchema: FormType | null;
+  schema: FormType | null;
   formio:
     | (
         | FormioFRF2022Submission
@@ -481,9 +481,9 @@ export function Helpdesk() {
     },
   });
 
-  const { rebateId, formSchema, formio, bap } = submissionQuery.data ?? {
+  const { rebateId, schema, formio, bap } = submissionQuery.data ?? {
     rebateId: null,
-    formSchema: null,
+    schema: null,
     formio: null,
     bap: null,
   };
@@ -808,7 +808,7 @@ export function Helpdesk() {
                 </>
               )}
 
-              {formDisplayed && formSchema && (
+              {formDisplayed && schema && (
                 <>
                   <ul className="usa-icon-list">
                     <li className="usa-icon-list__item">
@@ -841,7 +841,7 @@ export function Helpdesk() {
                   </ul>
 
                   <Form
-                    src={formSchema}
+                    src={schema}
                     submission={formio}
                     options={{ readOnly: true }}
                   />

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -100,7 +100,7 @@ function PaymentRequestForm(props: { email: string }) {
   const submissions = useSubmissions("2022");
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
-  const { userAccess, formSchema, submission } = query.data ?? {};
+  const { access, schema, submission } = query.data ?? {};
 
   const mongoId = submission?._id || "";
   const comboKey = submission?.data.bap_hidden_entity_combo_key || "";
@@ -158,7 +158,7 @@ function PaymentRequestForm(props: { email: string }) {
     return <Loading />;
   }
 
-  if (query.isError || !userAccess || !formSchema || !submission) {
+  if (query.isError || !access || !schema || !submission) {
     return <Message type="error" text={messages.formSubmissionError} />;
   }
 
@@ -294,7 +294,7 @@ function PaymentRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema}
+          src={schema}
           url={`${serverUrl}/api/formio/2022/s3/prf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -100,7 +100,7 @@ function PaymentRequestForm(props: { email: string }) {
   const submissions = useSubmissions("2023");
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
-  const { userAccess, formSchema, submission } = query.data ?? {};
+  const { access, schema, submission } = query.data ?? {};
 
   const mongoId = submission?._id || "";
   const comboKey = submission?.data._bap_entity_combo_key || "";
@@ -158,7 +158,7 @@ function PaymentRequestForm(props: { email: string }) {
     return <Loading />;
   }
 
-  if (query.isError || !userAccess || !formSchema || !submission) {
+  if (query.isError || !access || !schema || !submission) {
     return <Message type="error" text={messages.formSubmissionError} />;
   }
 
@@ -292,7 +292,7 @@ function PaymentRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema}
+          src={schema}
           url={`${serverUrl}/api/formio/2023/s3/prf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -100,7 +100,7 @@ function PaymentRequestForm(props: { email: string }) {
   const submissions = useSubmissions("2024");
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
-  const { userAccess, formSchema, submission } = query.data ?? {};
+  const { access, schema, submission } = query.data ?? {};
 
   const mongoId = submission?._id || "";
   const comboKey = submission?.data._bap_entity_combo_key || "";
@@ -158,7 +158,7 @@ function PaymentRequestForm(props: { email: string }) {
     return <Loading />;
   }
 
-  if (query.isError || !userAccess || !formSchema || !submission) {
+  if (query.isError || !access || !schema || !submission) {
     return <Message type="error" text={messages.formSubmissionError} />;
   }
 
@@ -292,7 +292,7 @@ function PaymentRequestForm(props: { email: string }) {
 
       <div className="csb-form">
         <Form
-          src={formSchema}
+          src={schema}
           url={`${serverUrl}/api/formio/2024/s3/prf/${mongoId}/${comboKey}`}
           submission={{
             /**

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -630,13 +630,13 @@ type FormioChange2024Data = {
 
 export type FormioSchemaAndSubmission<FormioFormSubmission> =
   | {
-      userAccess: false;
-      formSchema: null;
+      access: false;
+      schema: null;
       submission: null;
     }
   | {
-      userAccess: true;
-      formSchema: FormType;
+      access: true;
+      schema: FormType;
       submission: FormioFormSubmission;
     };
 

--- a/app/server/app/config/formio.js
+++ b/app/server/app/config/formio.js
@@ -161,8 +161,8 @@ const formioExampleComboKey = "0000000000000000";
 
 /** JSON response for forms user doesn't have access to */
 const formioNoUserAccess = {
-  userAccess: false,
-  formSchema: null,
+  access: false,
+  schema: null,
   submission: null,
 };
 

--- a/app/server/app/routes/help.js
+++ b/app/server/app/routes/help.js
@@ -205,7 +205,7 @@ router.get("/formio/submission/:rebateYear/:formType/:id", async (req, res) => {
 
   const result = {
     rebateId: null,
-    formSchema: null,
+    schema: null,
     formio: null,
     bap: null,
   };
@@ -234,9 +234,9 @@ router.get("/formio/submission/:rebateYear/:formType/:id", async (req, res) => {
     return res.status(errorStatus).json({ message: errorMessage });
   }
 
-  result.formSchema = await fetchFormioFormSchema({ formioFormUrl, req });
+  result.schema = await fetchFormioFormSchema({ formioFormUrl, req });
 
-  if (!result.formSchema) {
+  if (!result.schema) {
     const errorStatus = 400;
     const errorMessage = `Error getting Formio ${rebateYear} ${formName} form schema.`;
     return res.status(errorStatus).json({ message: errorMessage });

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -1433,8 +1433,8 @@ function fetchFRFSubmission({ rebateYear, req, res }) {
           : schema;
 
       return res.json({
-        userAccess: true,
-        formSchema,
+        access: true,
+        schema: formSchema,
         submission,
       });
     })
@@ -1715,8 +1715,8 @@ function fetchPRFSubmission({ rebateYear, req, res }) {
         .then((axiosRes) => axiosRes.data)
         .then((submission) => {
           return res.json({
-            userAccess: true,
-            formSchema,
+            access: true,
+            schema: formSchema,
             submission,
           });
         });
@@ -2088,8 +2088,8 @@ function fetchCRFSubmission({ rebateYear, req, res }) {
         .then((axiosRes) => axiosRes.data)
         .then((submission) => {
           return res.json({
-            userAccess: true,
-            formSchema: schema,
+            access: true,
+            schema,
             submission,
           });
         });
@@ -2375,8 +2375,8 @@ function fetchChangeRequest({ rebateYear, req, res }) {
       }
 
       return res.json({
-        userAccess: true,
-        formSchema: schema,
+        access: true,
+        schema,
         submission,
       });
     })

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -1713,7 +1713,7 @@
                       "nullable": true,
                       "example": "000000"
                     },
-                    "formSchema": {
+                    "schema": {
                       "type": "object",
                       "nullable": true
                     },
@@ -2089,11 +2089,11 @@
       "FormioSchemaAndSubmission": {
         "type": "object",
         "properties": {
-          "userAccess": {
+          "access": {
             "type": "boolean",
             "example": true
           },
-          "formSchema": {
+          "schema": {
             "type": "object",
             "nullable": true
           },


### PR DESCRIPTION
## Related Issues:
* CSBAPP-562

## Main Changes:
Update API requests for formio schema and submission data to use 'access' and 'schema' keys instead of 'userAccess' and 'formSchema'

## Steps To Test:
1. Navigate to any form submission from any rebate year that you have access to.
2. The form should function properly – the same data is returned, just keys have been renamed.
3. Navigate to the helpdesk page, and search for a form.
4. The results should display for the form – again, the same data is returned, just the keys have been renamed.
