### PR TITLE
Feature/update fetched dashboard data

### DIFF
--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -140,6 +140,7 @@ export type FormioSubmission = Submission & {
 };
 
 type FormioFRF2022DashboardDataFields = {
+  bap_hidden_entity_combo_key: string;
   applicantUEI: string;
   applicantEfti: string;
   applicantEfti_display: string;
@@ -153,7 +154,6 @@ type FormioFRF2022FormDataFields = FormioFRF2022DashboardDataFields & {
   hidden_current_user_email: string;
   hidden_current_user_title: string;
   hidden_current_user_name: string;
-  bap_hidden_entity_combo_key: string;
   sam_hidden_applicant_email: string;
   sam_hidden_applicant_title: string;
   sam_hidden_applicant_name: string;
@@ -168,13 +168,13 @@ type FormioFRF2022FormDataFields = FormioFRF2022DashboardDataFields & {
 };
 
 type FormioPRF2022DashboardDataFields = {
+  bap_hidden_entity_combo_key: string;
   hidden_current_user_email: string;
   hidden_bap_rebate_id: string;
 };
 
 type FormioPRF2022FormDataFields = FormioPRF2022DashboardDataFields & {
   [field: string]: unknown;
-  bap_hidden_entity_combo_key: string;
   hidden_application_form_modified: string; // ISO 8601 date time string,
   hidden_current_user_title: string;
   hidden_current_user_name: string;
@@ -213,13 +213,13 @@ type FormioPRF2022FormDataFields = FormioPRF2022DashboardDataFields & {
 };
 
 type FormioCRF2022DashboardDataFields = {
+  bap_hidden_entity_combo_key: string;
   hidden_current_user_email: string;
   hidden_bap_rebate_id: string;
 };
 
 type FormioCRF2022FormDataFields = FormioCRF2022DashboardDataFields & {
   [field: string]: unknown;
-  bap_hidden_entity_combo_key: string;
   hidden_prf_modified: string; // ISO 8601 date time string
   hidden_current_user_title: string;
   hidden_current_user_name: string;

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -687,7 +687,7 @@ async function queryForBapFormSubmissionData(
   //   Order_Request__c
   // WHERE
   //   RecordTypeId = '${formRecordTypeId}' AND
-  //   CSB_Form_ID__c = '${mongoId}'
+  //   CSB_Form_ID__c = '${mongoId}' AND
   //   Latest_Version__c = TRUE`
 
   const formRecordQuery = await bapConnection

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -35,6 +35,7 @@ const { NODE_ENV } = process.env;
 const formDataFieldNames = {
   2022: {
     frf: [
+      "bap_hidden_entity_combo_key",
       "applicantUEI",
       "applicantEfti",
       "applicantEfti_display",
@@ -42,8 +43,16 @@ const formDataFieldNames = {
       "schoolDistrictName",
       "last_updated_by",
     ],
-    prf: ["hidden_current_user_email", "hidden_bap_rebate_id"],
-    crf: ["hidden_current_user_email", "hidden_bap_rebate_id"],
+    prf: [
+      "bap_hidden_entity_combo_key",
+      "hidden_current_user_email",
+      "hidden_bap_rebate_id",
+    ],
+    crf: [
+      "bap_hidden_entity_combo_key",
+      "hidden_current_user_email",
+      "hidden_bap_rebate_id",
+    ],
     change: [],
   },
   2023: {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-563

## Main Changes:
* Follow up to #576 – updates Formio submission data fetched for a user's dashboard for the 2022 rebate year to include the SAM.gov entity combo key field, for getting the submission's matched SAM.gov entity (and determining if the submission should be shown).

## Steps To Test:
1. Navigate to the dashboard.
2. Change the rebate year to 2022.
3. Ensure a "New Payment Request" button is displayed below a 2022 FRF submission that's status has been changed to "Accepted"
4. NOTE: before this change (after the refactor in #576), we weren't fetching the SAM.gov entity combo key field for any 2022 submission data shown on the dashboard, and that field is used in 2022 PRF and CRF submissions to determine if a SAM.gov entity used in that submission is valid.
