### PR TITLE
Feature/update client app dependencies

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -10,7 +10,7 @@
       "license": "CC0-1.0",
       "dependencies": {
         "@formio/bootstrap": "3.1.1",
-        "@formio/js": "5.1.1",
+        "@formio/js": "5.0.1",
         "@formio/premium": "3.0.5",
         "@formio/react": "6.0.1",
         "@formio/uswds": "2.6.0",
@@ -727,7 +727,6 @@
       "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.3.2.tgz",
       "integrity": "sha512-tkH9MtDR+nZuTuizy+qlnce03C3hnd4Dm/2eFjY7cEUZdpIIh1QQ9j9s4W47Si/QOMkS7trIVxKUjxuKrt8j6Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-logic-js": "^2.0.7",
         "browser-cookies": "^1.2.0",
@@ -744,15 +743,15 @@
       }
     },
     "node_modules/@formio/js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.1.1.tgz",
-      "integrity": "sha512-dslkDKe9ppyt3gVkQWlFcJFfdtHUvaUl7mCVdGKmk/fVGamUsH2rObLZIqHnTy4ruEr269echkILyN2l+2bfUw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.0.1.tgz",
+      "integrity": "sha512-MVAT9lseEYmdiivVuQRvWxwXpp402YYpStrTkMqi8nvCA/AmFb9Ld5nsFUqQsfzf4jzY5NgefFmoFlSMfTk0Kg==",
       "license": "MIT",
       "dependencies": {
-        "@formio/bootstrap": "3.1.0",
+        "@formio/bootstrap": "3.0.1",
         "@formio/choices.js": "^10.2.1",
-        "@formio/core": "2.4.0",
-        "@formio/text-mask-addons": "^3.8.0-formio.4",
+        "@formio/core": "2.3.2",
+        "@formio/text-mask-addons": "3.8.0-formio.4",
         "@formio/vanilla-text-mask": "^5.1.1-formio.1",
         "abortcontroller-polyfill": "^1.7.5",
         "autocompleter": "^8.0.4",
@@ -763,7 +762,7 @@
         "core-js": "^3.37.1",
         "dialog-polyfill": "^0.5.6",
         "dom-autoscroller": "^2.3.4",
-        "dompurify": "^3.2.4",
+        "dompurify": "^3.1.3",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.3",
         "eventemitter3": "^5.0.1",
@@ -787,9 +786,9 @@
       }
     },
     "node_modules/@formio/js/node_modules/@formio/bootstrap": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.0.tgz",
-      "integrity": "sha512-BaH74g+0N9Ddrp7wTn6Ej5Lk/nbKj8h5eqzA6s0I3pvqAgmqTYITlKMXhtWAESWOUA34n18rumpyZIdpB5B35g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.0.1.tgz",
+      "integrity": "sha512-TAP9Tf/p5l8w8T2NWIA509H9XkzF2OlX6+VRFFz9L2rbVJsYXKUe+DzlkfjIu+8FuqbzlIXpwdydUWiA1qM5vA==",
       "license": "MIT"
     },
     "node_modules/@formio/js/node_modules/@formio/choices.js": {
@@ -801,25 +800,6 @@
         "deepmerge": "^4.2.2",
         "fuse.js": "^6.6.2",
         "redux": "^4.2.0"
-      }
-    },
-    "node_modules/@formio/js/node_modules/@formio/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-JUEyDSQv39EfvL5EURKnSYWPz+T1Csc29WiZ+4aQNjsuskhbHOWcmHmPFrdv2JD8xct16g2bLHHne+Bowy5RDw==",
-      "license": "MIT",
-      "dependencies": {
-        "browser-cookies": "^1.2.0",
-        "core-js": "^3.39.0",
-        "dayjs": "^1.11.12",
-        "dompurify": "^3.2.4",
-        "eventemitter3": "^5.0.0",
-        "fast-json-patch": "^3.1.1",
-        "fetch-ponyfill": "^7.1.0",
-        "inputmask": "5.0.9",
-        "json-logic-js": "^2.0.5",
-        "lodash": "^4.17.21",
-        "moment": "^2.29.4"
       }
     },
     "node_modules/@formio/js/node_modules/autocompleter": {
@@ -2569,8 +2549,7 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/json-logic-js/-/json-logic-js-2.0.8.tgz",
       "integrity": "sha512-WgNsDPuTPKYXl0Jh0IfoCoJoAGGYZt5qzpmjuLSEg7r0cKp/kWtWp0HAsVepyPSPyXiHo6uXp/B/kW/2J1fa2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -7169,7 +7148,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.3.2.tgz",
       "integrity": "sha512-tkH9MtDR+nZuTuizy+qlnce03C3hnd4Dm/2eFjY7cEUZdpIIh1QQ9j9s4W47Si/QOMkS7trIVxKUjxuKrt8j6Q==",
-      "peer": true,
       "requires": {
         "@types/json-logic-js": "^2.0.7",
         "browser-cookies": "^1.2.0",
@@ -7186,14 +7164,14 @@
       }
     },
     "@formio/js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.1.1.tgz",
