### PR TITLE
Feature/update 2022 frf sam entities check

### DIFF
--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -174,8 +174,17 @@ function FRF2022Submission(props: { rebate: Rebate2022 }) {
   const { frf, prf, crf } = rebate;
 
   const configData = useConfigData();
+  const bapSamData = useBapSamData();
 
-  if (!configData) return null;
+  if (!configData || !bapSamData) return null;
+
+  /** matched SAM.gov entity for the FRF submission */
+  const entity = bapSamData.entities.find((entity) => {
+    const comboKey = frf.formio.data.bap_hidden_entity_combo_key;
+    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+  });
+
+  if (!entity) return null;
 
   const frfSubmissionPeriodOpen = configData.submissionPeriodOpen["2022"].frf;
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-562

## Main Changes:
Update user dashboard submissions to include SAM.gov entity check for 2022 FRF submissions. In practice, nothing should change, as we're only fetching submissions tied to a user's SAM.gov entities – this just adds in the extra check for each 2022 FRF submission before displaying it in the table as we do for all other form submissions (e.g., 2022 PRF and CRF, 2023 FRF and PRF, 2024 FRF). Note, the check also already exists on each form submission page, so when the user clicks the link to a submission, the same SAM.gov entity check occurs (including for the 2022 FRF).

## Steps To Test:
1. Navigate to dashboard – all should still function normally, with your submissions being fetched and displayed.
