### PR TITLE
Feature/fix change request form schema response

### DIFF
--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -2349,7 +2349,7 @@ function fetchChangeRequestSchema({ rebateYear, req, res }) {
   axiosFormio(req)
     .get(formioFormUrl)
     .then((axiosRes) => axiosRes.data)
-    .then((schema) => res.json({ url: formioFormUrl, json: schema }))
+    .then((schema) => res.json(schema))
     .catch((error) => {
       // NOTE: error is logged in axiosFormio response interceptor
       const errorStatus = error.response?.status || 500;


### PR DESCRIPTION
## Related Issues:
* CSBAPP-554

## Main Changes:
* Update server app's `fetchChangeRequestSchema()` to only return the form schema JSON, and not also the form schema's URL. This fixes a regression introduced in #573.

## Steps To Test:
1. Navigate to the dashboard.
2. Click the "Change" link in the table of submissions to create a new change request form submission.
3. The change request form for the given year (2023 or 2024) should be displayed in a modal window, allowing you to create the new change request form.