-      "integrity": "sha512-dslkDKe9ppyt3gVkQWlFcJFfdtHUvaUl7mCVdGKmk/fVGamUsH2rObLZIqHnTy4ruEr269echkILyN2l+2bfUw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.0.1.tgz",
+      "integrity": "sha512-MVAT9lseEYmdiivVuQRvWxwXpp402YYpStrTkMqi8nvCA/AmFb9Ld5nsFUqQsfzf4jzY5NgefFmoFlSMfTk0Kg==",
       "requires": {
-        "@formio/bootstrap": "3.1.0",
+        "@formio/bootstrap": "3.0.1",
         "@formio/choices.js": "^10.2.1",
-        "@formio/core": "2.4.0",
-        "@formio/text-mask-addons": "^3.8.0-formio.4",
+        "@formio/core": "2.3.2",
+        "@formio/text-mask-addons": "3.8.0-formio.4",
         "@formio/vanilla-text-mask": "^5.1.1-formio.1",
         "abortcontroller-polyfill": "^1.7.5",
         "autocompleter": "^8.0.4",
@@ -7204,7 +7182,7 @@
         "core-js": "^3.37.1",
         "dialog-polyfill": "^0.5.6",
         "dom-autoscroller": "^2.3.4",
-        "dompurify": "^3.2.4",
+        "dompurify": "^3.1.3",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.3",
         "eventemitter3": "^5.0.1",
@@ -7228,9 +7206,9 @@
       },
       "dependencies": {
         "@formio/bootstrap": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.0.tgz",
-          "integrity": "sha512-BaH74g+0N9Ddrp7wTn6Ej5Lk/nbKj8h5eqzA6s0I3pvqAgmqTYITlKMXhtWAESWOUA34n18rumpyZIdpB5B35g=="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.0.1.tgz",
+          "integrity": "sha512-TAP9Tf/p5l8w8T2NWIA509H9XkzF2OlX6+VRFFz9L2rbVJsYXKUe+DzlkfjIu+8FuqbzlIXpwdydUWiA1qM5vA=="
         },
         "@formio/choices.js": {
           "version": "10.2.1",
@@ -7240,24 +7218,6 @@
             "deepmerge": "^4.2.2",
             "fuse.js": "^6.6.2",
             "redux": "^4.2.0"
-          }
-        },
-        "@formio/core": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.4.0.tgz",
-          "integrity": "sha512-JUEyDSQv39EfvL5EURKnSYWPz+T1Csc29WiZ+4aQNjsuskhbHOWcmHmPFrdv2JD8xct16g2bLHHne+Bowy5RDw==",
-          "requires": {
-            "browser-cookies": "^1.2.0",
-            "core-js": "^3.39.0",
-            "dayjs": "^1.11.12",
-            "dompurify": "^3.2.4",
-            "eventemitter3": "^5.0.0",
-            "fast-json-patch": "^3.1.1",
-            "fetch-ponyfill": "^7.1.0",
-            "inputmask": "5.0.9",
-            "json-logic-js": "^2.0.5",
-            "lodash": "^4.17.21",
-            "moment": "^2.29.4"
           }
         },
         "autocompleter": {
@@ -8209,8 +8169,7 @@
     "@types/json-logic-js": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/json-logic-js/-/json-logic-js-2.0.8.tgz",
-      "integrity": "sha512-WgNsDPuTPKYXl0Jh0IfoCoJoAGGYZt5qzpmjuLSEg7r0cKp/kWtWp0HAsVepyPSPyXiHo6uXp/B/kW/2J1fa2Q==",
-      "peer": true
+      "integrity": "sha512-WgNsDPuTPKYXl0Jh0IfoCoJoAGGYZt5qzpmjuLSEg7r0cKp/kWtWp0HAsVepyPSPyXiHo6uXp/B/kW/2J1fa2Q=="
     },
     "@types/json-schema": {
       "version": "7.0.15",

--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -9,9 +9,9 @@
       "version": "7.0.0",
       "license": "CC0-1.0",
       "dependencies": {
-        "@formio/bootstrap": "3.0.1",
-        "@formio/js": "5.0.1",
-        "@formio/premium": "3.0.3",
+        "@formio/bootstrap": "3.1.1",
+        "@formio/js": "5.1.1",
+        "@formio/premium": "3.0.5",
         "@formio/react": "6.0.1",
         "@formio/uswds": "2.6.0",
         "@fortawesome/fontawesome-free": "6.7.2",
@@ -717,9 +717,9 @@
       "license": "MIT"
     },
     "node_modules/@formio/bootstrap": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.0.1.tgz",
-      "integrity": "sha512-TAP9Tf/p5l8w8T2NWIA509H9XkzF2OlX6+VRFFz9L2rbVJsYXKUe+DzlkfjIu+8FuqbzlIXpwdydUWiA1qM5vA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.1.tgz",
+      "integrity": "sha512-VXm5P5Ic3q7d5tkWaweIRAaPtBjDoov6Vv28y5aHKbR2Ri8ykMINtQJ70NwPHghW+csZmjmtKDDGDXENQVhIbA==",
       "license": "MIT"
     },
     "node_modules/@formio/core": {
@@ -727,6 +727,7 @@
       "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.3.2.tgz",
       "integrity": "sha512-tkH9MtDR+nZuTuizy+qlnce03C3hnd4Dm/2eFjY7cEUZdpIIh1QQ9j9s4W47Si/QOMkS7trIVxKUjxuKrt8j6Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-logic-js": "^2.0.7",
         "browser-cookies": "^1.2.0",
@@ -742,31 +743,16 @@
         "moment": "^2.29.4"
       }
     },
