### PR TITLE
Feature/update fetched dashboard change request data

### DIFF
--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -453,19 +453,22 @@ type FormioCRF2023FormDataFields = FormioCRF2023DashboardDataFields & {
   _bap_rebate_id: string;
 };
 
-type FormioChange2023FormDataFields = {
-  [field: string]: unknown;
+type FormioChange2023DashboardDataFields = {
   _request_form: CSBFormType;
-  _bap_entity_combo_key: string;
   _bap_rebate_id: string;
   _mongo_id: string;
   _user_email: string;
-  _user_title: string;
-  _user_name: string;
   request_type: {
     label: string;
     value: string;
   };
+};
+
+type FormioChange2023FormDataFields = FormioChange2023DashboardDataFields & {
+  [field: string]: unknown;
+  _bap_entity_combo_key: string;
+  _user_title: string;
+  _user_name: string;
 };
 
 type FormioFRF2024DashboardDataFields = {
@@ -628,19 +631,22 @@ type FormioCRF2024FormDataFields = FormioCRF2024DashboardDataFields & {
   _bap_rebate_id: string;
 };
 
-type FormioChange2024FormDataFields = {
-  [field: string]: unknown;
+type FormioChange2024DashboardDataFields = {
   _request_form: CSBFormType;
-  _bap_entity_combo_key: string;
   _bap_rebate_id: string;
   _mongo_id: string;
   _user_email: string;
-  _user_title: string;
-  _user_name: string;
   request_type: {
     label: string;
     value: string;
   };
+};
+
+type FormioChange2024FormDataFields = FormioChange2024DashboardDataFields & {
+  [field: string]: unknown;
+  _bap_entity_combo_key: string;
+  _user_title: string;
+  _user_name: string;
 };
 
 export type FormioSchemaAndSubmission<FormioFormSubmission> =
@@ -703,6 +709,10 @@ export type FormioCRF2023FormSubmission = FormioSubmission & {
   data: FormioCRF2023FormDataFields;
 };
 
+export type FormioChange2023DashboardSubmission = FormioSubmission & {
+  data: FormioChange2023DashboardDataFields;
+};
+
 export type FormioChange2023FormSubmission = FormioSubmission & {
   data: FormioChange2023FormDataFields;
 };
@@ -729,6 +739,10 @@ export type FormioCRF2024DashboardSubmission = FormioSubmission & {
 
 export type FormioCRF2024FormSubmission = FormioSubmission & {
   data: FormioCRF2024FormDataFields;
+};
+
+export type FormioChange2024DashboardSubmission = FormioSubmission & {
+  data: FormioChange2024DashboardDataFields;
 };
 
 export type FormioChange2024FormSubmission = FormioSubmission & {

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -27,11 +27,11 @@ import {
   type FormioFRF2023DashboardSubmission,
   type FormioPRF2023DashboardSubmission,
   type FormioCRF2023DashboardSubmission,
-  type FormioChange2023FormSubmission,
+  type FormioChange2023DashboardSubmission,
   type FormioFRF2024DashboardSubmission,
   type FormioPRF2024DashboardSubmission,
   type FormioCRF2024DashboardSubmission,
-  type FormioChange2024FormSubmission,
+  type FormioChange2024DashboardSubmission,
   type Rebate2022,
   type Rebate2023,
   type Rebate2024,
@@ -46,8 +46,8 @@ import {
 /* prettier-ignore */
 type FormioChangeRequestsByYear<Year> =
   Year extends "2022" ? never[] | undefined :
-  Year extends "2023" ? FormioChange2023FormSubmission[] | undefined :
-  Year extends "2024" ? FormioChange2024FormSubmission[] | undefined :
+  Year extends "2023" ? FormioChange2023DashboardSubmission[] | undefined :
+  Year extends "2024" ? FormioChange2024DashboardSubmission[] | undefined :
   never;
 
 /** BAP and Formio submissions by rebate year. */
@@ -276,7 +276,7 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
     queryKey: ["formio/2023/changes"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2023/changes`;
-      return getData<FormioChange2023FormSubmission[]>(url);
+      return getData<FormioChange2023DashboardSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -285,7 +285,7 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
     queryKey: ["formio/2024/changes"],
     queryFn: () => {
       const url = `${serverUrl}/api/formio/2024/changes`;
-      return getData<FormioChange2024FormSubmission[]>(url);
+      return getData<FormioChange2024DashboardSubmission[]>(url);
     },
     refetchOnWindowFocus: false,
   };
@@ -297,7 +297,7 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
     refetchOnWindowFocus: false,
   };
 
-  const query: UseQueryOptions<BapAndFormioSubmissionsByYear<RebateYear>> =
+  const query: UseQueryOptions<FormioChangeRequestsByYear<RebateYear>> =
     rebateYear === "2022"
       ? changeRequest2022Query
       : rebateYear === "2023"
@@ -319,8 +319,8 @@ export function useChangeRequests<Year extends RebateYear>(
   const queryClient = useQueryClient();
 
   const changeRequest2022Data = queryClient.getQueryData<[]>(["formio/2022/changes"]); // prettier-ignore
-  const changeRequest2023Data = queryClient.getQueryData<FormioChange2023FormSubmission[]>(["formio/2023/changes"]); // prettier-ignore
-  const changeRequest2024Data = queryClient.getQueryData<FormioChange2024FormSubmission[]>(["formio/2024/changes"]); // prettier-ignore
+  const changeRequest2023Data = queryClient.getQueryData<FormioChange2023DashboardSubmission[]>(["formio/2023/changes"]); // prettier-ignore
+  const changeRequest2024Data = queryClient.getQueryData<FormioChange2024DashboardSubmission[]>(["formio/2024/changes"]); // prettier-ignore
 
   const result: FormioChangeRequestsByYear<RebateYear> =
     rebateYear === "2022"

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -44,6 +44,7 @@ const formDataFieldNames = {
     ],
     prf: ["hidden_current_user_email", "hidden_bap_rebate_id"],
     crf: ["hidden_current_user_email", "hidden_bap_rebate_id"],
+    change: [],
   },
   2023: {
     frf: [
@@ -66,6 +67,13 @@ const formDataFieldNames = {
       "_bap_district_state",
     ],
     crf: [],
+    change: [
+      "_request_form",
+      "_bap_rebate_id",
+      "_mongo_id",
+      "_user_email",
+      "request_type",
+    ],
   },
   2024: {
     frf: [
@@ -81,6 +89,13 @@ const formDataFieldNames = {
     ],
     prf: [],
     crf: [],
+    change: [
+      "_request_form",
+      "_bap_rebate_id",
+      "_mongo_id",
+      "_user_email",
+      "request_type",
+    ],
   },
 };
 
@@ -2276,6 +2291,7 @@ function fetchChangeRequests({ rebateYear, req, res }) {
     return res.status(errorStatus).json({ message: errorMessage });
   }
 
+  const dataFieldNames = formDataFieldNames[rebateYear]?.["change"] || [];
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
   const comboKeySearchParam = `&data.${comboKeyFieldName}=`;
 
@@ -2291,8 +2307,8 @@ function fetchChangeRequests({ rebateYear, req, res }) {
     `${formioFormUrl}/submission` +
     `?sort=-modified` +
     `&limit=1000000` +
-    comboKeySearchParam +
-    `${bapComboKeys.join(comboKeySearchParam)}`;
+    `${comboKeySearchParam}${bapComboKeys.join(comboKeySearchParam)}` +
+    `&select=_id,modified,state,data.${dataFieldNames.join(",data.")}`;
 
   axiosFormio(req)
     .get(submissionsUrl)


### PR DESCRIPTION
## Related Issues:
* CSBAPP-563

## Main Changes:
* Small follow-up to #576 – Does the same minimal data fetching for the 2023 and 2024 Change Request form submissions: Update fetched Formio change request submissions data to include the minimum fields needed to display change request submissions on the dashboard.

## Steps To Test:
1. Navigate to the dashboard
2. Ensure any 2024 change request form submissions display (create one if you don't already have any and navigate back to the dashboard and ensure it displays properly).
3. Click one of your 2024 change request form submissions and ensure the data loads properly (the form submission will display).
4. Change the rebate year to 2023 and test the same way (NOTE: there is no 2022 change request form).
