### PR TITLE
Feature/remove regenerator runtime

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -27,7 +27,6 @@
         "react-idle-timer": "5.7.2",
         "react-markdown": "10.1.0",
         "react-router": "7.7.1",
-        "regenerator-runtime": "0.14.1",
         "remark-gfm": "4.0.1",
         "uswds": "2.14.0"
       },
@@ -5951,11 +5950,6 @@
         "@babel/runtime": "^7.9.2"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -10422,11 +10416,6 @@
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "remark-gfm": {
       "version": "4.0.1",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -54,7 +54,6 @@
     "react-idle-timer": "5.7.2",
     "react-markdown": "10.1.0",
     "react-router": "7.7.1",
-    "regenerator-runtime": "0.14.1",
     "remark-gfm": "4.0.1",
     "uswds": "2.14.0"
   }

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -1,14 +1,5 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-/*
-  NOTE: regenerator-runtime is imported to avoid a bug with a GitHub Action
-  workflow including regenerator-runtime in the build as an external dependency.
-  For reference, the GitHub Action workflow's log message stated:
-    "regenerator-runtime/runtime.js" is imported by
-    "regenerator-runtime/runtime.js?commonjs-external", but could not be
-    resolved – treating it as an external dependency.
-*/
-import "regenerator-runtime";
 // ---
 import { ErrorBoundary } from "@/components/errorBoundary";
 import { Providers } from "@/components/providers";


### PR DESCRIPTION
## Related Issues:
* CSBAPP-562

## Main Changes:
Follow up to #369 – Remove client app package `regenerator-runtime` as it was only used in the GitHub Action workflow.

## Steps To Test:
1. Run app – all should still function as normal.