-    "node_modules/@formio/core/node_modules/dompurify": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
-      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
-    "node_modules/@formio/core/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
-    },
     "node_modules/@formio/js": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.0.1.tgz",
-      "integrity": "sha512-MVAT9lseEYmdiivVuQRvWxwXpp402YYpStrTkMqi8nvCA/AmFb9Ld5nsFUqQsfzf4jzY5NgefFmoFlSMfTk0Kg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.1.1.tgz",
+      "integrity": "sha512-dslkDKe9ppyt3gVkQWlFcJFfdtHUvaUl7mCVdGKmk/fVGamUsH2rObLZIqHnTy4ruEr269echkILyN2l+2bfUw==",
       "license": "MIT",
       "dependencies": {
-        "@formio/bootstrap": "3.0.1",
+        "@formio/bootstrap": "3.1.0",
         "@formio/choices.js": "^10.2.1",
-        "@formio/core": "2.3.2",
-        "@formio/text-mask-addons": "3.8.0-formio.4",
+        "@formio/core": "2.4.0",
+        "@formio/text-mask-addons": "^3.8.0-formio.4",
         "@formio/vanilla-text-mask": "^5.1.1-formio.1",
         "abortcontroller-polyfill": "^1.7.5",
         "autocompleter": "^8.0.4",
@@ -777,7 +763,7 @@
         "core-js": "^3.37.1",
         "dialog-polyfill": "^0.5.6",
         "dom-autoscroller": "^2.3.4",
-        "dompurify": "^3.1.3",
+        "dompurify": "^3.2.4",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.3",
         "eventemitter3": "^5.0.1",
@@ -800,6 +786,12 @@
         "vanilla-picker": "^2.12.3"
       }
     },
