### PR TITLE
Feature/update data fetched for dashboard

### DIFF
--- a/app/client/src/components/change2023New.tsx
+++ b/app/client/src/components/change2023New.tsx
@@ -13,7 +13,7 @@ import { type FormType, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import icons from "uswds/img/sprite.svg";
 // ---
-import { type CSBFormType, type FormioChange2023Submission } from "@/types";
+import { type CSBFormType, type FormioChange2023FormSubmission } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
   getData,
@@ -61,7 +61,7 @@ function useFormioSubmissionMutation() {
 
   const mutation = useMutation({
     mutationFn: (submission: Submission) => {
-      return postData<FormioChange2023Submission>(url, submission);
+      return postData<FormioChange2023FormSubmission>(url, submission);
     },
   });
 

--- a/app/client/src/components/change2024New.tsx
+++ b/app/client/src/components/change2024New.tsx
@@ -13,7 +13,7 @@ import { type FormType, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import icons from "uswds/img/sprite.svg";
 // ---
-import { type CSBFormType, type FormioChange2024Submission } from "@/types";
+import { type CSBFormType, type FormioChange2024FormSubmission } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
   getData,
@@ -61,7 +61,7 @@ function useFormioSubmissionMutation() {
 
   const mutation = useMutation({
     mutationFn: (submission: Submission) => {
-      return postData<FormioChange2024Submission>(url, submission);
+      return postData<FormioChange2024FormSubmission>(url, submission);
     },
   });
 

--- a/app/client/src/routes/change2023.tsx
+++ b/app/client/src/routes/change2023.tsx
@@ -6,7 +6,7 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import {
   type FormioSchemaAndSubmission,
-  type FormioChange2023Submission,
+  type FormioChange2023FormSubmission,
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import { getData, useContentData } from "@/utilities";
@@ -14,7 +14,7 @@ import { Loading } from "@/components/loading";
 import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 
-type Response = FormioSchemaAndSubmission<FormioChange2023Submission>;
+type Response = FormioSchemaAndSubmission<FormioChange2023FormSubmission>;
 
 /** Custom hook to fetch Formio submission data */
 function useFormioSubmissionQuery(mongoId: string | undefined) {

--- a/app/client/src/routes/change2024.tsx
+++ b/app/client/src/routes/change2024.tsx
@@ -6,7 +6,7 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import {
   type FormioSchemaAndSubmission,
-  type FormioChange2024Submission,
+  type FormioChange2024FormSubmission,
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import { getData, useContentData } from "@/utilities";
@@ -14,7 +14,7 @@ import { Loading } from "@/components/loading";
 import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 
-type Response = FormioSchemaAndSubmission<FormioChange2024Submission>;
+type Response = FormioSchemaAndSubmission<FormioChange2024FormSubmission>;
 
 /** Custom hook to fetch Formio submission data */
 function useFormioSubmissionQuery(mongoId: string | undefined) {

--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -9,7 +9,7 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import {
   type FormioSchemaAndSubmission,
-  type FormioCRF2022Submission,
+  type FormioCRF2022FormSubmission,
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
@@ -32,7 +32,7 @@ import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useNotificationsActions } from "@/contexts/notifications";
 
-type Response = FormioSchemaAndSubmission<FormioCRF2022Submission>;
+type Response = FormioSchemaAndSubmission<FormioCRF2022FormSubmission>;
 
 /** Custom hook to fetch and update Formio submission data */
 function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
@@ -56,7 +56,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
       mongoId: string;
       submission: Submission;
     }) => {
-      return postData<FormioCRF2022Submission>(url, updatedSubmission);
+      return postData<FormioCRF2022FormSubmission>(url, updatedSubmission);
     },
     onSuccess: (res, _payload, _context) => {
       return queryClient.setQueryData<Response>(

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -10,7 +10,7 @@ import "bootstrap/dist/css/bootstrap-grid.min.css";
 // ---
 import {
   type FormioSchemaAndSubmission,
-  type FormioFRF2022Submission,
+  type FormioFRF2022FormSubmission,
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
@@ -34,7 +34,7 @@ import { MarkdownContent } from "@/components/markdownContent";
 import { useDialogActions } from "@/contexts/dialog";
 import { useNotificationsActions } from "@/contexts/notifications";
 
-type Response = FormioSchemaAndSubmission<FormioFRF2022Submission>;
+type Response = FormioSchemaAndSubmission<FormioFRF2022FormSubmission>;
 
 /** Custom hook to fetch and update Formio submission data */
 function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
@@ -70,7 +70,7 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
   const mutation = useMutation({
     mutationFn: (updatedSubmission: Submission) => {
-      return postData<FormioFRF2022Submission>(url, updatedSubmission);
+      return postData<FormioFRF2022FormSubmission>(url, updatedSubmission);
     },
     onSuccess: (res, _payload, _context) => {
       return queryClient.setQueryData<Response>(

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -9,7 +9,7 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import {
   type FormioSchemaAndSubmission,
-  type FormioFRF2023Submission,
+  type FormioFRF2023FormSubmission,
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
@@ -33,7 +33,7 @@ import { MarkdownContent } from "@/components/markdownContent";
 import { useDialogActions } from "@/contexts/dialog";
 import { useNotificationsActions } from "@/contexts/notifications";
 
-type Response = FormioSchemaAndSubmission<FormioFRF2023Submission>;
+type Response = FormioSchemaAndSubmission<FormioFRF2023FormSubmission>;
 
 /** Custom hook to fetch and update Formio submission data */
 function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
@@ -54,7 +54,7 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
   const mutation = useMutation({
     mutationFn: (updatedSubmission: Submission) => {
-      return postData<FormioFRF2023Submission>(url, updatedSubmission);
+      return postData<FormioFRF2023FormSubmission>(url, updatedSubmission);
     },
     onSuccess: (res, _payload, _context) => {
       return queryClient.setQueryData<Response>(

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -9,7 +9,7 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import {
   type FormioSchemaAndSubmission,
-  type FormioFRF2024Submission,
+  type FormioFRF2024FormSubmission,
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
@@ -33,7 +33,7 @@ import { MarkdownContent } from "@/components/markdownContent";
 import { useDialogActions } from "@/contexts/dialog";
 import { useNotificationsActions } from "@/contexts/notifications";
 
-type Response = FormioSchemaAndSubmission<FormioFRF2024Submission>;
+type Response = FormioSchemaAndSubmission<FormioFRF2024FormSubmission>;
 
 /** Custom hook to fetch and update Formio submission data */
 function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
@@ -54,7 +54,7 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
   const mutation = useMutation({
     mutationFn: (updatedSubmission: Submission) => {
-      return postData<FormioFRF2024Submission>(url, updatedSubmission);
+      return postData<FormioFRF2024FormSubmission>(url, updatedSubmission);
     },
     onSuccess: (res, _payload, _context) => {
       return queryClient.setQueryData<Response>(

--- a/app/client/src/routes/frfNew.tsx
+++ b/app/client/src/routes/frfNew.tsx
@@ -15,9 +15,9 @@ import icons from "uswds/img/sprite.svg";
 import {
   type RebateYear,
   type BapSamEntity,
-  type FormioFRF2022Submission,
-  type FormioFRF2023Submission,
-  type FormioFRF2024Submission,
+  type FormioFRF2022FormSubmission,
+  type FormioFRF2023FormSubmission,
+  type FormioFRF2024FormSubmission,
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
@@ -341,9 +341,9 @@ export function FRFNew() {
                                           });
 
                                         postData<
-                                          | FormioFRF2022Submission
-                                          | FormioFRF2023Submission
-                                          | FormioFRF2024Submission
+                                          | FormioFRF2022FormSubmission
+                                          | FormioFRF2023FormSubmission
+                                          | FormioFRF2024FormSubmission
                                         >(
                                           `${serverUrl}/api/formio/${rebateYear}/frf-submission/`,
                                           { data, state: "draft" },

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -17,12 +17,15 @@ import {
   type RebateYear,
   type CSBFormType,
   type BapSubmissionData,
-  type FormioFRF2022Submission,
-  type FormioPRF2022Submission,
-  type FormioCRF2022Submission,
-  type FormioFRF2023Submission,
-  type FormioPRF2023Submission,
-  // type FormioCRF2023Submission
+  type FormioFRF2022FormSubmission,
+  type FormioPRF2022FormSubmission,
+  type FormioCRF2022FormSubmission,
+  type FormioFRF2023FormSubmission,
+  type FormioPRF2023FormSubmission,
+  // type FormioCRF2023FormSubmission
+  type FormioFRF2024FormSubmission,
+  // type FormioPRF2025FormSubmission,
+  // type FormioCRF2023FormSubmission
 } from "@/types";
 import {
   serverUrl,
@@ -55,11 +58,12 @@ type Response = {
   schema: FormType | null;
   formio:
     | (
-        | FormioFRF2022Submission
-        | FormioPRF2022Submission
-        | FormioCRF2022Submission
-        | FormioFRF2023Submission
-        | FormioPRF2023Submission
+        | FormioFRF2022FormSubmission
+        | FormioPRF2022FormSubmission
+        | FormioCRF2022FormSubmission
+        | FormioFRF2023FormSubmission
+        | FormioPRF2023FormSubmission
+        | FormioFRF2024FormSubmission
       )
     | null;
   bap: BapSubmissionData | null;
@@ -124,11 +128,12 @@ function ResultTableRow(props: {
   formType: CSBFormType;
   rebateId: string | null;
   formio:
-    | FormioFRF2022Submission
-    | FormioPRF2022Submission
-    | FormioCRF2022Submission
-    | FormioFRF2023Submission
-    | FormioPRF2023Submission;
+    | FormioFRF2022FormSubmission
+    | FormioPRF2022FormSubmission
+    | FormioCRF2022FormSubmission
+    | FormioFRF2023FormSubmission
+    | FormioPRF2023FormSubmission
+    | FormioFRF2024FormSubmission;
   bap: BapSubmissionData | null;
 }) {
   const {

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -9,7 +9,7 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import {
   type FormioSchemaAndSubmission,
-  type FormioPRF2022Submission,
+  type FormioPRF2022FormSubmission,
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
@@ -32,7 +32,7 @@ import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useNotificationsActions } from "@/contexts/notifications";
 
-type Response = FormioSchemaAndSubmission<FormioPRF2022Submission>;
+type Response = FormioSchemaAndSubmission<FormioPRF2022FormSubmission>;
 
 /** Custom hook to fetch and update Formio submission data */
 function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
@@ -56,7 +56,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
       mongoId: string;
       submission: Submission;
     }) => {
-      return postData<FormioPRF2022Submission>(url, updatedSubmission);
+      return postData<FormioPRF2022FormSubmission>(url, updatedSubmission);
     },
     onSuccess: (res, _payload, _context) => {
       return queryClient.setQueryData<Response>(

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -9,7 +9,7 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import {
   type FormioSchemaAndSubmission,
-  type FormioPRF2023Submission,
+  type FormioPRF2023FormSubmission,
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
@@ -32,7 +32,7 @@ import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useNotificationsActions } from "@/contexts/notifications";
 
-type Response = FormioSchemaAndSubmission<FormioPRF2023Submission>;
+type Response = FormioSchemaAndSubmission<FormioPRF2023FormSubmission>;
 
 /** Custom hook to fetch and update Formio submission data */
 function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
@@ -56,7 +56,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
       mongoId: string;
       submission: Submission;
     }) => {
-      return postData<FormioPRF2023Submission>(url, updatedSubmission);
+      return postData<FormioPRF2023FormSubmission>(url, updatedSubmission);
     },
     onSuccess: (res, _payload, _context) => {
       return queryClient.setQueryData<Response>(

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -9,7 +9,7 @@ import icons from "uswds/img/sprite.svg";
 // ---
 import {
   type FormioSchemaAndSubmission,
-  type FormioPRF2024Submission,
+  type FormioPRF2024FormSubmission,
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
@@ -32,7 +32,7 @@ import { Message } from "@/components/message";
 import { MarkdownContent } from "@/components/markdownContent";
 import { useNotificationsActions } from "@/contexts/notifications";
 
-type Response = FormioSchemaAndSubmission<FormioPRF2024Submission>;
+type Response = FormioSchemaAndSubmission<FormioPRF2024FormSubmission>;
 
 /** Custom hook to fetch and update Formio submission data */
 function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
@@ -56,7 +56,7 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
       mongoId: string;
       submission: Submission;
     }) => {
-      return postData<FormioPRF2024Submission>(url, updatedSubmission);
+      return postData<FormioPRF2024FormSubmission>(url, updatedSubmission);
     },
     onSuccess: (res, _payload, _context) => {
       return queryClient.setQueryData<Response>(

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -139,10 +139,17 @@ export type FormioSubmission = Submission & {
   modified: string; // ISO 8601 date time string
 };
 
-type FormioFRF2022Data = {
-  [field: string]: unknown;
-  // fields injected upon a new draft FRF submission creation:
+type FormioFRF2022DashboardDataFields = {
+  applicantUEI: string;
+  applicantEfti: string;
+  applicantEfti_display: string;
+  applicantOrganizationName: string;
+  schoolDistrictName: string;
   last_updated_by: string;
+};
+
+type FormioFRF2022FormDataFields = FormioFRF2022DashboardDataFields & {
+  [field: string]: unknown;
   hidden_current_user_email: string;
   hidden_current_user_title: string;
   hidden_current_user_name: string;
@@ -158,20 +165,17 @@ type FormioFRF2022Data = {
   sam_hidden_applicant_city: string;
   sam_hidden_applicant_state: string;
   sam_hidden_applicant_zip_code: string;
-  // fields set by form definition (among others):
-  applicantUEI: string;
-  applicantEfti: string;
-  applicantEfti_display: string;
-  applicantOrganizationName: string;
-  schoolDistrictName: string;
 };
 
-type FormioPRF2022Data = {
+type FormioPRF2022DashboardDataFields = {
+  hidden_current_user_email: string;
+  hidden_bap_rebate_id: string;
+};
+
+type FormioPRF2022FormDataFields = FormioPRF2022DashboardDataFields & {
   [field: string]: unknown;
-  // fields injected upon a new draft PRF submission creation:
   bap_hidden_entity_combo_key: string;
   hidden_application_form_modified: string; // ISO 8601 date time string,
-  hidden_current_user_email: string;
   hidden_current_user_title: string;
   hidden_current_user_name: string;
   hidden_sam_uei: string;
@@ -180,7 +184,6 @@ type FormioPRF2022Data = {
   hidden_sam_alt_elec_bus_poc_email: string | null;
   hidden_sam_govt_bus_poc_email: string | null;
   hidden_sam_alt_govt_bus_poc_email: string | null;
-  hidden_bap_rebate_id: string;
   hidden_bap_district_id: string;
   hidden_bap_primary_name: string;
   hidden_bap_primary_title: string;
@@ -206,19 +209,20 @@ type FormioPRF2022Data = {
     hidden_bap_max_rebate: number;
   }[];
   purchaseOrders: [];
-  // fields set by form definition (among others):
   applicantName: string;
 };
 
-type FormioCRF2022Data = {
+type FormioCRF2022DashboardDataFields = {
+  hidden_current_user_email: string;
+  hidden_bap_rebate_id: string;
+};
+
+type FormioCRF2022FormDataFields = FormioCRF2022DashboardDataFields & {
   [field: string]: unknown;
-  // fields injected upon a new draft CRF submission creation:
   bap_hidden_entity_combo_key: string;
   hidden_prf_modified: string; // ISO 8601 date time string
-  hidden_current_user_email: string;
   hidden_current_user_title: string;
   hidden_current_user_name: string;
-  hidden_bap_rebate_id: string;
   hidden_sam_uei: string;
   hidden_sam_efti: string;
   hidden_sam_elec_bus_poc_email: string | null;
@@ -287,29 +291,13 @@ type FormioCRF2022Data = {
     hidden_prf_newBusPurchasePrice: number;
     hidden_prf_rebate: number;
   }[];
-  // fields set by form definition (among others):
   signatureName: string;
 };
 
-type FormioFRF2023Data = {
-  [field: string]: unknown;
-  // fields injected upon a new draft FRF submission creation:
+type FormioFRF2023DashboardDataFields = {
   _user_email: string;
-  _user_title: string;
-  _user_name: string;
   _bap_entity_combo_key: string;
-  _bap_applicant_email: string;
-  _bap_applicant_title: string;
   _bap_applicant_name: string;
-  _bap_applicant_efti: string;
-  _bap_applicant_uei: string;
-  _bap_applicant_organization_name: string;
-  _bap_applicant_street_address_1: string;
-  _bap_applicant_street_address_2: string;
-  _bap_applicant_city: string;
-  _bap_applicant_state: string;
-  _bap_applicant_zip: string;
-  // fields set by form definition (among others):
   appInfo_uei: string;
   appInfo_efti: string;
   appInfo_orgName: string;
@@ -318,18 +306,38 @@ type FormioFRF2023Data = {
   org_district_state: string;
 };
 
-type FormioPRF2023Data = {
+type FormioFRF2023FormDataFields = FormioFRF2023DashboardDataFields & {
   [field: string]: unknown;
-  // fields injected upon a new draft PRF submission creation:
-  _application_form_modified: string;
-  _bap_entity_combo_key: string;
-  _bap_rebate_id: string;
-  _user_email: string;
   _user_title: string;
   _user_name: string;
   _bap_applicant_email: string;
   _bap_applicant_title: string;
+  _bap_applicant_efti: string;
+  _bap_applicant_uei: string;
+  _bap_applicant_organization_name: string;
+  _bap_applicant_street_address_1: string;
+  _bap_applicant_street_address_2: string;
+  _bap_applicant_city: string;
+  _bap_applicant_state: string;
+  _bap_applicant_zip: string;
+};
+
+type FormioPRF2023DashboardDataFields = {
+  _user_email: string;
+  _bap_entity_combo_key: string;
+  _bap_rebate_id: string;
   _bap_applicant_name: string;
+  _bap_district_name: string;
+  _bap_district_state: string;
+};
+
+type FormioPRF2023FormDataFields = FormioPRF2023DashboardDataFields & {
+  [field: string]: unknown;
+  _application_form_modified: string;
+  _user_title: string;
+  _user_name: string;
+  _bap_applicant_email: string;
+  _bap_applicant_title: string;
   _bap_applicant_efti: string;
   _bap_applicant_uei: string;
   _bap_applicant_organization_id: string;
@@ -358,11 +366,9 @@ type FormioPRF2023Data = {
   _bap_alternate_phone: string | null;
   _bap_district_id: string;
   _bap_district_nces_id: string;
-  _bap_district_name: string;
   _bap_district_address_1: string;
   _bap_district_address_2: string;
   _bap_district_city: string;
-  _bap_district_state: string;
   _bap_district_zip: string;
   _bap_district_priority: string;
   _bap_district_priority_reason: {
@@ -435,19 +441,20 @@ type FormioPRF2023Data = {
   }[];
 };
 
-type FormioCRF2023Data = {
-  [field: string]: unknown;
-  // fields injected upon a new draft CRF submission creation:
+type FormioCRF2023DashboardDataFields = {
   _user_email: string;
+  _bap_entity_combo_key: string;
+};
+
+type FormioCRF2023FormDataFields = FormioCRF2023DashboardDataFields & {
+  [field: string]: unknown;
   _user_title: string;
   _user_name: string;
-  _bap_entity_combo_key: string;
   _bap_rebate_id: string;
 };
 
-type FormioChange2023Data = {
+type FormioChange2023FormDataFields = {
   [field: string]: unknown;
-  // fields injected upon a new draft Change Request form submission creation:
   _request_form: CSBFormType;
   _bap_entity_combo_key: string;
   _bap_rebate_id: string;
@@ -455,20 +462,30 @@ type FormioChange2023Data = {
   _user_email: string;
   _user_title: string;
   _user_name: string;
-  // fields set by the form definition (among others):
-  request_type: { label: string; value: string };
+  request_type: {
+    label: string;
+    value: string;
+  };
 };
 
-type FormioFRF2024Data = {
-  [field: string]: unknown;
-  // fields injected upon a new draft FRF submission creation:
+type FormioFRF2024DashboardDataFields = {
   _user_email: string;
+  _bap_entity_combo_key: string;
+  _bap_applicant_name: string;
+  _formio_schoolDistrictName: string;
+  appInfo_uei: string;
+  appInfo_efti: string;
+  appInfo_organization_name: string;
+  org_district_name: string;
+  org_district_state: string;
+};
+
+type FormioFRF2024FormDataFields = FormioFRF2024DashboardDataFields & {
+  [field: string]: unknown;
   _user_title: string;
   _user_name: string;
-  _bap_entity_combo_key: string;
   _bap_applicant_email: string;
   _bap_applicant_title: string;
-  _bap_applicant_name: string;
   _bap_applicant_efti: string;
   _bap_applicant_uei: string;
   _bap_applicant_organization_name: string;
@@ -477,27 +494,24 @@ type FormioFRF2024Data = {
   _bap_applicant_city: string;
   _bap_applicant_state: string;
   _bap_applicant_zip: string;
-  // fields set by form definition (among others):
-  appInfo_uei: string;
-  appInfo_efti: string;
-  appInfo_organization_name: string;
-  _formio_schoolDistrictName: string;
-  org_district_name: string;
-  org_district_state: string;
 };
 
-type FormioPRF2024Data = {
-  [field: string]: unknown;
-  // fields injected upon a new draft PRF submission creation:
-  _frf_modified: string;
+type FormioPRF2024DashboardDataFields = {
+  _user_email: string;
   _bap_entity_combo_key: string;
   _bap_rebate_id: string;
-  _user_email: string;
+  _bap_applicant_name: string;
+  _bap_district_name: string;
+  _bap_district_state: string;
+};
+
+type FormioPRF2024FormDataFields = FormioPRF2024DashboardDataFields & {
+  [field: string]: unknown;
+  _frf_modified: string;
   _user_title: string;
   _user_name: string;
   _bap_applicant_email: string;
   _bap_applicant_title: string;
-  _bap_applicant_name: string;
   _bap_applicant_efti: string;
   _bap_applicant_uei: string;
   _bap_applicant_organization_id: string;
@@ -526,11 +540,9 @@ type FormioPRF2024Data = {
   _bap_alternate_phone: string | null;
   _bap_district_id: string;
   _bap_district_nces_id: string;
-  _bap_district_name: string;
   _bap_district_address_1: string;
   _bap_district_address_2: string;
   _bap_district_city: string;
-  _bap_district_state: string;
   _bap_district_zip: string;
   _bap_district_priority: string;
   _bap_district_priority_reason: {
@@ -604,19 +616,20 @@ type FormioPRF2024Data = {
   }[];
 };
 
-type FormioCRF2024Data = {
-  [field: string]: unknown;
-  // fields injected upon a new draft CRF submission creation:
+type FormioCRF2024DashboardDataFields = {
   _user_email: string;
+  _bap_entity_combo_key: string;
+};
+
+type FormioCRF2024FormDataFields = FormioCRF2024DashboardDataFields & {
+  [field: string]: unknown;
   _user_title: string;
   _user_name: string;
-  _bap_entity_combo_key: string;
   _bap_rebate_id: string;
 };
 
-type FormioChange2024Data = {
+type FormioChange2024FormDataFields = {
   [field: string]: unknown;
-  // fields injected upon a new draft Change Request form submission creation:
   _request_form: CSBFormType;
   _bap_entity_combo_key: string;
   _bap_rebate_id: string;
@@ -624,8 +637,10 @@ type FormioChange2024Data = {
   _user_email: string;
   _user_title: string;
   _user_name: string;
-  // fields set by the form definition (among others):
-  request_type: { label: string; value: string };
+  request_type: {
+    label: string;
+    value: string;
+  };
 };
 
 export type FormioSchemaAndSubmission<FormioFormSubmission> =
@@ -640,62 +655,98 @@ export type FormioSchemaAndSubmission<FormioFormSubmission> =
       submission: FormioFormSubmission;
     };
 
-export type FormioFRF2022Submission = FormioSubmission & {
-  data: FormioFRF2022Data;
+export type FormioFRF2022DashboardSubmission = FormioSubmission & {
+  data: FormioFRF2022DashboardDataFields;
 };
 
-export type FormioPRF2022Submission = FormioSubmission & {
-  data: FormioPRF2022Data;
+export type FormioFRF2022FormSubmission = FormioSubmission & {
+  data: FormioFRF2022FormDataFields;
 };
 
-export type FormioCRF2022Submission = FormioSubmission & {
-  data: FormioCRF2022Data;
+export type FormioPRF2022DashboardSubmission = FormioSubmission & {
+  data: FormioPRF2022DashboardDataFields;
 };
 
-export type FormioFRF2023Submission = FormioSubmission & {
-  data: FormioFRF2023Data;
+export type FormioPRF2022FormSubmission = FormioSubmission & {
+  data: FormioPRF2022FormDataFields;
 };
 
-export type FormioPRF2023Submission = FormioSubmission & {
-  data: FormioPRF2023Data;
+export type FormioCRF2022DashboardSubmission = FormioSubmission & {
+  data: FormioCRF2022DashboardDataFields;
 };
 
-export type FormioCRF2023Submission = FormioSubmission & {
-  data: FormioCRF2023Data;
+export type FormioCRF2022FormSubmission = FormioSubmission & {
+  data: FormioCRF2022FormDataFields;
 };
 
-export type FormioChange2023Submission = FormioSubmission & {
-  data: FormioChange2023Data;
+export type FormioFRF2023DashboardSubmission = FormioSubmission & {
+  data: FormioFRF2023DashboardDataFields;
 };
 
-export type FormioFRF2024Submission = FormioSubmission & {
-  data: FormioFRF2024Data;
+export type FormioFRF2023FormSubmission = FormioSubmission & {
+  data: FormioFRF2023FormDataFields;
 };
 
-export type FormioPRF2024Submission = FormioSubmission & {
-  data: FormioPRF2024Data;
+export type FormioPRF2023DashboardSubmission = FormioSubmission & {
+  data: FormioPRF2023DashboardDataFields;
 };
 
-export type FormioCRF2024Submission = FormioSubmission & {
-  data: FormioCRF2024Data;
+export type FormioPRF2023FormSubmission = FormioSubmission & {
+  data: FormioPRF2023FormDataFields;
 };
 
-export type FormioChange2024Submission = FormioSubmission & {
-  data: FormioChange2024Data;
+export type FormioCRF2023DashboardSubmission = FormioSubmission & {
+  data: FormioCRF2023DashboardDataFields;
+};
+
+export type FormioCRF2023FormSubmission = FormioSubmission & {
+  data: FormioCRF2023FormDataFields;
+};
+
+export type FormioChange2023FormSubmission = FormioSubmission & {
+  data: FormioChange2023FormDataFields;
+};
+
+export type FormioFRF2024DashboardSubmission = FormioSubmission & {
+  data: FormioFRF2024DashboardDataFields;
+};
+
+export type FormioFRF2024FormSubmission = FormioSubmission & {
+  data: FormioFRF2024FormDataFields;
+};
+
+export type FormioPRF2024DashboardSubmission = FormioSubmission & {
+  data: FormioPRF2024DashboardDataFields;
+};
+
+export type FormioPRF2024FormSubmission = FormioSubmission & {
+  data: FormioPRF2024FormDataFields;
+};
+
+export type FormioCRF2024DashboardSubmission = FormioSubmission & {
+  data: FormioCRF2024DashboardDataFields;
+};
+
+export type FormioCRF2024FormSubmission = FormioSubmission & {
+  data: FormioCRF2024FormDataFields;
+};
+
+export type FormioChange2024FormSubmission = FormioSubmission & {
+  data: FormioChange2024FormDataFields;
 };
 
 export type Rebate2022 = {
   rebateYear: "2022";
   frf: {
-    formio: FormioFRF2022Submission;
+    formio: FormioFRF2022DashboardSubmission;
     bap: BapSubmissionData | null;
   };
   prf: {
-    formio: FormioPRF2022Submission | null;
+    formio: FormioPRF2022DashboardSubmission | null;
     bap: BapSubmissionData | null;
   };
   crf: {
-    formio: FormioCRF2022Submission | null;
+    formio: FormioCRF2022DashboardSubmission | null;
     bap: BapSubmissionData | null;
   };
 };
@@ -703,15 +754,15 @@ export type Rebate2022 = {
 export type Rebate2023 = {
   rebateYear: "2023";
   frf: {
-    formio: FormioFRF2023Submission;
+    formio: FormioFRF2023DashboardSubmission;
     bap: BapSubmissionData | null;
   };
   prf: {
-    formio: FormioPRF2023Submission | null;
+    formio: FormioPRF2023DashboardSubmission | null;
     bap: BapSubmissionData | null;
   };
   crf: {
-    formio: FormioCRF2023Submission | null;
+    formio: FormioCRF2023DashboardSubmission | null;
     bap: BapSubmissionData | null;
   };
 };
@@ -719,15 +770,15 @@ export type Rebate2023 = {
 export type Rebate2024 = {
   rebateYear: "2024";
   frf: {
-    formio: FormioFRF2024Submission;
+    formio: FormioFRF2024DashboardSubmission;
     bap: BapSubmissionData | null;
   };
   prf: {
-    formio: FormioPRF2024Submission | null;
+    formio: FormioPRF2024DashboardSubmission | null;
     bap: BapSubmissionData | null;
   };
   crf: {
-    formio: FormioCRF2024Submission | null;
+    formio: FormioCRF2024DashboardSubmission | null;
     bap: BapSubmissionData | null;
   };
 };

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -44,7 +44,7 @@ import {
 
 /** Formio Change Request submissions by rebate year. */
 /* prettier-ignore */
-type FormioChangeRequests<Year> =
+type FormioChangeRequestsByYear<Year> =
   Year extends "2022" ? never[] | undefined :
   Year extends "2023" ? FormioChange2023FormSubmission[] | undefined :
   Year extends "2024" ? FormioChange2024FormSubmission[] | undefined :
@@ -52,7 +52,7 @@ type FormioChangeRequests<Year> =
 
 /** BAP and Formio submissions by rebate year. */
 /* prettier-ignore */
-type BapAndFormioSubmissions<Year> =
+type BapAndFormioSubmissionsByYear<Year> =
   Year extends "2022" ? BapFormSubmissions | FormioFRF2022DashboardSubmission[] | FormioPRF2022DashboardSubmission[] | FormioCRF2022DashboardSubmission[] :
   Year extends "2023" ? BapFormSubmissions | FormioFRF2023DashboardSubmission[] | FormioPRF2023DashboardSubmission[] | FormioCRF2023DashboardSubmission[] :
   Year extends "2024" ? BapFormSubmissions | FormioFRF2024DashboardSubmission[] | FormioPRF2024DashboardSubmission[] | FormioCRF2024DashboardSubmission[] :
@@ -63,7 +63,7 @@ type BapAndFormioSubmissions<Year> =
  * (FRF, PRF, CRF) for a given rebate year.
  */
 /* prettier-ignore */
-type Rebate<Year> =
+type RebateByYear<Year> =
   Year extends "2022" ? Rebate2022 :
   Year extends "2023" ? Rebate2023 :
   Year extends "2024" ? Rebate2024 :
@@ -261,7 +261,7 @@ export function useSubmissionPDFQuery(options: {
 /** Custom hook to fetch Change Request form submissions from Formio. */
 export function useChangeRequestsQuery<Year extends RebateYear>(
   rebateYear: Year,
-): UseQueryResult<FormioChangeRequests<Year>> {
+): UseQueryResult<FormioChangeRequestsByYear<Year>> {
   /*
    * NOTE: Change Request form was added in the 2023 rebate year, so there's no
    * change request data to fetch for 2022.
@@ -297,7 +297,7 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
     refetchOnWindowFocus: false,
   };
 
-  const query: UseQueryOptions<BapAndFormioSubmissions<RebateYear>> =
+  const query: UseQueryOptions<BapAndFormioSubmissionsByYear<RebateYear>> =
     rebateYear === "2022"
       ? changeRequest2022Query
       : rebateYear === "2023"
@@ -306,7 +306,7 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
           ? changeRequest2024Query
           : changeRequestFallbackQuery;
 
-  return useQuery(query) as UseQueryResult<FormioChangeRequests<Year>>;
+  return useQuery(query) as UseQueryResult<FormioChangeRequestsByYear<Year>>;
 }
 
 /**
@@ -315,14 +315,14 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
  */
 export function useChangeRequests<Year extends RebateYear>(
   rebateYear: Year,
-): FormioChangeRequests<Year> {
+): FormioChangeRequestsByYear<Year> {
   const queryClient = useQueryClient();
 
   const changeRequest2022Data = queryClient.getQueryData<[]>(["formio/2022/changes"]); // prettier-ignore
   const changeRequest2023Data = queryClient.getQueryData<FormioChange2023FormSubmission[]>(["formio/2023/changes"]); // prettier-ignore
   const changeRequest2024Data = queryClient.getQueryData<FormioChange2024FormSubmission[]>(["formio/2024/changes"]); // prettier-ignore
 
-  const result: FormioChangeRequests<RebateYear> =
+  const result: FormioChangeRequestsByYear<RebateYear> =
     rebateYear === "2022"
       ? changeRequest2022Data
       : rebateYear === "2023"
@@ -331,13 +331,13 @@ export function useChangeRequests<Year extends RebateYear>(
           ? changeRequest2024Data
           : undefined;
 
-  return result as FormioChangeRequests<Year>;
+  return result as FormioChangeRequestsByYear<Year>;
 }
 
 /** Custom hook to fetch submissions from the BAP and Formio. */
 export function useSubmissionsQueries<Year extends RebateYear>(
   rebateYear: Year,
-): UseQueryResult<BapAndFormioSubmissions<Year>>[] {
+): UseQueryResult<BapAndFormioSubmissionsByYear<Year>>[] {
   const bapQuery = {
     queryKey: ["bap/submissions"],
     queryFn: () => {
@@ -475,7 +475,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
     refetchOnWindowFocus: false,
   };
 
-  const queries: UseQueryOptions<BapAndFormioSubmissions<RebateYear>>[] =
+  const queries: UseQueryOptions<BapAndFormioSubmissionsByYear<RebateYear>>[] =
     rebateYear === "2022"
       ? [bapQuery, formioFRF2022Query, formioPRF2022Query, formioCRF2022Query]
       : rebateYear === "2023"
@@ -485,7 +485,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
           : [];
 
   return useQueries({ queries }) as UseQueryResult<
-    BapAndFormioSubmissions<Year>
+    BapAndFormioSubmissionsByYear<Year>
   >[];
 }
 
@@ -496,7 +496,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
  **/
 function useCombinedSubmissions<Year extends RebateYear>(
   rebateYear: Year,
-): { [rebateId: string]: Rebate<Year> } {
+): { [rebateId: string]: RebateByYear<Year> } {
   const queryClient = useQueryClient();
 
   const bapFormSubmissions = queryClient.getQueryData<BapFormSubmissions>(["bap/submissions"]); // prettier-ignore
@@ -541,7 +541,7 @@ function useCombinedSubmissions<Year extends RebateYear>(
           : undefined;
 
   const submissions: {
-    [rebateId: string]: Rebate<Year>;
+    [rebateId: string]: RebateByYear<Year>;
   } = {};
 
   /* ensure form submissions data has been fetched from both the BAP and Formio */
@@ -597,7 +597,7 @@ function useCombinedSubmissions<Year extends RebateYear>(
       },
       prf: { formio: null, bap: null },
       crf: { formio: null, bap: null },
-    } as Rebate<Year>;
+    } as RebateByYear<Year>;
   }
 
   /**
@@ -633,7 +633,7 @@ function useCombinedSubmissions<Year extends RebateYear>(
           status,
           reimbursementNeeded,
         },
-      } as Rebate<Year>["prf"];
+      } as RebateByYear<Year>["prf"];
     }
   }
 
@@ -670,7 +670,7 @@ function useCombinedSubmissions<Year extends RebateYear>(
           status,
           reimbursementNeeded,
         },
-      } as Rebate<Year>["crf"];
+      } as RebateByYear<Year>["crf"];
     }
   }
 
@@ -685,8 +685,8 @@ function useCombinedSubmissions<Year extends RebateYear>(
  * - Funding Approved PRF submissions without a corresponding CRF submission
  **/
 function useSortedSubmissions<Year extends RebateYear>(rebates: {
-  [rebateId: string]: Rebate<Year>;
-}): (Rebate<Year> & { rebateId: string })[] {
+  [rebateId: string]: RebateByYear<Year>;
+}): (RebateByYear<Year> & { rebateId: string })[] {
   return Object.entries(rebates)
     .map(([rebateId, rebate]) => ({ rebateId, ...rebate }))
     .sort((r1, r2) => {

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -21,17 +21,17 @@ import {
   type BapFormSubmissions,
   type BapSubmissionData,
   type FormioSubmission,
-  type FormioFRF2022Submission,
-  type FormioPRF2022Submission,
-  type FormioCRF2022Submission,
-  type FormioFRF2023Submission,
-  type FormioPRF2023Submission,
-  type FormioCRF2023Submission,
-  type FormioChange2023Submission,
-  type FormioFRF2024Submission,
-  type FormioPRF2024Submission,
-  type FormioCRF2024Submission,
-  type FormioChange2024Submission,
+  type FormioFRF2022DashboardSubmission,
+  type FormioPRF2022DashboardSubmission,
+  type FormioCRF2022DashboardSubmission,
+  type FormioFRF2023DashboardSubmission,
+  type FormioPRF2023DashboardSubmission,
+  type FormioCRF2023DashboardSubmission,
+  type FormioChange2023FormSubmission,
+  type FormioFRF2024DashboardSubmission,
+  type FormioPRF2024DashboardSubmission,
+  type FormioCRF2024DashboardSubmission,
+  type FormioChange2024FormSubmission,
   type Rebate2022,
   type Rebate2023,
   type Rebate2024,
@@ -46,16 +46,16 @@ import {
 /* prettier-ignore */
 type FormioChangeRequests<Year> =
   Year extends "2022" ? never[] | undefined :
-  Year extends "2023" ? FormioChange2023Submission[] | undefined :
-  Year extends "2024" ? FormioChange2024Submission[] | undefined :
+  Year extends "2023" ? FormioChange2023FormSubmission[] | undefined :
+  Year extends "2024" ? FormioChange2024FormSubmission[] | undefined :
   never;
 
 /** BAP and Formio submissions by rebate year. */
 /* prettier-ignore */
 type BapAndFormioSubmissions<Year> =
-  Year extends "2022" ? BapFormSubmissions | FormioFRF2022Submission[] | FormioPRF2022Submission[] | FormioCRF2022Submission[] :
-  Year extends "2023" ? BapFormSubmissions | FormioFRF2023Submission[] | FormioPRF2023Submission[] | FormioCRF2023Submission[] :
-  Year extends "2024" ? BapFormSubmissions | FormioFRF2024Submission[] | FormioPRF2024Submission[] | FormioCRF2024Submission[] :
+  Year extends "2022" ? BapFormSubmissions | FormioFRF2022DashboardSubmission[] | FormioPRF2022DashboardSubmission[] | FormioCRF2022DashboardSubmission[] :
+  Year extends "2023" ? BapFormSubmissions | FormioFRF2023DashboardSubmission[] | FormioPRF2023DashboardSubmission[] | FormioCRF2023DashboardSubmission[] :
+  Year extends "2024" ? BapFormSubmissions | FormioFRF2024DashboardSubmission[] | FormioPRF2024DashboardSubmission[] | FormioCRF2024DashboardSubmission[] :
   never;
 
 /**
@@ -276,7 +276,7 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
     queryKey: ["formio/2023/changes"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2023/changes`;
-      return getData<FormioChange2023Submission[]>(url);
+      return getData<FormioChange2023FormSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -285,7 +285,7 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
     queryKey: ["formio/2024/changes"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2024/changes`;
-      return getData<FormioChange2024Submission[]>(url);
+      return getData<FormioChange2024FormSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -319,8 +319,8 @@ export function useChangeRequests<Year extends RebateYear>(
   const queryClient = useQueryClient();
 
   const changeRequest2022Data = queryClient.getQueryData<[]>(["formio/2022/changes"]); // prettier-ignore
-  const changeRequest2023Data = queryClient.getQueryData<FormioChange2023Submission[]>(["formio/2023/changes"]); // prettier-ignore
-  const changeRequest2024Data = queryClient.getQueryData<FormioChange2024Submission[]>(["formio/2024/changes"]); // prettier-ignore
+  const changeRequest2023Data = queryClient.getQueryData<FormioChange2023FormSubmission[]>(["formio/2023/changes"]); // prettier-ignore
+  const changeRequest2024Data = queryClient.getQueryData<FormioChange2024FormSubmission[]>(["formio/2024/changes"]); // prettier-ignore
 
   const result: FormioChangeRequests<RebateYear> =
     rebateYear === "2022"
@@ -398,7 +398,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
     queryKey: ["formio/2022/frf-submissions"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2022/frf-submissions`;
-      return getData<FormioFRF2022Submission[]>(url);
+      return getData<FormioFRF2022DashboardSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -407,7 +407,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
     queryKey: ["formio/2022/prf-submissions"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2022/prf-submissions`;
-      return getData<FormioPRF2022Submission[]>(url);
+      return getData<FormioPRF2022DashboardSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -416,7 +416,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
     queryKey: ["formio/2022/crf-submissions"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2022/crf-submissions`;
-      return getData<FormioCRF2022Submission[]>(url);
+      return getData<FormioCRF2022DashboardSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -425,7 +425,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
     queryKey: ["formio/2023/frf-submissions"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2023/frf-submissions`;
-      return getData<FormioFRF2023Submission[]>(url);
+      return getData<FormioFRF2023DashboardSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -434,7 +434,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
     queryKey: ["formio/2023/prf-submissions"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2023/prf-submissions`;
-      return getData<FormioPRF2023Submission[]>(url);
+      return getData<FormioPRF2023DashboardSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -443,7 +443,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
     queryKey: ["formio/2023/crf-submissions"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2023/crf-submissions`;
-      return getData<FormioCRF2023Submission[]>(url);
+      return getData<FormioCRF2023DashboardSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -452,7 +452,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
     queryKey: ["formio/2024/frf-submissions"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2024/frf-submissions`;
-      return getData<FormioFRF2024Submission[]>(url);
+      return getData<FormioFRF2024DashboardSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -461,7 +461,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
     queryKey: ["formio/2024/prf-submissions"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2024/prf-submissions`;
-      return getData<FormioPRF2024Submission[]>(url);
+      return getData<FormioPRF2024DashboardSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -470,7 +470,7 @@ export function useSubmissionsQueries<Year extends RebateYear>(
     queryKey: ["formio/2024/crf-submissions"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2024/crf-submissions`;
-      return getData<FormioCRF2024Submission[]>(url);
+      return getData<FormioCRF2024DashboardSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -501,17 +501,17 @@ function useCombinedSubmissions<Year extends RebateYear>(
 
   const bapFormSubmissions = queryClient.getQueryData<BapFormSubmissions>(["bap/submissions"]); // prettier-ignore
 
-  const formioFRF2022Data = queryClient.getQueryData<FormioFRF2022Submission[]>(["formio/2022/frf-submissions"]); // prettier-ignore
-  const formioFRF2023Data = queryClient.getQueryData<FormioFRF2023Submission[]>(["formio/2023/frf-submissions"]); // prettier-ignore
-  const formioFRF2024Data = queryClient.getQueryData<FormioFRF2024Submission[]>(["formio/2024/frf-submissions"]); // prettier-ignore
+  const formioFRF2022Data = queryClient.getQueryData<FormioFRF2022DashboardSubmission[]>(["formio/2022/frf-submissions"]); // prettier-ignore
+  const formioFRF2023Data = queryClient.getQueryData<FormioFRF2023DashboardSubmission[]>(["formio/2023/frf-submissions"]); // prettier-ignore
+  const formioFRF2024Data = queryClient.getQueryData<FormioFRF2024DashboardSubmission[]>(["formio/2024/frf-submissions"]); // prettier-ignore
 
-  const formioPRF2022Data = queryClient.getQueryData<FormioPRF2022Submission[]>(["formio/2022/prf-submissions"]); // prettier-ignore
-  const formioPRF2023Data = queryClient.getQueryData<FormioPRF2023Submission[]>(["formio/2023/prf-submissions"]); // prettier-ignore
-  const formioPRF2024Data = queryClient.getQueryData<FormioPRF2024Submission[]>(["formio/2024/prf-submissions"]); // prettier-ignore
+  const formioPRF2022Data = queryClient.getQueryData<FormioPRF2022DashboardSubmission[]>(["formio/2022/prf-submissions"]); // prettier-ignore
+  const formioPRF2023Data = queryClient.getQueryData<FormioPRF2023DashboardSubmission[]>(["formio/2023/prf-submissions"]); // prettier-ignore
+  const formioPRF2024Data = queryClient.getQueryData<FormioPRF2024DashboardSubmission[]>(["formio/2024/prf-submissions"]); // prettier-ignore
 
-  const formioCRF2022Data = queryClient.getQueryData<FormioCRF2022Submission[]>(["formio/2022/crf-submissions"]); // prettier-ignore
-  const formioCRF2023Data = queryClient.getQueryData<FormioCRF2023Submission[]>(["formio/2023/crf-submissions"]); // prettier-ignore
-  const formioCRF2024Data = queryClient.getQueryData<FormioCRF2024Submission[]>(["formio/2024/crf-submissions"]); // prettier-ignore
+  const formioCRF2022Data = queryClient.getQueryData<FormioCRF2022DashboardSubmission[]>(["formio/2022/crf-submissions"]); // prettier-ignore
+  const formioCRF2023Data = queryClient.getQueryData<FormioCRF2023DashboardSubmission[]>(["formio/2023/crf-submissions"]); // prettier-ignore
+  const formioCRF2024Data = queryClient.getQueryData<FormioCRF2024DashboardSubmission[]>(["formio/2024/crf-submissions"]); // prettier-ignore
 
   const formioFRFSubmissions =
     rebateYear === "2022"

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -30,6 +30,61 @@ const { NODE_ENV } = process.env;
  */
 
 /**
+ * Stores data fields used in the dashboard table for each form by rebate year.
+ */
+const formDataFieldNames = {
+  2022: {
+    frf: [
+      "applicantUEI",
+      "applicantEfti",
+      "applicantEfti_display",
+      "applicantOrganizationName",
+      "schoolDistrictName",
+      "last_updated_by",
+    ],
+    prf: ["hidden_current_user_email", "hidden_bap_rebate_id"],
+    crf: ["hidden_current_user_email", "hidden_bap_rebate_id"],
+  },
+  2023: {
+    frf: [
+      "_user_email",
+      "_bap_entity_combo_key",
+      "_bap_applicant_name",
+      "appInfo_uei",
+      "appInfo_efti",
+      "appInfo_orgName",
+      "_formio_schoolDistrictName",
+      "org_district_orgName",
+      "org_district_state",
+    ],
+    prf: [
+      "_user_email",
+      "_bap_entity_combo_key",
+      "_bap_rebate_id",
+      "_bap_applicant_name",
+      "_bap_district_name",
+      "_bap_district_state",
+    ],
+    crf: [],
+  },
+  2024: {
+    frf: [
+      "_user_email",
+      "_bap_entity_combo_key",
+      "_bap_applicant_name",
+      "_formio_schoolDistrictName",
+      "appInfo_uei",
+      "appInfo_efti",
+      "appInfo_organization_name",
+      "org_district_name",
+      "org_district_state",
+    ],
+    prf: [],
+    crf: [],
+  },
+};
+
+/**
  * @param {Object} param
  * @param {RebateYear} param.rebateYear
  * @param {express.Request} param.req
@@ -1290,6 +1345,7 @@ function fetchFRFSubmissions({ rebateYear, req, res }) {
     return res.status(errorStatus).json({ message: errorMessage });
   }
 
+  const dataFieldNames = formDataFieldNames[rebateYear]?.["frf"] || [];
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
   const comboKeySearchParam = `&data.${comboKeyFieldName}=`;
 
@@ -1305,8 +1361,8 @@ function fetchFRFSubmissions({ rebateYear, req, res }) {
     `${formioFormUrl}/submission` +
     `?sort=-modified` +
     `&limit=1000000` +
-    comboKeySearchParam +
-    `${bapComboKeys.join(comboKeySearchParam)}`;
+    `${comboKeySearchParam}${bapComboKeys.join(comboKeySearchParam)}` +
+    `&select=_id,modified,state,data.${dataFieldNames.join(",data.")}`;
 
   axiosFormio(req)
     .get(submissionsUrl)
@@ -1549,6 +1605,7 @@ function fetchPRFSubmissions({ rebateYear, req, res }) {
     return res.status(errorStatus).json({ message: errorMessage });
   }
 
+  const dataFieldNames = formDataFieldNames[rebateYear]?.["prf"] || [];
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
   const comboKeySearchParam = `&data.${comboKeyFieldName}=`;
 
@@ -1564,8 +1621,8 @@ function fetchPRFSubmissions({ rebateYear, req, res }) {
     `${formioFormUrl}/submission` +
     `?sort=-modified` +
     `&limit=1000000` +
-    comboKeySearchParam +
-    `${bapComboKeys.join(comboKeySearchParam)}`;
+    `${comboKeySearchParam}${bapComboKeys.join(comboKeySearchParam)}` +
+    `&select=_id,modified,state,data.${dataFieldNames.join(",data.")}`;
 
   axiosFormio(req)
     .get(submissionsUrl)
@@ -1928,6 +1985,7 @@ function fetchCRFSubmissions({ rebateYear, req, res }) {
     return res.status(errorStatus).json({ message: errorMessage });
   }
 
+  const dataFieldNames = formDataFieldNames[rebateYear]?.["crf"] || [];
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
   const comboKeySearchParam = `&data.${comboKeyFieldName}=`;
 
@@ -1943,8 +2001,8 @@ function fetchCRFSubmissions({ rebateYear, req, res }) {
     `${formioFormUrl}/submission` +
     `?sort=-modified` +
     `&limit=1000000` +
-    comboKeySearchParam +
-    `${bapComboKeys.join(comboKeySearchParam)}`;
+    `${comboKeySearchParam}${bapComboKeys.join(comboKeySearchParam)}` +
+    `&select=_id,modified,state,data.${dataFieldNames.join(",data.")}`;
 
   axiosFormio(req)
     .get(submissionsUrl)


### PR DESCRIPTION
## Related Issues:
* CSBAPP-563

## Main Changes:
* Update the data fetched for Formio form submissions to the minimum fields needed to display on the user's dashboard table.

## Steps To Test:
1. Navigate to the dashboard
2. Ensure you're still viewing 2024 form submissisons.
3. Change the rebate year to 2023 and then 2022 and ensure form submissions still load from those rebate years.
4. Click any form submission to view or edit it. Ensure form data still loads properly.
5. Navigate to the helpdesk page and search for a submission. Ensure form data still loads properly. 
