### PR TITLE
Feature/fix pdf download

### DIFF
--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -40,7 +40,6 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2022/crf-submission"] });
-    queryClient.resetQueries({ queryKey: ["formio/2022/crf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2022/crf-submission/${rebateId}`;
@@ -232,7 +231,7 @@ function CloseOutRequestForm(props: { email: string }) {
             className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
             type="button"
             disabled={pdfQuery.isFetching}
-            onClick={(_ev) => pdfQuery.refetch()}
+            onClick={(_ev) => pdfQuery.downloadPDF()}
           >
             <span className="display-flex flex-align-center">
               <svg

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -42,7 +42,6 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2022/frf-submission"] });
-    queryClient.resetQueries({ queryKey: ["formio/2022/frf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2022/frf-submission/${mongoId}`;
@@ -385,7 +384,7 @@ function FundingRequestForm(props: { email: string }) {
           className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
           type="button"
           disabled={pdfQuery.isFetching}
-          onClick={(_ev) => pdfQuery.refetch()}
+          onClick={(_ev) => pdfQuery.downloadPDF()}
         >
           <span className="display-flex flex-align-center">
             <svg

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -41,7 +41,6 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2023/frf-submission"] });
-    queryClient.resetQueries({ queryKey: ["formio/2023/frf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2023/frf-submission/${mongoId}`;
@@ -369,7 +368,7 @@ function FundingRequestForm(props: { email: string }) {
           className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
           type="button"
           disabled={pdfQuery.isFetching}
-          onClick={(_ev) => pdfQuery.refetch()}
+          onClick={(_ev) => pdfQuery.downloadPDF()}
         >
           <span className="display-flex flex-align-center">
             <svg

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -41,7 +41,6 @@ function useFormioSubmissionQueryAndMutation(mongoId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2024/frf-submission"] });
-    queryClient.resetQueries({ queryKey: ["formio/2024/frf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2024/frf-submission/${mongoId}`;
@@ -369,7 +368,7 @@ function FundingRequestForm(props: { email: string }) {
           className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
           type="button"
           disabled={pdfQuery.isFetching}
-          onClick={(_ev) => pdfQuery.refetch()}
+          onClick={(_ev) => pdfQuery.downloadPDF()}
         >
           <span className="display-flex flex-align-center">
             <svg

--- a/app/client/src/routes/helpdesk.tsx
+++ b/app/client/src/routes/helpdesk.tsx
@@ -113,6 +113,52 @@ function formatTime(dateTimeString: string | null) {
   return dateTimeString ? new Date(dateTimeString).toLocaleTimeString() : "";
 }
 
+/** Custom hook to fetch a PDF of a form submission from Formio. */
+function useSubmissionPDFQuery(options: {
+  formio:
+    | FormioFRF2022FormSubmission
+    | FormioPRF2022FormSubmission
+    | FormioCRF2022FormSubmission
+    | FormioFRF2023FormSubmission
+    | FormioPRF2023FormSubmission
+    | FormioFRF2024FormSubmission;
+}) {
+  const { formio } = options;
+
+  const formId = formio.form;
+  const mongoId = formio._id;
+
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.resetQueries({ queryKey: ["helpdesk/pdf"] });
+  }, [queryClient]);
+
+  const query = useQuery({
+    queryKey: ["helpdesk/pdf"],
+    queryFn: () => {
+      const url = `${serverUrl}/api/help/formio/pdf/${formId}/${mongoId}`;
+      return getData<string>(url);
+    },
+    enabled: false,
+  });
+
+  async function downloadPDF() {
+    const result = await query.refetch();
+
+    if (result.data) {
+      const link = document.createElement("a");
+      link.setAttribute("href", `data:application/pdf;base64,${result.data}`);
+      link.setAttribute("download", `${mongoId}.pdf`);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+  }
+
+  return { ...query, downloadPDF };
+}
+
 function ResultTableRow(props: {
   formDisplayed: boolean;
   setFormDisplayed: Dispatch<SetStateAction<boolean>>;
@@ -157,11 +203,9 @@ function ResultTableRow(props: {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["helpdesk/actions"] });
-    queryClient.resetQueries({ queryKey: ["helpdesk/pdf"] });
   }, [queryClient]);
 
   const actionsUrl = `${serverUrl}/api/help/formio/actions/${formId}/${mongoId}`;
-  const pdfUrl = `${serverUrl}/api/help/formio/pdf/${formId}/${mongoId}`;
 
   const actionsQuery = useQuery({
     queryKey: ["helpdesk/actions"],
@@ -179,25 +223,7 @@ function ResultTableRow(props: {
     }
   }, [actionsQuery.status, actionsQuery.data, setActionsData]);
 
-  const pdfQuery = useQuery({
-    queryKey: ["helpdesk/pdf"],
-    queryFn: () => getData<string>(pdfUrl),
-    enabled: false,
-  });
-
-  useEffect(() => {
-    if (pdfQuery.status === "success" && pdfQuery.data) {
-      const link = document.createElement("a");
-      link.setAttribute("href", `data:application/pdf;base64,${pdfQuery.data}`);
-      link.setAttribute("download", `${formio._id}.pdf`);
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-
-      // clear the pdf query cache after the download succeeds
-      queryClient.resetQueries({ queryKey: ["helpdesk/pdf"] });
-    }
-  }, [pdfQuery.status, pdfQuery.data, formio._id, queryClient]);
+  const pdfQuery = useSubmissionPDFQuery({ formio });
 
   if (!rebateYear) {
     return null;
@@ -381,7 +407,7 @@ function ResultTableRow(props: {
           className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
           type="button"
           disabled={pdfQuery.isFetching}
-          onClick={(_ev) => pdfQuery.refetch()}
+          onClick={(_ev) => pdfQuery.downloadPDF()}
         >
           <span className="display-flex flex-align-center">
             <svg

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -40,7 +40,6 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2022/prf-submission"] });
-    queryClient.resetQueries({ queryKey: ["formio/2022/prf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2022/prf-submission/${rebateId}`;
@@ -253,7 +252,7 @@ function PaymentRequestForm(props: { email: string }) {
             className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
             type="button"
             disabled={pdfQuery.isFetching}
-            onClick={(_ev) => pdfQuery.refetch()}
+            onClick={(_ev) => pdfQuery.downloadPDF()}
           >
             <span className="display-flex flex-align-center">
               <svg

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -40,7 +40,6 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2023/prf-submission"] });
-    queryClient.resetQueries({ queryKey: ["formio/2023/prf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2023/prf-submission/${rebateId}`;
@@ -251,7 +250,7 @@ function PaymentRequestForm(props: { email: string }) {
             className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
             type="button"
             disabled={pdfQuery.isFetching}
-            onClick={(_ev) => pdfQuery.refetch()}
+            onClick={(_ev) => pdfQuery.downloadPDF()}
           >
             <span className="display-flex flex-align-center">
               <svg

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -40,7 +40,6 @@ function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: ["formio/2024/prf-submission"] });
-    queryClient.resetQueries({ queryKey: ["formio/2024/prf-pdf"] });
   }, [queryClient]);
 
   const url = `${serverUrl}/api/formio/2024/prf-submission/${rebateId}`;
@@ -251,7 +250,7 @@ function PaymentRequestForm(props: { email: string }) {
             className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
             type="button"
             disabled={pdfQuery.isFetching}
-            onClick={(_ev) => pdfQuery.refetch()}
+            onClick={(_ev) => pdfQuery.downloadPDF()}
           >
             <span className="display-flex flex-align-center">
               <svg

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -235,6 +235,14 @@ export function useSubmissionPDFQuery(options: {
 }) {
   const { rebateYear, formType, mongoId } = options;
 
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.resetQueries({
+      queryKey: [`formio/${rebateYear}/${formType}-pdf`],
+    });
+  }, [queryClient, formType, rebateYear]);
+
   const query = useQuery({
     queryKey: [`formio/${rebateYear}/${formType}-pdf`, { id: mongoId }],
     queryFn: () => {
@@ -244,18 +252,22 @@ export function useSubmissionPDFQuery(options: {
     enabled: false,
   });
 
-  useEffect(() => {
-    if (query.status === "success" && query.data) {
+  async function downloadPDF() {
+    if (!mongoId) return;
+
+    const result = await query.refetch();
+
+    if (result.data) {
       const link = document.createElement("a");
-      link.setAttribute("href", `data:application/pdf;base64,${query.data}`);
+      link.setAttribute("href", `data:application/pdf;base64,${result.data}`);
       link.setAttribute("download", `${mongoId}.pdf`);
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
     }
-  }, [query.status, query.data, mongoId]);
+  }
 
-  return query;
+  return { ...query, downloadPDF };
 }
 
 /** Custom hook to fetch Change Request form submissions from Formio. */


### PR DESCRIPTION
## Related Issues:
* CSBAPP-566

## Main Changes:
Follow up to #584: Updates PDF download code after `react` update. Before this change (and since the react package update was pushed to dev), when a user downloaded a PDF for a form submission, went back to the dashboard, then revisited the route, the PDF would immediately re-download two more times, due to the component being re-rendered and the cached PDF data not yet being cleared. This update moves the code that triggers the download to be explicitly called only when the button is clicked, and not called implicitly based on the query's status and data.

## Steps To Test:
1. Navigate to a form submission (either draft or submitted).
2. Click the button to download a PDF of the submission.
3. Navigate to the dashboard.
4. Navigate back to the previous form submission, and ensure the PDF doesn't immediately re-download again.
5. NOTE: The bug didn't occur for helpdesk PDF downloads, but the code changes were made there too, so it'd be worth testing there as well:
- Visit the helpdesk page. Search for a form submission. Download a PDF of the submission. Go back to the dashboard. Return to the helpdesk page. Search for the same form submission, and ensure the PDF doesn't immediately re-download again.