+    "node_modules/@formio/js/node_modules/@formio/bootstrap": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.0.tgz",
+      "integrity": "sha512-BaH74g+0N9Ddrp7wTn6Ej5Lk/nbKj8h5eqzA6s0I3pvqAgmqTYITlKMXhtWAESWOUA34n18rumpyZIdpB5B35g==",
+      "license": "MIT"
+    },
     "node_modules/@formio/js/node_modules/@formio/choices.js": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/@formio/choices.js/-/choices.js-10.2.1.tgz",
@@ -809,6 +801,25 @@
         "deepmerge": "^4.2.2",
         "fuse.js": "^6.6.2",
         "redux": "^4.2.0"
+      }
+    },
+    "node_modules/@formio/js/node_modules/@formio/core": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-JUEyDSQv39EfvL5EURKnSYWPz+T1Csc29WiZ+4aQNjsuskhbHOWcmHmPFrdv2JD8xct16g2bLHHne+Bowy5RDw==",
+      "license": "MIT",
+      "dependencies": {
+        "browser-cookies": "^1.2.0",
+        "core-js": "^3.39.0",
+        "dayjs": "^1.11.12",
+        "dompurify": "^3.2.4",
+        "eventemitter3": "^5.0.0",
+        "fast-json-patch": "^3.1.1",
+        "fetch-ponyfill": "^7.1.0",
+        "inputmask": "5.0.9",
+        "json-logic-js": "^2.0.5",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4"
       }
     },
     "node_modules/@formio/js/node_modules/autocompleter": {
@@ -821,21 +832,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
       "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
-      "license": "MIT"
-    },
-    "node_modules/@formio/js/node_modules/dompurify": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
-      "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
-    "node_modules/@formio/js/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
     },
     "node_modules/@formio/js/node_modules/fuse.js": {
@@ -860,9 +856,9 @@
       "license": "MIT"
     },
     "node_modules/@formio/premium": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.0.3.tgz",
-      "integrity": "sha512-avzAiMH8yJMX56rAMpftYkwtVASqVkeiblxs3hR2Yt9DfOPj1znnCVaZXXzDzb/wKh8fvnw2WUOdukXTI8j8Yw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.0.5.tgz",
+      "integrity": "sha512-3B/5Mt0UQi9cLA6Bnzm63ediYRG2auoQ4SBXphWYPXQjEF+03k7p/LdovRtwlpkLPwkTf8Y2izqrfiE7Ac2oDg==",
       "license": "UNLICENSED",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
@@ -2573,7 +2569,8 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/json-logic-js/-/json-logic-js-2.0.8.tgz",
       "integrity": "sha512-WgNsDPuTPKYXl0Jh0IfoCoJoAGGYZt5qzpmjuLSEg7r0cKp/kWtWp0HAsVepyPSPyXiHo6uXp/B/kW/2J1fa2Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -3445,6 +3442,15 @@
         "iselement": "^1.1.4"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domready": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
@@ -3748,6 +3754,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4206,9 +4218,10 @@
       "dev": true
     },
     "node_modules/json-logic-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.2.tgz",
-      "integrity": "sha512-ZBtBdMJieqQcH7IX/LaBsr5pX+Y5JIW+EhejtM3Ffg2jdN9Iwf+Ht6TbHnvAZ/YtwyuhPaCBlnvzrwVeWdvGDQ=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.5.tgz",
+      "integrity": "sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==",
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5866,12 +5879,6 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/quill/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
-    },
     "node_modules/react": {
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.0.tgz",
@@ -7154,14 +7161,15 @@
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
     },
     "@formio/bootstrap": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.0.1.tgz",
-      "integrity": "sha512-TAP9Tf/p5l8w8T2NWIA509H9XkzF2OlX6+VRFFz9L2rbVJsYXKUe+DzlkfjIu+8FuqbzlIXpwdydUWiA1qM5vA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.1.tgz",
+      "integrity": "sha512-VXm5P5Ic3q7d5tkWaweIRAaPtBjDoov6Vv28y5aHKbR2Ri8ykMINtQJ70NwPHghW+csZmjmtKDDGDXENQVhIbA=="
     },
     "@formio/core": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.3.2.tgz",
       "integrity": "sha512-tkH9MtDR+nZuTuizy+qlnce03C3hnd4Dm/2eFjY7cEUZdpIIh1QQ9j9s4W47Si/QOMkS7trIVxKUjxuKrt8j6Q==",
+      "peer": true,
       "requires": {
         "@types/json-logic-js": "^2.0.7",
         "browser-cookies": "^1.2.0",
@@ -7175,32 +7183,17 @@
         "json-logic-js": "^2.0.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.4"
-      },
-      "dependencies": {
-        "dompurify": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
-          "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
-          "requires": {
-            "@types/trusted-types": "^2.0.7"
-          }
-        },
-        "eventemitter3": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
-        }
       }
     },
     "@formio/js": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.0.1.tgz",
-      "integrity": "sha512-MVAT9lseEYmdiivVuQRvWxwXpp402YYpStrTkMqi8nvCA/AmFb9Ld5nsFUqQsfzf4jzY5NgefFmoFlSMfTk0Kg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.1.1.tgz",
+      "integrity": "sha512-dslkDKe9ppyt3gVkQWlFcJFfdtHUvaUl7mCVdGKmk/fVGamUsH2rObLZIqHnTy4ruEr269echkILyN2l+2bfUw==",
       "requires": {
-        "@formio/bootstrap": "3.0.1",
+        "@formio/bootstrap": "3.1.0",
         "@formio/choices.js": "^10.2.1",
-        "@formio/core": "2.3.2",
-        "@formio/text-mask-addons": "3.8.0-formio.4",
+        "@formio/core": "2.4.0",
+        "@formio/text-mask-addons": "^3.8.0-formio.4",
         "@formio/vanilla-text-mask": "^5.1.1-formio.1",
         "abortcontroller-polyfill": "^1.7.5",
         "autocompleter": "^8.0.4",
@@ -7211,7 +7204,7 @@
         "core-js": "^3.37.1",
         "dialog-polyfill": "^0.5.6",
         "dom-autoscroller": "^2.3.4",
-        "dompurify": "^3.1.3",
+        "dompurify": "^3.2.4",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.3",
         "eventemitter3": "^5.0.1",
@@ -7234,6 +7227,11 @@
         "vanilla-picker": "^2.12.3"
       },
       "dependencies": {
+        "@formio/bootstrap": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.0.tgz",
+          "integrity": "sha512-BaH74g+0N9Ddrp7wTn6Ej5Lk/nbKj8h5eqzA6s0I3pvqAgmqTYITlKMXhtWAESWOUA34n18rumpyZIdpB5B35g=="
+        },
         "@formio/choices.js": {
           "version": "10.2.1",
           "resolved": "https://registry.npmjs.org/@formio/choices.js/-/choices.js-10.2.1.tgz",
@@ -7242,6 +7240,24 @@
             "deepmerge": "^4.2.2",
             "fuse.js": "^6.6.2",
             "redux": "^4.2.0"
+          }
+        },
+        "@formio/core": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.4.0.tgz",
+          "integrity": "sha512-JUEyDSQv39EfvL5EURKnSYWPz+T1Csc29WiZ+4aQNjsuskhbHOWcmHmPFrdv2JD8xct16g2bLHHne+Bowy5RDw==",
+          "requires": {
+            "browser-cookies": "^1.2.0",
+            "core-js": "^3.39.0",
+            "dayjs": "^1.11.12",
+            "dompurify": "^3.2.4",
+            "eventemitter3": "^5.0.0",
+            "fast-json-patch": "^3.1.1",
+            "fetch-ponyfill": "^7.1.0",
+            "inputmask": "5.0.9",
+            "json-logic-js": "^2.0.5",
+            "lodash": "^4.17.21",
+            "moment": "^2.29.4"
           }
         },
         "autocompleter": {
@@ -7253,19 +7269,6 @@
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
           "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="
-        },
-        "dompurify": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
-          "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
-          "requires": {
-            "@types/trusted-types": "^2.0.7"
-          }
-        },
-        "eventemitter3": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
         },
         "fuse.js": {
           "version": "6.6.2",
@@ -7285,9 +7288,9 @@
       }
     },
     "@formio/premium": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.0.3.tgz",
-      "integrity": "sha512-avzAiMH8yJMX56rAMpftYkwtVASqVkeiblxs3hR2Yt9DfOPj1znnCVaZXXzDzb/wKh8fvnw2WUOdukXTI8j8Yw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.0.5.tgz",
+      "integrity": "sha512-3B/5Mt0UQi9cLA6Bnzm63ediYRG2auoQ4SBXphWYPXQjEF+03k7p/LdovRtwlpkLPwkTf8Y2izqrfiE7Ac2oDg==",
       "requires": {
         "@juggle/resize-observer": "^3.4.0",
         "@zxing/library": "^0.21.2",
@@ -8206,7 +8209,8 @@
     "@types/json-logic-js": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/json-logic-js/-/json-logic-js-2.0.8.tgz",
-      "integrity": "sha512-WgNsDPuTPKYXl0Jh0IfoCoJoAGGYZt5qzpmjuLSEg7r0cKp/kWtWp0HAsVepyPSPyXiHo6uXp/B/kW/2J1fa2Q=="
+      "integrity": "sha512-WgNsDPuTPKYXl0Jh0IfoCoJoAGGYZt5qzpmjuLSEg7r0cKp/kWtWp0HAsVepyPSPyXiHo6uXp/B/kW/2J1fa2Q==",
+      "peer": true
     },
     "@types/json-schema": {
       "version": "7.0.15",
@@ -8795,6 +8799,14 @@
         "iselement": "^1.1.4"
       }
     },
+    "dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "requires": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "domready": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
@@ -9002,6 +9014,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "extend": {
       "version": "3.0.2",
@@ -9330,9 +9347,9 @@
       "dev": true
     },
     "json-logic-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.2.tgz",
-      "integrity": "sha512-ZBtBdMJieqQcH7IX/LaBsr5pX+Y5JIW+EhejtM3Ffg2jdN9Iwf+Ht6TbHnvAZ/YtwyuhPaCBlnvzrwVeWdvGDQ=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.5.tgz",
+      "integrity": "sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -10311,13 +10328,6 @@
         "lodash-es": "^4.17.21",
         "parchment": "^3.0.0",
         "quill-delta": "^5.1.0"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
-        }
       }
     },
     "quill-delta": {

--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -47,7 +47,7 @@
         "tailwindcss": "4.1.11",
         "typescript": "5.8.3",
         "typescript-eslint": "8.35.1",
-        "vite": "6.2.2"
+        "vite": "7.0.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -664,22 +664,22 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
+      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react": {
@@ -698,12 +698,12 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
+      "integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
+        "@floating-ui/dom": "^1.7.2"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -711,9 +711,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
     "node_modules/@formio/bootstrap": {
@@ -6356,6 +6356,51 @@
       "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
       "integrity": "sha1-t8+nHnaPHJAAxJe5FRswlHxQ5G0="
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tippy.js": {
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
@@ -6666,21 +6711,24 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.1.tgz",
+      "integrity": "sha512-BiKOQoW5HGR30E6JDeNsati6HnSPMVEKbkIWbCiol+xKeu3g5owrjy7kbk/QEMuzCV87dSUTvycYKmlcfGKq3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "postcss": "^8.5.3",
-        "rollup": "^4.30.1"
+        "fdir": "^6.4.6",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.6",
+        "rollup": "^4.40.0",
+        "tinyglobby": "^0.2.14"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -6689,14 +6737,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
         "jiti": ">=1.21.0",
-        "less": "*",
+        "less": "^4.0.0",
         "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -6735,6 +6783,34 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/which": {
@@ -7100,20 +7176,20 @@
       }
     },
     "@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
       "requires": {
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
+      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
       "requires": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "@floating-ui/react": {
@@ -7127,17 +7203,17 @@
       }
     },
     "@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
+      "integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
       "requires": {
-        "@floating-ui/dom": "^1.0.0"
+        "@floating-ui/dom": "^1.7.2"
       }
     },
     "@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
     "@formio/bootstrap": {
       "version": "3.1.1",
@@ -10652,6 +10728,31 @@
       "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
       "integrity": "sha1-t8+nHnaPHJAAxJe5FRswlHxQ5G0="
     },
+    "tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "requires": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "dependencies": {
+        "fdir": {
+          "version": "6.4.6",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+          "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+          "dev": true,
+          "requires": {}
+        },
+        "picomatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+          "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+          "dev": true
+        }
+      }
+    },
     "tippy.js": {
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
@@ -10856,15 +10957,33 @@
       }
     },
     "vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.1.tgz",
+      "integrity": "sha512-BiKOQoW5HGR30E6JDeNsati6HnSPMVEKbkIWbCiol+xKeu3g5owrjy7kbk/QEMuzCV87dSUTvycYKmlcfGKq3Q==",
       "dev": true,
       "requires": {
         "esbuild": "^0.25.0",
+        "fdir": "^6.4.6",
         "fsevents": "~2.3.3",
-        "postcss": "^8.5.3",
-        "rollup": "^4.30.1"
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.6",
+        "rollup": "^4.40.0",
+        "tinyglobby": "^0.2.14"
+      },
+      "dependencies": {
+        "fdir": {
+          "version": "6.4.6",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+          "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+          "dev": true,
+          "requires": {}
+        },
+        "picomatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+          "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+          "dev": true
+        }
       }
     },
     "which": {

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -33,7 +33,7 @@
     "tailwindcss": "4.1.11",
     "typescript": "5.8.3",
     "typescript-eslint": "8.35.1",
-    "vite": "6.2.2"
+    "vite": "7.0.1"
   },
   "dependencies": {
     "@formio/bootstrap": "3.1.1",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -36,9 +36,9 @@
     "vite": "6.2.2"
   },
   "dependencies": {
-    "@formio/bootstrap": "3.0.1",
-    "@formio/js": "5.0.1",
-    "@formio/premium": "3.0.3",
+    "@formio/bootstrap": "3.1.1",
+    "@formio/js": "5.1.1",
+    "@formio/premium": "3.0.5",
     "@formio/react": "6.0.1",
     "@formio/uswds": "2.6.0",
     "@fortawesome/fontawesome-free": "6.7.2",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@formio/bootstrap": "3.1.1",
-    "@formio/js": "5.1.1",
+    "@formio/js": "5.0.1",
     "@formio/premium": "3.0.5",
     "@formio/react": "6.0.1",
     "@formio/uswds": "2.6.0",


### PR DESCRIPTION
## Related Issues:
* CSBAPP-566

## Main Changes:
* Follow up to #581 – Updates `@formio/bootstrap` and `@formio/premium` to versions matching the versions used in the [Formio API server v4.9.3](https://github.com/formio/enterprise-release/blob/master/API-Server-Change-Log.md#api-server-version-943). We're currently unable to update `@formio/js` to v5.1.1 due to a peerDependency conflict with `@formio/premium`.
* Also updates `vite` to it's latest version (unrelated to the formio package updates).

## Steps To Test:
1. Run app – all should still function as normal.

## TODO:
- [ ] Update `@formio/js` to v5.1.1 when we're able to (will likely mean also updating `@formio/premium` to a newer version where it's peerDependency for `@formio/js` has been updated).
