### PR TITLE
Feature/add 2023 cfr support

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -35,7 +35,7 @@ import { CRF2022 } from "@/routes/crf2022";
 import { Change2023 } from "@/routes/change2023";
 import { FRF2023 } from "@/routes/frf2023";
 import { PRF2023 } from "@/routes/prf2023";
-// import { CRF2023 } from "@/routes/crf2023";
+import { CRF2023 } from "@/routes/crf2023";
 import { Change2024 } from "@/routes/change2024";
 import { FRF2024 } from "@/routes/frf2024";
 // import { PRF2024 } from "@/routes/prf2024";
@@ -263,7 +263,7 @@ export function App() {
         <Route path="/change/2023/:id" element={<Change2023 />} />
         <Route path="frf/2023/:id" element={<FRF2023 />} />
         <Route path="prf/2023/:id" element={<PRF2023 />} />
-        {/* <Route path="crf/2023/:id" element={<CRF2023 />} /> */}
+        <Route path="crf/2023/:id" element={<CRF2023 />} />
 
         <Route path="/change/2024/:id" element={<Change2024 />} />
         <Route path="frf/2024/:id" element={<FRF2024 />} />

--- a/app/client/src/routes/crf2023.tsx
+++ b/app/client/src/routes/crf2023.tsx
@@ -1,0 +1,492 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useNavigate, useOutletContext, useParams } from "react-router";
+import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
+import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
+import { type FormProps, type Submission, Form } from "@formio/react";
+import clsx from "clsx";
+import { cloneDeep, isEqual } from "lodash";
+import icons from "uswds/img/sprite.svg";
+// ---
+import {
+  type FormioSchemaAndSubmission,
+  type FormioCRF2023FormSubmission,
+} from "@/types";
+import { serverUrl, messages } from "@/config";
+import {
+  getData,
+  postData,
+  useContentData,
+  useConfigData,
+  useBapSamData,
+  useSubmissionPDFQuery,
+  useSubmissionsQueries,
+  useSubmissions,
+  submissionNeedsEdits,
+  entityIsActive,
+  entityHasExclusionStatus,
+  entityHasDebtSubjectToOffset,
+  getUserInfo,
+} from "@/utilities";
+import { Loading, LoadingButtonIcon } from "@/components/loading";
+import { Message } from "@/components/message";
+import { MarkdownContent } from "@/components/markdownContent";
+import { useNotificationsActions } from "@/contexts/notifications";
+
+type Response = FormioSchemaAndSubmission<FormioCRF2023FormSubmission>;
+
+/** Custom hook to fetch and update Formio submission data */
+function useFormioSubmissionQueryAndMutation(rebateId: string | undefined) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.resetQueries({ queryKey: ["formio/2023/crf-submission"] });
+  }, [queryClient]);
+
+  const url = `${serverUrl}/api/formio/2023/crf-submission/${rebateId}`;
+
+  const query = useQuery({
+    queryKey: ["formio/2023/crf-submission", { id: rebateId }],
+    queryFn: () => getData<Response>(url),
+    refetchOnWindowFocus: false,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (updatedSubmission: {
+      mongoId: string;
+      submission: Submission;
+    }) => {
+      return postData<FormioCRF2023FormSubmission>(url, updatedSubmission);
+    },
+    onSuccess: (res, _payload, _context) => {
+      return queryClient.setQueryData<Response>(
+        ["formio/2023/crf-submission", { id: rebateId }],
+        (prevData) => {
+          return prevData?.submission
+            ? { ...prevData, submission: res }
+            : prevData;
+        },
+      );
+    },
+  });
+
+  return { query, mutation };
+}
+
+export function CRF2023() {
+  const { email } = useOutletContext<{ email: string }>();
+  /* ensure user verification (JWT refresh) doesn't cause form to re-render */
+  return useMemo(() => {
+    return <CloseOutRequestForm email={email} />;
+  }, [email]);
+}
+
+function CloseOutRequestForm(props: { email: string }) {
+  const { email } = props;
+
+  const navigate = useNavigate();
+  const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
+
+  const content = useContentData();
+  const configData = useConfigData();
+  const bapSamData = useBapSamData();
+  const {
+    displaySuccessNotification,
+    displayErrorNotification,
+    dismissNotification,
+  } = useNotificationsActions();
+
+  const submissionsQueries = useSubmissionsQueries("2023");
+  const submissions = useSubmissions("2023");
+
+  const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
+  const { access, schema, submission } = query.data ?? {};
+
+  const mongoId = submission?._id || "";
+  const comboKey = submission?.data._bap_entity_combo_key || "";
+
+  const pdfQuery = useSubmissionPDFQuery({
+    rebateYear: "2023",
+    formType: "crf",
+    mongoId: submission?._id || "",
+  });
+
+  /**
+   * Stores when data is being posted to the server, so a loading overlay can
+   * be rendered over the form, preventing the user from losing input data when
+   * the form is re-rendered with data returned from the server's successful
+   * post response.
+   */
+  const dataIsPosting = useRef(false);
+
+  /**
+   * Stores when the form is being submitted, so it can be referenced in the
+   * Form component's `onSubmit` event prop to prevent double submits.
+   */
+  const formIsBeingSubmitted = useRef(false);
+
+  /**
+   * Stores the form data's state right after the user clicks the Save, Submit,
+   * or Next button. As soon as a post request to update the data succeeds, this
+   * pending submission data is reset to an empty object. This pending data,
+   * along with the submission data returned from the server is passed into the
+   * Form component's `submission` prop.
+   */
+  const pendingSubmissionData = useRef<{ [field: string]: unknown }>({});
+
+  /**
+   * Stores the last succesfully submitted data, so it can be used in the Form
+   * component's `onNextPage` event prop's "dirty check" which determines if
+   * posting of updated data is needed (so we don't make needless requests if no
+   * field data in the form has changed).
+   */
+  const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  if (!configData || !bapSamData) {
+    return <Loading />;
+  }
+
+  if (submissionsQueries.some((query) => query.isFetching)) {
+    return <Loading />;
+  }
+
+  if (submissionsQueries.some((query) => query.isError)) {
+    return <Message type="error" text={messages.formSubmissionsError} />;
+  }
+
+  if (query.isInitialLoading) {
+    return <Loading />;
+  }
+
+  if (query.isError || !access || !schema || !submission) {
+    return <Message type="error" text={messages.formSubmissionError} />;
+  }
+
+  const rebate = submissions.find((r) => r.rebateId === rebateId);
+
+  const crfNeedsEdits = !rebate
+    ? false
+    : submissionNeedsEdits({
+        formio: rebate.crf.formio,
+        bap: rebate.crf.bap,
+      });
+
+  const crfSubmissionPeriodOpen = configData.submissionPeriodOpen["2023"].crf;
+
+  const formIsReadOnly =
+    (submission.state === "submitted" || !crfSubmissionPeriodOpen) &&
+    !crfNeedsEdits;
+
+  /** matched SAM.gov entity for the Close Out submission */
+  const entity = bapSamData.entities.find((entity) => {
+    const { ENTITY_COMBO_KEY__c } = entity;
+    return ENTITY_COMBO_KEY__c === submission.data._bap_entity_combo_key;
+  });
+
+  if (!entity) {
+    return <Message type="error" text={messages.formSubmissionError} />;
+  }
+
+  const isActive = entityIsActive(entity);
+  const hasExclusionStatus = entityHasExclusionStatus(entity);
+  const hasDebtSubjectToOffset = entityHasDebtSubjectToOffset(entity);
+
+  if (!isActive || hasExclusionStatus || hasDebtSubjectToOffset) {
+    return <Message type="error" text={messages.bapSamIneligible} />;
+  }
+
+  const {
+    ELEC_BUS_POC_EMAIL__c,
+    ALT_ELEC_BUS_POC_EMAIL__c,
+    GOVT_BUS_POC_EMAIL__c,
+    ALT_GOVT_BUS_POC_EMAIL__c,
+  } = entity;
+
+  const { title, name } = getUserInfo(email, entity);
+
+  return (
+    <div className="margin-top-2">
+      {content && (
+        <div className="margin-top-4">
+          <MarkdownContent
+            children={
+              submission.state === "draft"
+                ? content.draftCRFIntro
+                : submission.state === "submitted"
+                  ? content.submittedCRFIntro
+                  : ""
+            }
+          />
+        </div>
+      )}
+
+      <ul className="usa-icon-list">
+        <li className="usa-icon-list__item">
+          <div className="usa-icon-list__icon text-primary">
+            <svg className="usa-icon" aria-hidden="true" role="img">
+              <use href={`${icons}#local_offer`} />
+            </svg>
+          </div>
+          <div className="usa-icon-list__content">
+            <strong>Rebate ID:</strong> {rebateId}
+          </div>
+        </li>
+      </ul>
+
+      {submission?._id && (
+        <p>
+          <button
+            className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+            type="button"
+            disabled={pdfQuery.isFetching}
+            onClick={(_ev) => pdfQuery.downloadPDF()}
+          >
+            <span className="display-flex flex-align-center">
+              <svg
+                className="usa-icon"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
+              >
+                <use href={`${icons}#arrow_downward`} />
+              </svg>
+              <span className="margin-left-1">Download PDF</span>
+              {pdfQuery.isFetching && <LoadingButtonIcon position="end" />}
+            </span>
+          </button>
+        </p>
+      )}
+
+      <Dialog open={dataIsPosting.current} onClose={(_value) => {}}>
+        <DialogBackdrop
+          className={clsx("tw:fixed tw:inset-0 tw:bg-black/30")}
+        />
+        <div className={clsx("tw:fixed tw:inset-0 tw:z-20")}>
+          <div
+            className={clsx(
+              "tw:flex tw:min-h-full tw:items-center tw:justify-center",
+            )}
+          >
+            <DialogPanel
+              className={clsx(
+                "tw:rounded-lg tw:bg-white tw:px-4 tw:pb-4 tw:shadow-xl",
+              )}
+            >
+              <Loading />
+            </DialogPanel>
+          </div>
+        </div>
+      </Dialog>
+
+      <div className="csb-form">
+        <Form
+          src={schema}
+          url={`${serverUrl}/api/formio/2023/s3/crf/${mongoId}/${comboKey}`}
+          submission={{
+            /**
+             * NOTE: The `csb-form-submission-state` metadata field's value is
+             * used in the Formio signature component's calculateValue config:
+             * on "Next" and "Previous" page events, if the form's current
+             * submission state is "draft", the signature component's value will
+             * be cleared, ensuring the user always signs their submission each
+             * time before submitting.
+             */
+            metadata: {
+              ...submission.metadata,
+              "csb-form-submission-state": submission.state,
+            },
+            data: {
+              ...submission.data,
+              _user_email: email,
+              _user_title: title,
+              _user_name: name,
+              _bap_elec_bus_poc_email: ELEC_BUS_POC_EMAIL__c,
+              _bap_alt_elec_bus_poc_email: ALT_ELEC_BUS_POC_EMAIL__c,
+              _bap_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
+              _bap_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
+              ...pendingSubmissionData.current,
+            },
+          }}
+          options={{
+            readOnly: formIsReadOnly,
+            noAlerts: true,
+          }}
+          onSubmit={(onSubmitParam: Submission) => {
+            if (formIsReadOnly) return;
+
+            // account for when form is being submitted to prevent double submits
+            if (formIsBeingSubmitted.current) return;
+            if (onSubmitParam.state === "submitted") {
+              formIsBeingSubmitted.current = true;
+            }
+
+            const data = { ...onSubmitParam.data };
+
+            const updatedSubmission = {
+              mongoId: submission._id,
+              submission: {
+                ...onSubmitParam,
+                metadata: {
+                  ...onSubmitParam.metadata,
+                  "csb-form-submission-state": onSubmitParam.state,
+                },
+                data,
+              },
+            };
+
+            dismissNotification({ id: 0 });
+            dataIsPosting.current = true;
+            pendingSubmissionData.current = data;
+
+            mutation.mutate(updatedSubmission, {
+              onSuccess: (res, _payload, _context) => {
+                pendingSubmissionData.current = {};
+                lastSuccesfullySubmittedData.current = cloneDeep(res.data);
+
+                /** success notification id */
+                const id = Date.now();
+
+                displaySuccessNotification({
+                  id,
+                  body: (
+                    <p
+                      className={clsx(
+                        "tw:text-sm tw:font-medium tw:text-gray-900",
+                      )}
+                    >
+                      {onSubmitParam.state === "submitted" && (
+                        <>
+                          Close Out <em>{rebateId}</em> submitted successfully.
+                        </>
+                      )}
+
+                      {onSubmitParam.state === "draft" && (
+                        <>Draft saved successfully.</>
+                      )}
+                    </p>
+                  ),
+                });
+
+                if (onSubmitParam.state === "submitted") {
+                  /**
+                   * NOTE: we'll keep the success notification displayed and
+                   * redirect the user to their dashboard
+                   */
+                  navigate("/", { viewTransition: true });
+                }
+
+                if (onSubmitParam.state === "draft") {
+                  setTimeout(() => dismissNotification({ id }), 5000);
+                }
+              },
+              onError: (_error, _payload, _context) => {
+                displayErrorNotification({
+                  id: Date.now(),
+                  body: (
+                    <p
+                      className={clsx(
+                        "tw:text-sm tw:font-medium tw:text-gray-900",
+                      )}
+                    >
+                      {onSubmitParam.state === "submitted" && (
+                        <>Error submitting Close Out form.</>
+                      )}
+
+                      {onSubmitParam.state === "draft" && (
+                        <>Error saving draft.</>
+                      )}
+                    </p>
+                  ),
+                });
+              },
+              onSettled: (_data, _error, _payload, _context) => {
+                dataIsPosting.current = false;
+                formIsBeingSubmitted.current = false;
+              },
+            });
+          }}
+          onNextPage={(param) => {
+            /** NOTE: The types for onNextPage params are incorrect */
+            type T = Parameters<Exclude<FormProps["onNextPage"], undefined>>;
+
+            const onNextPageParams = param as unknown as {
+              page: T[0];
+              submission: T[1];
+            };
+
+            if (formIsReadOnly) return;
+
+            const data = { ...onNextPageParams.submission.data };
+
+            // "dirty check" – don't post an update if no changes have been made
+            // to the form (ignoring current user fields)
+            const currentData = { ...data };
+            const submittedData = { ...lastSuccesfullySubmittedData.current };
+
+            delete currentData._user_email;
+            delete currentData._user_title;
+            delete currentData._user_name;
+            delete submittedData._user_email;
+            delete submittedData._user_title;
+            delete submittedData._user_name;
+            if (isEqual(currentData, submittedData)) return;
+
+            const updatedSubmission = {
+              mongoId: submission._id,
+              submission: {
+                ...onNextPageParams.submission,
+                data,
+                state: "draft",
+              },
+            };
+
+            dismissNotification({ id: 0 });
+            dataIsPosting.current = true;
+            pendingSubmissionData.current = data;
+
+            mutation.mutate(updatedSubmission, {
+              onSuccess: (res, _payload, _context) => {
+                pendingSubmissionData.current = {};
+                lastSuccesfullySubmittedData.current = cloneDeep(res.data);
+
+                /** success notification id */
+                const id = Date.now();
+
+                displaySuccessNotification({
+                  id,
+                  body: (
+                    <p
+                      className={clsx(
+                        "tw:text-sm tw:font-medium tw:text-gray-900",
+                      )}
+                    >
+                      Draft saved successfully.
+                    </p>
+                  ),
+                });
+
+                setTimeout(() => dismissNotification({ id }), 5000);
+              },
+              onError: (_error, _payload, _context) => {
+                displayErrorNotification({
+                  id: Date.now(),
+                  body: (
+                    <p
+                      className={clsx(
+                        "tw:text-sm tw:font-medium tw:text-gray-900",
+                      )}
+                    >
+                      Error saving draft.
+                    </p>
+                  ),
+                });
+              },
+              onSettled: (_data, _error, _payload, _context) => {
+                dataIsPosting.current = false;
+              },
+            });
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -1541,7 +1541,7 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
   if (prfApprovedButNoCRF) {
     return (
       <tr className={highlightedTableRowClassNames}>
-        <th scope="row" colSpan={6}>
+        <th scope="row" colSpan={7}>
           <button
             className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
             disabled={!crfSubmissionPeriodOpen}

--- a/app/client/src/routes/submissions.tsx
+++ b/app/client/src/routes/submissions.tsx
@@ -1503,9 +1503,223 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
   );
 }
 
-// function CRF2023Submission(props: { rebate: Rebate2023 }) {
-//   //
-// }
+function CRF2023Submission(props: { rebate: Rebate2023 }) {
+  const { rebate } = props;
+  const { frf, prf, crf } = rebate;
+
+  const navigate = useNavigate();
+  const { email } = useOutletContext<{ email: string }>();
+
+  const configData = useConfigData();
+  const bapSamData = useBapSamData();
+  const { displayErrorNotification } = useNotificationsActions();
+
+  /**
+   * Stores when data is being posted to the server, so a loading indicator can
+   * be rendered inside the "New Close Out" button, and we can prevent double
+   * submits/creations of new Close Out form submissions.
+   */
+  const [dataIsPosting, setDataIsPosting] = useState(false);
+
+  if (!configData || !bapSamData) return null;
+
+  /** matched SAM.gov entity for the PRF submission */
+  const entity = bapSamData.entities.find((entity) => {
+    const comboKey = prf.formio?.data._bap_entity_combo_key;
+    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+  });
+
+  if (!entity) return null;
+
+  const { title, name } = getUserInfo(email, entity);
+
+  const crfSubmissionPeriodOpen = configData.submissionPeriodOpen["2023"].crf;
+
+  const prfApproved = prf.bap?.status === "Accepted";
+  const prfApprovedButNoCRF = prfApproved && !Boolean(crf.formio);
+
+  if (prfApprovedButNoCRF) {
+    return (
+      <tr className={highlightedTableRowClassNames}>
+        <th scope="row" colSpan={6}>
+          <button
+            className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"
+            disabled={!crfSubmissionPeriodOpen}
+            onClick={(_ev) => {
+              if (!crfSubmissionPeriodOpen) return;
+              if (!frf.bap || !prf.bap) return;
+
+              // account for when data is posting to prevent double submits
+              if (dataIsPosting) return;
+              setDataIsPosting(true);
+
+              // create a new draft CRF submission
+              postData(`${serverUrl}/api/formio/2023/crf-submission/`, {
+                email,
+                title,
+                name,
+                entity,
+                comboKey: prf.bap.comboKey,
+                rebateId: prf.bap.rebateId, // CSB Rebate ID (6 digits)
+                frfReviewItemId: frf.bap.reviewItemId, // CSB Rebate ID with form/version ID (9 digits)
+                prfReviewItemId: prf.bap.reviewItemId, // CSB Rebate ID with form/version ID (9 digits)
+                prfModified: prf.bap.modified,
+              })
+                .then((_res) => {
+                  navigate(`/crf/2023/${prf.bap?.rebateId}`, {
+                    viewTransition: true,
+                  });
+                })
+                .catch((_err) => {
+                  displayErrorNotification({
+                    id: Date.now(),
+                    body: (
+                      <>
+                        <p
+                          className={clsx(
+                            "tw:text-sm tw:font-medium tw:text-gray-900",
+                          )}
+                        >
+                          Error creating Close Out <em>{prf.bap?.rebateId}</em>.
+                        </p>
+                        <p
+                          className={clsx(
+                            "tw:mt-1 tw:text-sm tw:text-gray-500",
+                          )}
+                        >
+                          Please try again.
+                        </p>
+                      </>
+                    ),
+                  });
+                })
+                .finally(() => {
+                  setDataIsPosting(false);
+                });
+            }}
+          >
+            <span className="display-flex flex-align-center">
+              <svg
+                className="usa-icon"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
+              >
+                <use href={`${icons}#add_circle`} />
+              </svg>
+              <span className="margin-left-1">New Close Out</span>
+              {dataIsPosting && <LoadingButtonIcon position="end" />}
+            </span>
+          </button>
+        </th>
+      </tr>
+    );
+  }
+
+  // return if a Close Out submission has not been created for this rebate
+  if (!crf.formio) return null;
+
+  const { _user_email, _bap_rebate_id } = crf.formio.data;
+
+  const date = new Date(crf.formio.modified).toLocaleDateString();
+  const time = new Date(crf.formio.modified).toLocaleTimeString();
+
+  const crfNeedsEdits = submissionNeedsEdits({
+    formio: crf.formio,
+    bap: crf.bap,
+  });
+
+  const crfBapInternalStatus = crf.bap?.status || "";
+  const crfBapStatus = bapStatusMap["2023"].crf.get(crfBapInternalStatus);
+  const crfFormioStatus = formioStatusMap.get(crf.formio.state || "");
+  const crfBapReimbursementNeeded = crf.bap?.reimbursementNeeded || false;
+
+  const crfNeedsReimbursement = submissionNeedsReimbursement({
+    status: crfBapInternalStatus,
+    reimbursementNeeded: crfBapReimbursementNeeded,
+  });
+
+  const crfStatus = crfNeedsEdits
+    ? "Edits Requested"
+    : crfNeedsReimbursement
+      ? "Reimbursement Needed"
+      : crfBapStatus || crfFormioStatus || "";
+
+  const crfApproved = crfStatus === "Close Out Approved";
+
+  const statusTableCellClassNames =
+    crfFormioStatus === "Submitted" || !crfSubmissionPeriodOpen
+      ? "text-italic"
+      : "";
+
+  const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
+
+  const crfUrl = `/crf/2023/${_bap_rebate_id}`;
+
+  return (
+    <tr
+      className={
+        crfNeedsEdits || prfApprovedButNoCRF
+          ? highlightedTableRowClassNames
+          : defaultTableRowClassNames
+      }
+    >
+      <th scope="row" className={statusTableCellClassNames}>
+        {crfNeedsEdits ? (
+          <FormLink type="edit" to={crfUrl} />
+        ) : crf.formio.state === "submitted" || !crfSubmissionPeriodOpen ? (
+          <FormLink type="view" to={crfUrl} />
+        ) : crf.formio.state === "draft" ? (
+          <FormLink type="edit" to={crfUrl} />
+        ) : null}
+      </th>
+
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
+
+      <td className={statusTableCellClassNames}>
+        <span>Close Out</span>
+        <br />
+        <span className="display-flex flex-align-center font-sans-2xs">
+          {crfStatus === "Needs Clarification" ? (
+            <TextWithTooltip
+              text={crfStatus}
+              tooltip="Check your email for instructions on what needs clarification"
+              iconClassNames="text-base-darkest"
+            />
+          ) : crfStatus === "Reimbursement Needed" ? (
+            <TextWithTooltip
+              text={crfStatus}
+              tooltip="Check your email for information on reimbursement needed"
+              iconClassNames="text-base-darkest"
+            />
+          ) : (
+            <>
+              <svg
+                className={clsx("usa-icon", crfApproved && "text-primary")}
+                aria-hidden="true"
+                focusable="false"
+                role="img"
+              >
+                <use href={`${icons}#${statusIconMap.get(crfStatus)}`} />
+              </svg>
+              <span className="margin-left-05">{crfStatus}</span>
+            </>
+          )}
+        </span>
+      </td>
+
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
+
+      <td className={hiddenTableCellClassNames}>&nbsp;</td>
+
+      <td className={statusTableCellClassNames}>
+        {_user_email}
+        <br />
+        <span title={`${date} ${time}`}>{date}</span>
+      </td>
+    </tr>
+  );
+}
 
 function Submissions2023() {
   const content = useContentData();
@@ -1557,7 +1771,7 @@ function Submissions2023() {
                 <Fragment key={rebate.rebateId}>
                   <FRF2023Submission rebate={rebate} />
                   <PRF2023Submission rebate={rebate} />
-                  {/* <CRF2023Submission rebate={rebate} /> */}
+                  <CRF2023Submission rebate={rebate} />
                   {/* blank row after all submissions but the last one */}
                   {index !== submissions.length - 1 && (
                     <tr className={clsx("tw:bg-white")}>

--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -25,10 +25,10 @@ const {
   updatePRFSubmission,
   deletePRFSubmission,
   //
-  // fetchCRFSubmissions,
-  // createCRFSubmission,
-  // fetchCRFSubmission,
-  // updateCRFSubmission,
+  fetchCRFSubmissions,
+  createCRFSubmission,
+  fetchCRFSubmission,
+  updateCRFSubmission,
   //
   fetchChangeRequests,
   fetchChangeRequestSchema,
@@ -135,23 +135,23 @@ router.post("/delete-prf-submission", fetchBapComboKeys, (req, res) => {
 
 // --- get user's 2023 CRF submissions from Formio
 router.get("/crf-submissions", fetchBapComboKeys, (req, res) => {
-  res.json([]); // TODO: replace with `fetchCRFSubmissions({ rebateYear, req, res })` when CRF is ready
+  fetchCRFSubmissions({ rebateYear, req, res });
 });
 
 // --- post a new 2023 CRF submission to Formio
-// router.post("/crf-submission", fetchBapComboKeys, (req, res) => {
-//   createCRFSubmission({ rebateYear, req, res });
-// });
+router.post("/crf-submission", fetchBapComboKeys, (req, res) => {
+  createCRFSubmission({ rebateYear, req, res });
+});
 
 // --- get an existing 2023 CRF's schema and submission data from Formio
-// router.get("/crf-submission/:rebateId", fetchBapComboKeys, (req, res) => {
-//   fetchCRFSubmission({ rebateYear, req, res });
-// });
+router.get("/crf-submission/:rebateId", fetchBapComboKeys, (req, res) => {
+  fetchCRFSubmission({ rebateYear, req, res });
+});
 
 // --- post an update to an existing draft 2023 CRF submission to Formio
-// router.post("/crf-submission/:rebateId", fetchBapComboKeys, (req, res) => {
-//   updateCRFSubmission({ rebateYear, req, res });
-// });
+router.post("/crf-submission/:rebateId", fetchBapComboKeys, (req, res) => {
+  updateCRFSubmission({ rebateYear, req, res });
+});
 
 // --- get user's 2023 Change Request form submissions from Formio
 router.get("/changes", fetchBapComboKeys, (req, res) => {

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -433,7 +433,7 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  New_Bus_GVWR__c: number
  *  New_Bus_Rebate_Amount__c: number
  *  New_Bus_Purchase_Price__c: number
- * }[]} prf2022busRecordsQuery
+ * }[]} prf2022BusRecordsQuery
  */
 
 /**
@@ -1999,7 +1999,7 @@ async function queryBapFor2022CRFData(req, frfReviewItemId, prfReviewItemId) {
   //   Related_Order_Request__c = '${prf2022RecordId}' AND
   //   CSB_Rebate_Item_Type__c = 'New Bus'`
 
-  const prf2022busRecordsQuery = await bapConnection
+  const prf2022BusRecordsQuery = await bapConnection
     .sobject("Line_Item__c")
     .find(
       {
@@ -2031,7 +2031,7 @@ async function queryBapFor2022CRFData(req, frfReviewItemId, prfReviewItemId) {
     )
     .execute(async (err, records) => ((await err) ? err : records));
 
-  return { frf2022RecordQuery, prf2022RecordQuery, prf2022busRecordsQuery };
+  return { frf2022RecordQuery, prf2022RecordQuery, prf2022BusRecordsQuery };
 }
 
 /**

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -437,6 +437,22 @@ const { submissionPeriodOpen } = require("../config/formio");
  */
 
 /**
+ * @typedef {Object} BapDataFor2023CRF
+ * @property {{
+ *  attributes: { type: "Order_Request__c", url: string }
+ *  Id: string
+ * }[]} frf2023RecordQuery
+ * @property {{
+ *  attributes: { type: "Order_Request__c", url: string }
+ *  Id: string
+ * }[]} prf2023RecordQuery
+ * @property {{
+ *  attributes: { type: "Line_Item__c", url: string }
+ *  Id: string
+ * }[]} prf2023busRecordsQuery
+ */
+
+/**
  * @typedef {Object.<string, {
  *  dupeList: {
  *    Id: string
@@ -1889,6 +1905,33 @@ async function queryBapFor2022CRFData(req, frfReviewItemId, prfReviewItemId) {
 }
 
 /**
+ * Uses cached JSforce connection to query the BAP for 2023 FRF submission data
+ * and 2023 PRF submission data, for use in a brand new 2023 CRF submission.
+ *
+ * @param {express.Request} req
+ * @param {string} frfReviewItemId CSB Rebate ID with the form/version ID (9 digits)
+ * @param {string} prfReviewItemId CSB Rebate ID with the form/version ID (9 digits)
+ * @returns {Promise<BapDataFor2023CRF>} 2022 FRF and 2022 PRF submission fields
+ */
+async function queryBapFor2023CRFData(req, frfReviewItemId, prfReviewItemId) {
+  const logMessage =
+    `Querying the BAP for 2023 FRF submission associated with ` +
+    `FRF Review Item ID: '${frfReviewItemId}' ` +
+    `and 2023 PRF submission associated with ` +
+    `PRF Review Item ID: '${prfReviewItemId}'.`;
+  log({ level: "info", message: logMessage, req });
+
+  /** @type {{ bapConnection: jsforce.Connection }} */
+  const { bapConnection } = req.app.locals;
+
+  const frf2023RecordQuery = {};
+  const prf2023RecordQuery = {};
+  const prf2023busRecordsQuery = {};
+
+  return { frf2023RecordQuery, prf2023RecordQuery, prf2023busRecordsQuery };
+}
+
+/**
  * Uses cached JSforce connection to query the BAP for duplicate contacts or
  * organizations.
  *
@@ -2073,6 +2116,22 @@ function getBapDataFor2022CRF(req, frfReviewItemId, prfReviewItemId) {
 }
 
 /**
+ * Fetches 2023 FRF submission data and 2023 PRF submission data associated with
+ * a FRF Review Item ID and a PRF Review Item ID.
+ *
+ * @param {express.Request} req
+ * @param {string} frfReviewItemId
+ * @param {string} prfReviewItemId
+ * @returns {ReturnType<queryBapFor2023CRFData>}
+ */
+function getBapDataFor2023CRF(req, frfReviewItemId, prfReviewItemId) {
+  return verifyBapConnection(req, {
+    name: queryBapFor2023CRFData,
+    args: [req, frfReviewItemId, prfReviewItemId],
+  });
+}
+
+/**
  * Checks for duplicate contacts or organizations in the BAP.
  *
  * @param {express.Request} req
@@ -2138,6 +2197,7 @@ module.exports = {
   getBapDataFor2023PRF,
   getBapDataFor2024PRF,
   getBapDataFor2022CRF,
+  getBapDataFor2023CRF,
   checkForBapDuplicates,
   checkFormSubmissionPeriodAndBapStatus,
 };

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -493,13 +493,10 @@ const { submissionPeriodOpen } = require("../config/formio");
  *    Phone: string
  *  } | null
  *  Org_District_Prioritized__c: string
- *  Self_Certification_Category__c: string
  *  Prioritized_as_High_Need__c: boolean
  *  Prioritized_as_Tribal__c: boolean
  *  Prioritized_as_Rural__c: boolean
- *  Total_Rebate_Funds_Requested_PO__c: number
- *  Total_Bus_And_Infrastructure_Rebate__c: number
- *  Total_Infrastructure_Funds__c: number
+ *  Self_Certification_Category__c: string
  *  Num_Of_Buses_Requested_From_Application__c: number
  *  Total_Price_All_Buses__c: number
  *  Total_Bus_Rebate_Amount__c: number
@@ -529,12 +526,6 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  Old_Bus_Estimated_Remaining_Life__c: number
  *  Old_Bus_Annual_Idling_Hours__c: number
  *  Old_Bus_Exclude__c: boolean
- *  Related_Line_Item__r: {
- *    attributes: { type: "Line_Item__c", url: string }
- *    Id: string
- *    Vendor_Name__c: string
- *  } | null
- *  New_Bus_Infra_Rebate_Requested__c: number
  *  New_Bus_EPA_Vehicle_Family__c: string
  *  New_Bus_Fuel_Type__c: string
  *  New_Bus_Make__c: string
@@ -545,6 +536,18 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  New_Bus_Rebate_Amount__c: number
  *  New_Bus_Purchase_Price__c: number
  *  New_Bus_ADA_Compliant__c: boolean
+ *  ADA_Compliance_Costs__c: number | null
+ *  Bus_Shipping_Costs__c: number | null
+ *  Eligible_ADA_Compliance_Rebate__c: number | null
+ *  Eligible_Bus_Shipping_Rebate__c: number | null
+ *  Donee_Contact_ID__c: string | null
+ *  Infrastructure_Other_Contact_ID__c: string | null
+ *  Infrastructure_Owner_Contact_ID__c: string | null
+ *  Infrastructure_Supplier_Contact_ID__c: string | null
+ *  New_Bus_Owner_Contact_ID__c: string | null
+ *  Old_Bus_Owner_Contact_ID__c: string | null
+ *  Purchaser_Contact_ID__c: string | null
+ *  Scrap_Contact_ID__c: string | null
  * }[]} prf2023BusRecordsQuery
  * @property {{
  *  attributes: { type: "Line_Item__c", url: string }
@@ -567,19 +570,35 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  Charger_Infrastructure_Quantity__c: number | null
  *  Infrastructure_Cost_per_Charger_from_PRF__c: number | null
  *  Charger_Cost_Includes_Installation__c: boolean
- *  Infrastructure_Owner_Contact_ID__c: string
+ *  Donee_Contact_ID__c: string | null
+ *  Infrastructure_Other_Contact_ID__c: string | null
+ *  Infrastructure_Owner_Contact_ID__c: string | null
+ *  Infrastructure_Supplier_Contact_ID__c: string | null
+ *  New_Bus_Owner_Contact_ID__c: string | null
+ *  Old_Bus_Owner_Contact_ID__c: string | null
+ *  Purchaser_Contact_ID__c: string | null
+ *  Scrap_Contact_ID__c: string | null
  * }[]} prf2023InfrastructureRecordsQuery
  * @property {{
  *  attributes: { type: "Contact", url: string }
  *  Id: string
+ *  Record_Type_Name__c: string
  *  FirstName: string
  *  LastName: string
+ *  Title: string
+ *  Email: string
+ *  Phone: string
  *  Account: {
  *    attributes: { type: "Account", url: string }
  *    Id: string
  *    Name: string
+ *    BillingStreet: string
+ *    BillingCity: string
+ *    BillingState: string
+ *    BillingPostalCode: string
+ *    County__c: string
  *  }
- * }[]} prf2023InfrastructureOwnerRecordsQuery
+ * }[]} prf2023ContactsQuery
  */
 
 /**
@@ -2104,13 +2123,10 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
   //   School_District_Contact__r.Phone,
   //   School_District_Contact__r.Email,
   //   Org_District_Prioritized__c,
-  //   Self_Certification_Category__c,
   //   Prioritized_as_High_Need__c,
   //   Prioritized_as_Tribal__c,
   //   Prioritized_as_Rural__c,
-  //   Total_Rebate_Funds_Requested_PO__c,
-  //   Total_Bus_And_Infrastructure_Rebate__c,
-  //   Total_Infrastructure_Funds__c,
+  //   Self_Certification_Category__c,
   //   Num_Of_Buses_Requested_From_Application__c,
   //   Total_Price_All_Buses__c,
   //   Total_Bus_Rebate_Amount__c,
@@ -2172,13 +2188,10 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
         "School_District_Contact__r.Phone": 1,
         "School_District_Contact__r.Email": 1,
         Org_District_Prioritized__c: 1,
-        Self_Certification_Category__c: 1,
         Prioritized_as_High_Need__c: 1,
         Prioritized_as_Tribal__c: 1,
         Prioritized_as_Rural__c: 1,
-        Total_Rebate_Funds_Requested_PO__c: 1,
-        Total_Bus_And_Infrastructure_Rebate__c: 1,
-        Total_Infrastructure_Funds__c: 1,
+        Self_Certification_Category__c: 1,
         Num_Of_Buses_Requested_From_Application__c: 1,
         Total_Price_All_Buses__c: 1,
         Total_Bus_Rebate_Amount__c: 1,
@@ -2238,9 +2251,6 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
   //   Old_Bus_Estimated_Remaining_Life__c,
   //   Old_Bus_Annual_Idling_Hours__c,
   //   Old_Bus_Exclude__c,
-  //   Related_Line_Item__r.Id,
-  //   Related_Line_Item__r.Vendor_Name__c,
-  //   New_Bus_Infra_Rebate_Requested__c,
   //   New_Bus_EPA_Vehicle_Family__c,
   //   New_Bus_Fuel_Type__c,
   //   New_Bus_Make__c,
@@ -2250,7 +2260,19 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
   //   New_Bus_GVWR__c,
   //   New_Bus_Rebate_Amount__c,
   //   New_Bus_Purchase_Price__c,
-  //   New_Bus_ADA_Compliant__c
+  //   New_Bus_ADA_Compliant__c,
+  //   ADA_Compliance_Costs__c,
+  //   Bus_Shipping_Costs__c,
+  //   Eligible_ADA_Compliance_Rebate__c,
+  //   Eligible_Bus_Shipping_Rebate__c,
+  //   Donee_Contact_ID__c,
+  //   Infrastructure_Other_Contact_ID__c,
+  //   Infrastructure_Owner_Contact_ID__c,
+  //   Infrastructure_Supplier_Contact_ID__c,
+  //   New_Bus_Owner_Contact_ID__c,
+  //   Old_Bus_Owner_Contact_ID__c,
+  //   Purchaser_Contact_ID__c,
+  //   Scrap_Contact_ID__c
   // FROM
   //   Line_Item__c
   // WHERE
@@ -2285,9 +2307,6 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
         Old_Bus_Estimated_Remaining_Life__c: 1,
         Old_Bus_Annual_Idling_Hours__c: 1,
         Old_Bus_Exclude__c: 1,
-        "Related_Line_Item__r.Id": 1,
-        "Related_Line_Item__r.Vendor_Name__c": 1,
-        New_Bus_Infra_Rebate_Requested__c: 1,
         New_Bus_EPA_Vehicle_Family__c: 1,
         New_Bus_Fuel_Type__c: 1,
         New_Bus_Make__c: 1,
@@ -2298,6 +2317,18 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
         New_Bus_Rebate_Amount__c: 1,
         New_Bus_Purchase_Price__c: 1,
         New_Bus_ADA_Compliant__c: 1,
+        ADA_Compliance_Costs__c: 1,
+        Bus_Shipping_Costs__c: 1,
+        Eligible_ADA_Compliance_Rebate__c: 1,
+        Eligible_Bus_Shipping_Rebate__c: 1,
+        Donee_Contact_ID__c: 1,
+        Infrastructure_Other_Contact_ID__c: 1,
+        Infrastructure_Owner_Contact_ID__c: 1,
+        Infrastructure_Supplier_Contact_ID__c: 1,
+        New_Bus_Owner_Contact_ID__c: 1,
+        Old_Bus_Owner_Contact_ID__c: 1,
+        Purchaser_Contact_ID__c: 1,
+        Scrap_Contact_ID__c: 1,
       },
     )
     .execute(async (err, records) => ((await err) ? err : records));
@@ -2322,7 +2353,14 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
   //   Charger_Infrastructure_Quantity__c,
   //   Infrastructure_Cost_per_Charger_from_PRF__c,
   //   Charger_Cost_Includes_Installation__c,
-  //   Infrastructure_Owner_Contact_ID__c
+  //   Donee_Contact_ID__c,
+  //   Infrastructure_Other_Contact_ID__c,
+  //   Infrastructure_Owner_Contact_ID__c,
+  //   Infrastructure_Supplier_Contact_ID__c,
+  //   New_Bus_Owner_Contact_ID__c,
+  //   Old_Bus_Owner_Contact_ID__c,
+  //   Purchaser_Contact_ID__c,
+  //   Scrap_Contact_ID__c
   // FROM
   //   Line_Item__c
   // WHERE
@@ -2359,27 +2397,64 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
         Charger_Infrastructure_Quantity__c: 1,
         Infrastructure_Cost_per_Charger_from_PRF__c: 1,
         Charger_Cost_Includes_Installation__c: 1,
+        Donee_Contact_ID__c: 1,
+        Infrastructure_Other_Contact_ID__c: 1,
         Infrastructure_Owner_Contact_ID__c: 1,
+        Infrastructure_Supplier_Contact_ID__c: 1,
+        New_Bus_Owner_Contact_ID__c: 1,
+        Old_Bus_Owner_Contact_ID__c: 1,
+        Purchaser_Contact_ID__c: 1,
+        Scrap_Contact_ID__c: 1,
       },
     )
     .execute(async (err, records) => ((await err) ? err : records));
 
-  const contactIds = prf2023InfrastructureRecordsQuery.map(
-    (record) => record.Infrastructure_Owner_Contact_ID__c,
-  );
+  const contactIdFields = [
+    "Donee_Contact_ID__c",
+    "Infrastructure_Other_Contact_ID__c",
+    "Infrastructure_Owner_Contact_ID__c",
+    "Infrastructure_Supplier_Contact_ID__c",
+    "New_Bus_Owner_Contact_ID__c",
+    "Old_Bus_Owner_Contact_ID__c",
+    "Purchaser_Contact_ID__c",
+    "Scrap_Contact_ID__c",
+  ];
+
+  // Unique contact IDs from both bus and infrastructure records
+  const contactIds = [
+    ...prf2023BusRecordsQuery,
+    ...prf2023InfrastructureRecordsQuery,
+  ].reduce((array, record) => {
+    for (const field of contactIdFields) {
+      if (record[field] && !array.includes(record[field])) {
+        array.push(record[field]);
+      }
+    }
+
+    return array;
+  }, []);
 
   // SELECT
   //   Id,
+  //   Record_Type_Name__c,
   //   FirstName,
   //   LastName,
+  //   Title,
+  //   Email,
+  //   Phone,
   //   Account.Id,
   //   Account.Name
+  //   Account.BillingStreet,
+  //   Account.BillingCity,
+  //   Account.BillingState,
+  //   Account.BillingPostalCode,
+  //   Account.County__c
   // FROM
   //   Contact
   // WHERE
   //   Id IN(${contactIds.map((id) => `'${id}'`)})
 
-  const prf2023InfrastructureOwnerRecordsQuery =
+  const prf2023ContactsQuery =
     contactIds.length === 0
       ? []
       : await bapConnection
@@ -2391,10 +2466,19 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
             {
               // "*": 1,
               Id: 1, // Salesforce record ID
+              Record_Type_Name__c: 1,
               FirstName: 1,
               LastName: 1,
+              Title: 1,
+              Email: 1,
+              Phone: 1,
               "Account.Id": 1,
               "Account.Name": 1,
+              "Account.BillingStreet": 1,
+              "Account.BillingCity": 1,
+              "Account.BillingState": 1,
+              "Account.BillingPostalCode": 1,
+              "Account.County__c": 1,
             },
           )
           .execute(async (err, records) => ((await err) ? err : records));
@@ -2403,7 +2487,7 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
     prf2023RecordQuery,
     prf2023BusRecordsQuery,
     prf2023InfrastructureRecordsQuery,
-    prf2023InfrastructureOwnerRecordsQuery,
+    prf2023ContactsQuery,
   };
 }
 

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -1924,9 +1924,157 @@ async function queryBapFor2023CRFData(req, frfReviewItemId, prfReviewItemId) {
   /** @type {{ bapConnection: jsforce.Connection }} */
   const { bapConnection } = req.app.locals;
 
-  const frf2023RecordQuery = {};
-  const prf2023RecordQuery = {};
-  const prf2023busRecordsQuery = {};
+  // `SELECT
+  //   Id
+  // FROM
+  //   RecordType
+  // WHERE
+  //   DeveloperName = 'CSB_Funding_Request_2023' AND
+  //   SObjectType = 'Order_Request__c'
+  // LIMIT 1`
+
+  const frf2023RecordTypeIdQuery = await bapConnection
+    .sobject("RecordType")
+    .find(
+      {
+        DeveloperName: "CSB_Funding_Request_2023",
+        SObjectType: "Order_Request__c",
+      },
+      {
+        // "*": 1,
+        Id: 1, // Salesforce record ID
+      },
+    )
+    .limit(1)
+    .execute(async (err, records) => ((await err) ? err : records));
+
+  const frf2023RecordTypeId = frf2023RecordTypeIdQuery["0"].Id;
+
+  // `SELECT
+  //   Id
+  // FROM
+  //   Order_Request__c
+  // WHERE
+  //   RecordTypeId = '${frf2023RecordTypeId}' AND
+  //   CSB_Review_Item_ID__c = '${frfReviewItemId}' AND
+  //   Latest_Version__c = TRUE`
+
+  const frf2023RecordQuery = await bapConnection
+    .sobject("Order_Request__c")
+    .find(
+      {
+        RecordTypeId: frf2023RecordTypeId,
+        CSB_Review_Item_ID__c: frfReviewItemId,
+        Latest_Version__c: true,
+      },
+      {
+        // "*": 1,
+        Id: 1, // Salesforce record ID
+      },
+    )
+    .execute(async (err, records) => ((await err) ? err : records));
+
+  // `SELECT
+  //   Id
+  // FROM
+  //   RecordType
+  // WHERE
+  //   DeveloperName = 'CSB_Payment_Request_2023' AND
+  //   SObjectType = 'Order_Request__c'
+  // LIMIT 1`
+
+  const prf2023RecordTypeIdQuery = await bapConnection
+    .sobject("RecordType")
+    .find(
+      {
+        DeveloperName: "CSB_Payment_Request_2023",
+        SObjectType: "Order_Request__c",
+      },
+      {
+        // "*": 1,
+        Id: 1, // Salesforce record ID
+      },
+    )
+    .limit(1)
+    .execute(async (err, records) => ((await err) ? err : records));
+
+  const prf2023RecordTypeId = prf2023RecordTypeIdQuery["0"].Id;
+
+  // `SELECT
+  //   Id
+  // FROM
+  //   Order_Request__c
+  // WHERE
+  //   RecordTypeId = '${prf2023RecordTypeId}' AND
+  //   CSB_Review_Item_ID__c = '${prfReviewItemId}' AND
+  //   Latest_Version__c = TRUE`
+
+  const prf2023RecordQuery = await bapConnection
+    .sobject("Order_Request__c")
+    .find(
+      {
+        RecordTypeId: prf2023RecordTypeId,
+        CSB_Review_Item_ID__c: prfReviewItemId,
+        Latest_Version__c: true,
+      },
+      {
+        // "*": 1,
+        Id: 1, // Salesforce record ID
+      },
+    )
+    .execute(async (err, records) => ((await err) ? err : records));
+
+  const prf2023RecordId = prf2023RecordQuery["0"].Id;
+
+  // `SELECT
+  //   Id
+  // FROM
+  //   RecordType
+  // WHERE
+  //   DeveloperName = 'CSB_Rebate_Item' AND
+  //   SObjectType = 'Line_Item__c'
+  // LIMIT 1`
+
+  const rebateItemRecordTypeIdQuery = await bapConnection
+    .sobject("RecordType")
+    .find(
+      {
+        DeveloperName: "CSB_Rebate_Item",
+        SObjectType: "Line_Item__c",
+      },
+      {
+        // "*": 1,
+        Id: 1, // Salesforce record ID
+      },
+    )
+    .limit(1)
+    .execute(async (err, records) => ((await err) ? err : records));
+
+  const rebateItemRecordTypeId = rebateItemRecordTypeIdQuery["0"].Id;
+
+  // `SELECT
+  //   Id
+  // FROM
+  //   Line_Item__c
+  // WHERE
+  //   RecordTypeId = '${rebateItemRecordTypeId}' AND
+  //   Related_Order_Request__c = '${prf2023RecordId}' AND
+  //   CSB_Rebate_Item_Type__c = 'New Bus'`
+
+  const prf2023busRecordsQuery = await bapConnection
+    .sobject("Line_Item__c")
+    .find(
+      {
+        RecordTypeId: rebateItemRecordTypeId,
+        Related_Order_Request__c: prf2023RecordId,
+        CSB_Rebate_Item_Type__c: "New Bus",
+      },
+      {
+        // "*": 1,
+        Id: 1, // Salesforce record ID
+      },
+    )
+    .execute(async (err, records) => ((await err) ? err : records));
 
   return { frf2023RecordQuery, prf2023RecordQuery, prf2023busRecordsQuery };
 }

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -441,15 +441,145 @@ const { submissionPeriodOpen } = require("../config/formio");
  * @property {{
  *  attributes: { type: "Order_Request__c", url: string }
  *  Id: string
- * }[]} frf2023RecordQuery
- * @property {{
- *  attributes: { type: "Order_Request__c", url: string }
- *  Id: string
+ *  CSB_NCES_ID__c: string
+ *  CSB_Snapshot__r: {
+ *    attributes: { type: "Data_Staging__c", url: string }
+ *    Id: string
+ *    JSON_Snapshot__c: string
+ *  }
+ *  Primary_Applicant__r: {
+ *    attributes: { type: "Contact", url: string }
+ *    Id: string
+ *    Record_Type_Name__c: string
+ *    FirstName: string
+ *    LastName: string
+ *    Title: string
+ *    Email: string
+ *    Phone: string
+ *  } | null
+ *  Alternate_Applicant__r: {
+ *    attributes: { type: "Contact", url: string }
+ *    Id: string
+ *    Record_Type_Name__c: string
+ *    FirstName: string
+ *    LastName: string
+ *    Title: string
+ *    Email: string
+ *    Phone: string
+ *  } | null
+ *  Applicant_Organization__r: {
+ *    attributes: { type: "Account", url: string }
+ *    Id: string
+ *    Name: string
+ *    County__c: string
+ *  } | null
+ *  CSB_School_District__r: {
+ *    attributes: { type: "Account", url: string }
+ *    Id: string
+ *    Name: string
+ *    BillingStreet: string
+ *    BillingCity: string
+ *    BillingState: string
+ *    BillingPostalCode: string
+ *  } | null
+ *  School_District_Contact__r: {
+ *    attributes: { type: "Contact", url: string }
+ *    Id: string
+ *    Record_Type_Name__c: string
+ *    FirstName: string
+ *    LastName: string
+ *    Title: string
+ *    Email: string
+ *    Phone: string
+ *  } | null
+ *  Org_District_Prioritized__c: string
+ *  Self_Certification_Category__c: string
+ *  Prioritized_as_High_Need__c: boolean
+ *  Prioritized_as_Tribal__c: boolean
+ *  Prioritized_as_Rural__c: boolean
+ *  Total_Rebate_Funds_Requested_PO__c: number
+ *  Total_Bus_And_Infrastructure_Rebate__c: number
+ *  Total_Infrastructure_Funds__c: number
+ *  Num_Of_Buses_Requested_From_Application__c: number
+ *  Total_Price_All_Buses__c: number
+ *  Total_Bus_Rebate_Amount__c: number
+ *  Total_All_Eligible_Infrastructure_Costs__c: number
+ *  Total_Infrastructure_Rebate__c: number
+ *  Total_Level_2_Charger_Costs__c: number
+ *  Total_DC_Fast_Charger_Costs__c: number
+ *  Total_Other_Infrastructure_Costs__c: number
+ *  Funding_Alloc_for_Eligible_Infra_Costs__c: number
  * }[]} prf2023RecordQuery
  * @property {{
  *  attributes: { type: "Line_Item__c", url: string }
  *  Id: string
- * }[]} prf2023busRecordsQuery
+ *  CSB_Rebate_Item_Type__c: "New Bus"
+ *  Rebate_Item_num__c: number
+ *  CSB_VIN__c: string
+ *  CSB_Model__c: string
+ *  CSB_Model_Year__c: string
+ *  CSB_Fuel_Type__c: string
+ *  CSB_GVWR__c: number
+ *  CSB_Manufacturer__c: string
+ *  CSB_Manufacturer_if_Other__c: string
+ *  CSB_Annual_Fuel_Consumption__c: number
+ *  Annual_Mileage__c: number
+ *  Old_Bus_Odometer_miles__c: number
+ *  Old_Bus_NCES_District_ID__c: string
+ *  Old_Bus_Estimated_Remaining_Life__c: number
+ *  Old_Bus_Annual_Idling_Hours__c: number
+ *  Old_Bus_Exclude__c: boolean
+ *  Related_Line_Item__r: {
+ *    attributes: { type: "Line_Item__c", url: string }
+ *    Id: string
+ *    Vendor_Name__c: string
+ *  } | null
+ *  New_Bus_Infra_Rebate_Requested__c: number
+ *  New_Bus_EPA_Vehicle_Family__c: string
+ *  New_Bus_Fuel_Type__c: string
+ *  New_Bus_Make__c: string
+ *  New_Bus_Manufacturer_if_Other__c: string
+ *  New_Bus_Model__c: string
+ *  New_Bus_Model_Year__c: string
+ *  New_Bus_GVWR__c: number
+ *  New_Bus_Rebate_Amount__c: number
+ *  New_Bus_Purchase_Price__c: number
+ *  New_Bus_ADA_Compliant__c: boolean
+ * }[]} prf2023BusRecordsQuery
+ * @property {{
+ *  attributes: { type: "Line_Item__c", url: string }
+ *  Id: string
+ *  CSB_Rebate_Item_Type__c: "PRF Infrastructure"
+ *  Infrastructure_Type__c: string
+ *  Infrastructure_Type_Other__c: string
+ *  Description_of_Work__c: string
+ *  Other_Eligible_Infra_Cost_from_PRF__c: number
+ *  EVSE_Maximum_Output_Power_kW__c: number
+ *  EVSE_Manufacturer__c: string | null
+ *  EVSE_Manufacturer_if_Other__c: string | null
+ *  EVSE_Model__c: string | null
+ *  EVSE_Date_of_Manufacture__c: string | null
+ *  Number_of_Plugs_on_EVSE__c: number | null
+ *  Capable_of_Bidirectional_Charging__c: string
+ *  Planning_to_Use_Bidirectional_Charging__c: boolean
+ *  EVSE_Energy_Star__c: boolean
+ *  Charger_Infra_Materials_BABA_Compliant__c: boolean
+ *  Charger_Infrastructure_Quantity__c: number | null
+ *  Infrastructure_Cost_per_Charger_from_PRF__c: number | null
+ *  Charger_Cost_Includes_Installation__c: boolean
+ *  Infrastructure_Owner_Contact_ID__c: string
+ * }[]} prf2023InfrastructureRecordsQuery
+ * @property {{
+ *  attributes: { type: "Contact", url: string }
+ *  Id: string
+ *  FirstName: string
+ *  LastName: string
+ *  Account: {
+ *    attributes: { type: "Account", url: string }
+ *    Id: string
+ *    Name: string
+ *  }
+ * }[]} prf2023InfrastructureOwnerRecordsQuery
  */
 
 /**
@@ -1065,9 +1195,9 @@ async function queryBapFor2023PRFData(req, frfReviewItemId) {
   // `SELECT
   //   Id,
   //   CSB_Snapshot__r.Id,
-  //   CSB_Snapshot__r.JSON_Snapshot__c
-  //   Applicant_Organization__r.Id
-  //   Applicant_Organization__r.County__c
+  //   CSB_Snapshot__r.JSON_Snapshot__c,
+  //   Applicant_Organization__r.Id,
+  //   Applicant_Organization__r.County__c,
   //   Primary_Applicant__r.Id,
   //   Primary_Applicant__r.FirstName,
   //   Primary_Applicant__r.LastName,
@@ -1909,79 +2039,17 @@ async function queryBapFor2022CRFData(req, frfReviewItemId, prfReviewItemId) {
  * and 2023 PRF submission data, for use in a brand new 2023 CRF submission.
  *
  * @param {express.Request} req
- * @param {string} frfReviewItemId CSB Rebate ID with the form/version ID (9 digits)
  * @param {string} prfReviewItemId CSB Rebate ID with the form/version ID (9 digits)
  * @returns {Promise<BapDataFor2023CRF>} 2022 FRF and 2022 PRF submission fields
  */
-async function queryBapFor2023CRFData(req, frfReviewItemId, prfReviewItemId) {
+async function queryBapFor2023CRFData(req, prfReviewItemId) {
   const logMessage =
-    `Querying the BAP for 2023 FRF submission associated with ` +
-    `FRF Review Item ID: '${frfReviewItemId}' ` +
-    `and 2023 PRF submission associated with ` +
+    `Querying the BAP for 2023 PRF submission associated with ` +
     `PRF Review Item ID: '${prfReviewItemId}'.`;
   log({ level: "info", message: logMessage, req });
 
   /** @type {{ bapConnection: jsforce.Connection }} */
   const { bapConnection } = req.app.locals;
-
-  // `SELECT
-  //   Id
-  // FROM
-  //   RecordType
-  // WHERE
-  //   DeveloperName = 'CSB_Funding_Request_2023' AND
-  //   SObjectType = 'Order_Request__c'
-  // LIMIT 1`
-
-  const frf2023RecordTypeIdQuery = await bapConnection
-    .sobject("RecordType")
-    .find(
-      {
-        DeveloperName: "CSB_Funding_Request_2023",
-        SObjectType: "Order_Request__c",
-      },
-      {
-        // "*": 1,
-        Id: 1, // Salesforce record ID
-      },
-    )
-    .limit(1)
-    .execute(async (err, records) => ((await err) ? err : records));
-
-  const frf2023RecordTypeId = frf2023RecordTypeIdQuery["0"].Id;
-
-  // `SELECT
-  //   Id
-  // FROM
-  //   Order_Request__c
-  // WHERE
-  //   RecordTypeId = '${frf2023RecordTypeId}' AND
-  //   CSB_Review_Item_ID__c = '${frfReviewItemId}' AND
-  //   Latest_Version__c = TRUE`
-
-  const frf2023RecordQuery = await bapConnection
-    .sobject("Order_Request__c")
-    .find(
-      {
-        RecordTypeId: frf2023RecordTypeId,
-        CSB_Review_Item_ID__c: frfReviewItemId,
-        Latest_Version__c: true,
-      },
-      {
-        // "*": 1,
-        Id: 1, // Salesforce record ID
-      },
-    )
-    .execute(async (err, records) => ((await err) ? err : records));
-
-  // `SELECT
-  //   Id
-  // FROM
-  //   RecordType
-  // WHERE
-  //   DeveloperName = 'CSB_Payment_Request_2023' AND
-  //   SObjectType = 'Order_Request__c'
-  // LIMIT 1`
 
   const prf2023RecordTypeIdQuery = await bapConnection
     .sobject("RecordType")
@@ -2001,7 +2069,57 @@ async function queryBapFor2023CRFData(req, frfReviewItemId, prfReviewItemId) {
   const prf2023RecordTypeId = prf2023RecordTypeIdQuery["0"].Id;
 
   // `SELECT
-  //   Id
+  //   Id,
+  //   CSB_NCES_ID__c,
+  //   CSB_Snapshot__r.Id,
+  //   CSB_Snapshot__r.JSON_Snapshot__c,
+  //   Primary_Applicant__r.Id,
+  //   Primary_Applicant__r.Record_Type_Name__c,
+  //   Primary_Applicant__r.FirstName,
+  //   Primary_Applicant__r.LastName,
+  //   Primary_Applicant__r.Title,
+  //   Primary_Applicant__r.Phone,
+  //   Primary_Applicant__r.Email,
+  //   Alternate_Applicant__r.Id,
+  //   Alternate_Applicant__r.Record_Type_Name__c,
+  //   Alternate_Applicant__r.FirstName,
+  //   Alternate_Applicant__r.LastName,
+  //   Alternate_Applicant__r.Title,
+  //   Alternate_Applicant__r.Phone,
+  //   Alternate_Applicant__r.Email,
+  //   Applicant_Organization__r.Id,
+  //   Applicant_Organization__r.Name,
+  //   Applicant_Organization__r.County__c,
+  //   CSB_School_District__r.Id,
+  //   CSB_School_District__r.Name,
+  //   CSB_School_District__r.BillingStreet,
+  //   CSB_School_District__r.BillingCity,
+  //   CSB_School_District__r.BillingState,
+  //   CSB_School_District__r.BillingPostalCode,
+  //   School_District_Contact__r.Id,
+  //   School_District_Contact__r.Record_Type_Name__c,
+  //   School_District_Contact__r.FirstName,
+  //   School_District_Contact__r.LastName,
+  //   School_District_Contact__r.Title,
+  //   School_District_Contact__r.Phone,
+  //   School_District_Contact__r.Email,
+  //   Org_District_Prioritized__c,
+  //   Self_Certification_Category__c,
+  //   Prioritized_as_High_Need__c,
+  //   Prioritized_as_Tribal__c,
+  //   Prioritized_as_Rural__c,
+  //   Total_Rebate_Funds_Requested_PO__c,
+  //   Total_Bus_And_Infrastructure_Rebate__c,
+  //   Total_Infrastructure_Funds__c,
+  //   Num_Of_Buses_Requested_From_Application__c,
+  //   Total_Price_All_Buses__c,
+  //   Total_Bus_Rebate_Amount__c,
+  //   Total_All_Eligible_Infrastructure_Costs__c,
+  //   Total_Infrastructure_Rebate__c,
+  //   Total_Level_2_Charger_Costs__c,
+  //   Total_DC_Fast_Charger_Costs__c,
+  //   Total_Other_Infrastructure_Costs__c,
+  //   Funding_Alloc_for_Eligible_Infra_Costs__c
   // FROM
   //   Order_Request__c
   // WHERE
@@ -2020,6 +2138,56 @@ async function queryBapFor2023CRFData(req, frfReviewItemId, prfReviewItemId) {
       {
         // "*": 1,
         Id: 1, // Salesforce record ID
+        CSB_NCES_ID__c: 1,
+        "CSB_Snapshot__r.Id": 1,
+        "CSB_Snapshot__r.JSON_Snapshot__c": 1,
+        "Primary_Applicant__r.Id": 1,
+        "Primary_Applicant__r.Record_Type_Name__c": 1,
+        "Primary_Applicant__r.FirstName": 1,
+        "Primary_Applicant__r.LastName": 1,
+        "Primary_Applicant__r.Title": 1,
+        "Primary_Applicant__r.Phone": 1,
+        "Primary_Applicant__r.Email": 1,
+        "Alternate_Applicant__r.Id": 1,
+        "Alternate_Applicant__r.Record_Type_Name__c": 1,
+        "Alternate_Applicant__r.FirstName": 1,
+        "Alternate_Applicant__r.LastName": 1,
+        "Alternate_Applicant__r.Title": 1,
+        "Alternate_Applicant__r.Phone": 1,
+        "Alternate_Applicant__r.Email": 1,
+        "Applicant_Organization__r.Id": 1,
+        "Applicant_Organization__r.Name": 1,
+        "Applicant_Organization__r.County__c": 1,
+        "CSB_School_District__r.Id": 1,
+        "CSB_School_District__r.Name": 1,
+        "CSB_School_District__r.BillingStreet": 1,
+        "CSB_School_District__r.BillingCity": 1,
+        "CSB_School_District__r.BillingState": 1,
+        "CSB_School_District__r.BillingPostalCode": 1,
+        "School_District_Contact__r.Id": 1,
+        "School_District_Contact__r.Record_Type_Name__c": 1,
+        "School_District_Contact__r.FirstName": 1,
+        "School_District_Contact__r.LastName": 1,
+        "School_District_Contact__r.Title": 1,
+        "School_District_Contact__r.Phone": 1,
+        "School_District_Contact__r.Email": 1,
+        Org_District_Prioritized__c: 1,
+        Self_Certification_Category__c: 1,
+        Prioritized_as_High_Need__c: 1,
+        Prioritized_as_Tribal__c: 1,
+        Prioritized_as_Rural__c: 1,
+        Total_Rebate_Funds_Requested_PO__c: 1,
+        Total_Bus_And_Infrastructure_Rebate__c: 1,
+        Total_Infrastructure_Funds__c: 1,
+        Num_Of_Buses_Requested_From_Application__c: 1,
+        Total_Price_All_Buses__c: 1,
+        Total_Bus_Rebate_Amount__c: 1,
+        Total_All_Eligible_Infrastructure_Costs__c: 1,
+        Total_Infrastructure_Rebate__c: 1,
+        Total_Level_2_Charger_Costs__c: 1,
+        Total_DC_Fast_Charger_Costs__c: 1,
+        Total_Other_Infrastructure_Costs__c: 1,
+        Funding_Alloc_for_Eligible_Infra_Costs__c: 1,
       },
     )
     .execute(async (err, records) => ((await err) ? err : records));
@@ -2053,7 +2221,36 @@ async function queryBapFor2023CRFData(req, frfReviewItemId, prfReviewItemId) {
   const rebateItemRecordTypeId = rebateItemRecordTypeIdQuery["0"].Id;
 
   // `SELECT
-  //   Id
+  //   Id,
+  //   CSB_Rebate_Item_Type__c,
+  //   Rebate_Item_num__c,
+  //   CSB_VIN__c,
+  //   CSB_Model__c,
+  //   CSB_Model_Year__c,
+  //   CSB_Fuel_Type__c,
+  //   CSB_GVWR__c,
+  //   CSB_Manufacturer__c,
+  //   CSB_Manufacturer_if_Other__c,
+  //   CSB_Annual_Fuel_Consumption__c,
+  //   Annual_Mileage__c,
+  //   Old_Bus_Odometer_miles__c,
+  //   Old_Bus_NCES_District_ID__c,
+  //   Old_Bus_Estimated_Remaining_Life__c,
+  //   Old_Bus_Annual_Idling_Hours__c,
+  //   Old_Bus_Exclude__c,
+  //   Related_Line_Item__r.Id,
+  //   Related_Line_Item__r.Vendor_Name__c,
+  //   New_Bus_Infra_Rebate_Requested__c,
+  //   New_Bus_EPA_Vehicle_Family__c,
+  //   New_Bus_Fuel_Type__c,
+  //   New_Bus_Make__c,
+  //   New_Bus_Manufacturer_if_Other__c,
+  //   New_Bus_Model__c,
+  //   New_Bus_Model_Year__c,
+  //   New_Bus_GVWR__c,
+  //   New_Bus_Rebate_Amount__c,
+  //   New_Bus_Purchase_Price__c,
+  //   New_Bus_ADA_Compliant__c
   // FROM
   //   Line_Item__c
   // WHERE
@@ -2061,7 +2258,7 @@ async function queryBapFor2023CRFData(req, frfReviewItemId, prfReviewItemId) {
   //   Related_Order_Request__c = '${prf2023RecordId}' AND
   //   CSB_Rebate_Item_Type__c = 'New Bus'`
 
-  const prf2023busRecordsQuery = await bapConnection
+  const prf2023BusRecordsQuery = await bapConnection
     .sobject("Line_Item__c")
     .find(
       {
@@ -2072,11 +2269,142 @@ async function queryBapFor2023CRFData(req, frfReviewItemId, prfReviewItemId) {
       {
         // "*": 1,
         Id: 1, // Salesforce record ID
+        CSB_Rebate_Item_Type__c: 1,
+        Rebate_Item_num__c: 1,
+        CSB_VIN__c: 1,
+        CSB_Model__c: 1,
+        CSB_Model_Year__c: 1,
+        CSB_Fuel_Type__c: 1,
+        CSB_GVWR__c: 1,
+        CSB_Manufacturer__c: 1,
+        CSB_Manufacturer_if_Other__c: 1,
+        CSB_Annual_Fuel_Consumption__c: 1,
+        Annual_Mileage__c: 1,
+        Old_Bus_Odometer_miles__c: 1,
+        Old_Bus_NCES_District_ID__c: 1,
+        Old_Bus_Estimated_Remaining_Life__c: 1,
+        Old_Bus_Annual_Idling_Hours__c: 1,
+        Old_Bus_Exclude__c: 1,
+        "Related_Line_Item__r.Id": 1,
+        "Related_Line_Item__r.Vendor_Name__c": 1,
+        New_Bus_Infra_Rebate_Requested__c: 1,
+        New_Bus_EPA_Vehicle_Family__c: 1,
+        New_Bus_Fuel_Type__c: 1,
+        New_Bus_Make__c: 1,
+        New_Bus_Manufacturer_if_Other__c: 1,
+        New_Bus_Model__c: 1,
+        New_Bus_Model_Year__c: 1,
+        New_Bus_GVWR__c: 1,
+        New_Bus_Rebate_Amount__c: 1,
+        New_Bus_Purchase_Price__c: 1,
+        New_Bus_ADA_Compliant__c: 1,
       },
     )
     .execute(async (err, records) => ((await err) ? err : records));
 
-  return { frf2023RecordQuery, prf2023RecordQuery, prf2023busRecordsQuery };
+  // SELECT
+  //   Id,
+  //   CSB_Rebate_Item_Type__c,
+  //   Infrastructure_Type__c,
+  //   Infrastructure_Type_Other__c,
+  //   Description_of_Work__c,
+  //   Other_Eligible_Infra_Cost_from_PRF__c,
+  //   EVSE_Maximum_Output_Power_kW__c,
+  //   EVSE_Manufacturer__c,
+  //   EVSE_Manufacturer_if_Other__c,
+  //   EVSE_Model__c,
+  //   EVSE_Date_of_Manufacture__c,
+  //   Number_of_Plugs_on_EVSE__c,
+  //   Capable_of_Bidirectional_Charging__c,
+  //   Planning_to_Use_Bidirectional_Charging__c,
+  //   EVSE_Energy_Star__c,
+  //   Charger_Infra_Materials_BABA_Compliant__c,
+  //   Charger_Infrastructure_Quantity__c,
+  //   Infrastructure_Cost_per_Charger_from_PRF__c,
+  //   Charger_Cost_Includes_Installation__c,
+  //   Infrastructure_Owner_Contact_ID__c
+  // FROM
+  //   Line_Item__c
+  // WHERE
+  //   RecordTypeId = '${rebateItemRecordTypeId}' AND
+  //   Related_Order_Request__c = '${prf2023RecordId}' AND
+  //   CSB_Rebate_Item_Type__c = 'PRF Infrastructure'
+
+  const prf2023InfrastructureRecordsQuery = await bapConnection
+    .sobject("Line_Item__c")
+    .find(
+      {
+        RecordTypeId: rebateItemRecordTypeId,
+        Related_Order_Request__c: prf2023RecordId,
+        CSB_Rebate_Item_Type__c: "PRF Infrastructure",
+      },
+      {
+        // "*": 1,
+        Id: 1, // Salesforce record ID
+        CSB_Rebate_Item_Type__c: 1,
+        Infrastructure_Type__c: 1,
+        Infrastructure_Type_Other__c: 1,
+        Description_of_Work__c: 1,
+        Other_Eligible_Infra_Cost_from_PRF__c: 1,
+        EVSE_Maximum_Output_Power_kW__c: 1,
+        EVSE_Manufacturer__c: 1,
+        EVSE_Manufacturer_if_Other__c: 1,
+        EVSE_Model__c: 1,
+        EVSE_Date_of_Manufacture__c: 1,
+        Number_of_Plugs_on_EVSE__c: 1,
+        Capable_of_Bidirectional_Charging__c: 1,
+        Planning_to_Use_Bidirectional_Charging__c: 1,
+        EVSE_Energy_Star__c: 1,
+        Charger_Infra_Materials_BABA_Compliant__c: 1,
+        Charger_Infrastructure_Quantity__c: 1,
+        Infrastructure_Cost_per_Charger_from_PRF__c: 1,
+        Charger_Cost_Includes_Installation__c: 1,
+        Infrastructure_Owner_Contact_ID__c: 1,
+      },
+    )
+    .execute(async (err, records) => ((await err) ? err : records));
+
+  const contactIds = prf2023InfrastructureRecordsQuery.map(
+    (record) => record.Infrastructure_Owner_Contact_ID__c,
+  );
+
+  // SELECT
+  //   Id,
+  //   FirstName,
+  //   LastName,
+  //   Account.Id,
+  //   Account.Name
+  // FROM
+  //   Contact
+  // WHERE
+  //   Id IN(${contactIds.map((id) => `'${id}'`)})
+
+  const prf2023InfrastructureOwnerRecordsQuery =
+    contactIds.length === 0
+      ? []
+      : await bapConnection
+          .sobject("Contact")
+          .find(
+            {
+              Id: { $in: contactIds },
+            },
+            {
+              // "*": 1,
+              Id: 1, // Salesforce record ID
+              FirstName: 1,
+              LastName: 1,
+              "Account.Id": 1,
+              "Account.Name": 1,
+            },
+          )
+          .execute(async (err, records) => ((await err) ? err : records));
+
+  return {
+    prf2023RecordQuery,
+    prf2023BusRecordsQuery,
+    prf2023InfrastructureRecordsQuery,
+    prf2023InfrastructureOwnerRecordsQuery,
+  };
 }
 
 /**
@@ -2268,14 +2596,13 @@ function getBapDataFor2022CRF(req, frfReviewItemId, prfReviewItemId) {
  * a FRF Review Item ID and a PRF Review Item ID.
  *
  * @param {express.Request} req
- * @param {string} frfReviewItemId
  * @param {string} prfReviewItemId
  * @returns {ReturnType<queryBapFor2023CRFData>}
  */
-function getBapDataFor2023CRF(req, frfReviewItemId, prfReviewItemId) {
+function getBapDataFor2023CRF(req, prfReviewItemId) {
   return verifyBapConnection(req, {
     name: queryBapFor2023CRFData,
-    args: [req, frfReviewItemId, prfReviewItemId],
+    args: [req, prfReviewItemId],
   });
 }
 

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -1037,12 +1037,13 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
   }
 
   if (rebateYear === "2023") {
-    return getBapDataFor2023CRF(req, frfReviewItemId, prfReviewItemId)
+    return getBapDataFor2023CRF(req, prfReviewItemId)
       .then((results) => {
         const {
-          frf2023RecordQuery,
           prf2023RecordQuery,
-          prf2023busRecordsQuery,
+          prf2023BusRecordsQuery,
+          prf2023InfrastructureRecordsQuery,
+          prf2023InfrastructureOwnerRecordsQuery,
         } = results;
 
         return {

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -876,6 +876,12 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
   const {
     UNIQUE_ENTITY_ID__c,
     ENTITY_EFT_INDICATOR__c,
+    LEGAL_BUSINESS_NAME__c,
+    PHYSICAL_ADDRESS_LINE_1__c,
+    PHYSICAL_ADDRESS_LINE_2__c,
+    PHYSICAL_ADDRESS_CITY__c,
+    PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c,
+    PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c,
     ELEC_BUS_POC_EMAIL__c,
     ALT_ELEC_BUS_POC_EMAIL__c,
     GOVT_BUS_POC_EMAIL__c,
@@ -1043,12 +1049,336 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
           prf2023RecordQuery,
           prf2023BusRecordsQuery,
           prf2023InfrastructureRecordsQuery,
-          prf2023InfrastructureOwnerRecordsQuery,
+          prf2023ContactsQuery,
         } = results;
+
+        const {
+          CSB_NCES_ID__c,
+          CSB_Snapshot__r,
+          Primary_Applicant__r,
+          Alternate_Applicant__r,
+          Applicant_Organization__r,
+          CSB_School_District__r,
+          School_District_Contact__r,
+          Org_District_Prioritized__c,
+          Prioritized_as_High_Need__c,
+          Prioritized_as_Tribal__c,
+          Prioritized_as_Rural__c,
+          Self_Certification_Category__c,
+          Num_Of_Buses_Requested_From_Application__c,
+          Total_Price_All_Buses__c,
+          Total_Bus_Rebate_Amount__c,
+          Total_All_Eligible_Infrastructure_Costs__c,
+          Total_Infrastructure_Rebate__c,
+          Total_Level_2_Charger_Costs__c,
+          Total_DC_Fast_Charger_Costs__c,
+          Total_Other_Infrastructure_Costs__c,
+          Funding_Alloc_for_Eligible_Infra_Costs__c,
+        } = prf2023RecordQuery[0];
+
+        const prf2023RecordJson = JSON.parse(CSB_Snapshot__r.JSON_Snapshot__c);
+
+        const [schoolDistrictStreetAddress1, schoolDistrictStreetAddress2] = (
+          CSB_School_District__r?.BillingStreet ?? "\n"
+        ).split("\n");
+
+        const org_organizations = prf2023ContactsQuery.reduce(
+          (array, contact) => {
+            const {
+              Id: contactId,
+              Record_Type_Name__c,
+              FirstName,
+              LastName,
+              Title,
+              Email,
+              Phone,
+              Account,
+            } = contact;
+
+            const {
+              Id: orgId,
+              Name: orgName,
+              BillingStreet,
+              BillingCity,
+              BillingState,
+              BillingPostalCode,
+              County__c,
+            } = Account || {};
+
+            const jsonOrg = prf2023RecordJson.data.org_organizations.find(
+              (org) => {
+                const matchedName = org?.org_name?.trim() === orgName?.trim();
+                const matchedEmail =
+                  org.org_contact_email?.trim()?.toLowerCase() ===
+                  Email?.trim()?.toLowerCase();
+
+                return matchedName && matchedEmail;
+              },
+            );
+
+            const orgAlreadyAdded = array.some((org) => org._org_id === orgId);
+
+            /**
+             * Ensure the org exists in the 2023 PRF submission's
+             * "org_organizations" array, and it hasn't already been added.
+             */
+            if (jsonOrg && !orgAlreadyAdded) {
+              const [orgStreetAddress1, orgStreetAddress2] = (
+                BillingStreet ?? "\n"
+              ).split("\n");
+
+              array.push({
+                org_number: jsonOrg.org_number,
+                org_type: jsonOrg.org_type,
+                _org_id: orgId,
+                _bap_org_name: orgName,
+                _bap_org_address_1: orgStreetAddress1,
+                _bap_org_address_2: orgStreetAddress2,
+                _bap_org_county: County__c,
+                _bap_org_city: BillingCity,
+                _bap_org_state: { name: BillingState },
+                _bap_org_zip: BillingPostalCode,
+                _bap_org_contact_id: contactId,
+                _bap_org_contact_recordtype: Record_Type_Name__c,
+                _bap_org_contact_fname: FirstName,
+                _bap_org_contact_lname: LastName,
+                _bap_org_contact_title: Title,
+                _bap_org_contact_email: Email,
+                _bap_org_contact_phone: Phone,
+              });
+            }
+
+            return array;
+          },
+          [],
+        );
+
+        const bus_buses = prf2023BusRecordsQuery.map((prf2023BusRecord) => {
+          const {
+            Rebate_Item_num__c,
+            CSB_VIN__c,
+            CSB_Model__c,
+            CSB_Model_Year__c,
+            CSB_Fuel_Type__c,
+            CSB_GVWR__c,
+            CSB_Manufacturer__c,
+            CSB_Manufacturer_if_Other__c,
+            CSB_Annual_Fuel_Consumption__c,
+            Annual_Mileage__c,
+            Old_Bus_Odometer_miles__c,
+            Old_Bus_NCES_District_ID__c,
+            Old_Bus_Estimated_Remaining_Life__c,
+            Old_Bus_Annual_Idling_Hours__c,
+            Old_Bus_Exclude__c,
+            New_Bus_EPA_Vehicle_Family__c,
+            New_Bus_Fuel_Type__c,
+            New_Bus_Make__c,
+            New_Bus_Manufacturer_if_Other__c,
+            New_Bus_Model__c,
+            New_Bus_Model_Year__c,
+            New_Bus_GVWR__c,
+            New_Bus_Rebate_Amount__c,
+            New_Bus_Purchase_Price__c,
+            New_Bus_ADA_Compliant__c,
+            ADA_Compliance_Costs__c,
+            Bus_Shipping_Costs__c,
+            Eligible_ADA_Compliance_Rebate__c,
+            Eligible_Bus_Shipping_Rebate__c,
+            New_Bus_Owner_Contact_ID__c,
+            Old_Bus_Owner_Contact_ID__c,
+          } = prf2023BusRecord;
+
+          const existingOwnerRecord = prf2023ContactsQuery.find((contact) => {
+            return contact.Id === Old_Bus_Owner_Contact_ID__c;
+          });
+
+          const newOwnerRecord = prf2023ContactsQuery.find((contact) => {
+            return contact.Id === New_Bus_Owner_Contact_ID__c;
+          });
+
+          return {
+            bus_number: Rebate_Item_num__c,
+            bus_existing_excluded: Old_Bus_Exclude__c,
+            _prf_existing_excluded: Old_Bus_Exclude__c,
+            bus_existing_owner: {
+              org_id: existingOwnerRecord?.Account?.Id,
+              org_name: existingOwnerRecord?.Account?.Name,
+              org_contact_id: existingOwnerRecord?.Id,
+              org_contact_fname: existingOwnerRecord?.FirstName,
+              org_contact_lname: existingOwnerRecord?.LastName,
+            },
+            bus_existing_vin: CSB_VIN__c,
+            bus_existing_fuel_type: CSB_Fuel_Type__c,
+            bus_existing_gvwr: CSB_GVWR__c,
+            bus_existing_odometer: Old_Bus_Odometer_miles__c,
+            bus_existing_model: CSB_Model__c,
+            bus_existing_model_year: CSB_Model_Year__c,
+            bus_existing_nces_id: Old_Bus_NCES_District_ID__c,
+            bus_existing_manufacturer: CSB_Manufacturer__c,
+            bus_existing_manufacturer_other: CSB_Manufacturer_if_Other__c, // TODO: determine if this is correct – we used this field in the 2023 PRF, but the query was for the frf2023BusRecordsQuery where it was ""
+            bus_existing_remaining_life: Old_Bus_Estimated_Remaining_Life__c,
+            bus_existing_annual_fuel_consumption: CSB_Annual_Fuel_Consumption__c, // prettier-ignore
+            bus_existing_annual_mileage: Annual_Mileage__c,
+            bus_existing_idling_hours: Old_Bus_Annual_Idling_Hours__c,
+            bus_new_owner: {
+              org_id: newOwnerRecord?.Account?.Id,
+              org_name: newOwnerRecord?.Account?.Name,
+              org_contact_id: newOwnerRecord?.Id,
+              org_contact_fname: newOwnerRecord?.FirstName,
+              org_contact_lname: newOwnerRecord?.LastName,
+            },
+            _bus_prf_new_purchase_price: New_Bus_Purchase_Price__c,
+            _bus_prf_bus_new_fuel_type: New_Bus_Fuel_Type__c,
+            _bus_prf_new_gvwr: New_Bus_GVWR__c,
+            _bus_prf_new_ada: New_Bus_ADA_Compliant__c,
+            _prf_bus_new_manufacturer: New_Bus_Make__c,
+            _prf_bus_new_manufacturer_other: New_Bus_Manufacturer_if_Other__c,
+            _prf_bus_new_model: New_Bus_Model__c,
+            _prf_bus_new_epa_carb: New_Bus_EPA_Vehicle_Family__c,
+            _prf_bus_new_model_year: New_Bus_Model_Year__c,
+            bus_rebate_shipping: Eligible_Bus_Shipping_Rebate__c, // TODO: new field so confirm
+            bus_rebate_shipping_costs: Bus_Shipping_Costs__c, // TODO: new field so confirm
+            bus_rebate_ada: Eligible_ADA_Compliance_Rebate__c, // TODO: new field so confirm. Could also be "New_Bus_ADA_Rebate_Requested__c"
+            bus_rebate_ada_costs: ADA_Compliance_Costs__c, // TODO: new field so confirm
+            _prf_funding_amount: New_Bus_Rebate_Amount__c,
+          };
+        });
+
+        const infra_infrastructure = prf2023InfrastructureRecordsQuery.map(
+          (prf2023InfrastructureRecord) => {
+            const {
+              Id,
+              CSB_Rebate_Item_Type__c,
+              Infrastructure_Type__c,
+              Infrastructure_Type_Other__c,
+              Description_of_Work__c,
+              Other_Eligible_Infra_Cost_from_PRF__c,
+              EVSE_Maximum_Output_Power_kW__c,
+              EVSE_Manufacturer__c,
+              EVSE_Manufacturer_if_Other__c,
+              EVSE_Model__c,
+              EVSE_Date_of_Manufacture__c,
+              Number_of_Plugs_on_EVSE__c,
+              Capable_of_Bidirectional_Charging__c,
+              Planning_to_Use_Bidirectional_Charging__c,
+              EVSE_Energy_Star__c,
+              Charger_Infra_Materials_BABA_Compliant__c,
+              Charger_Infrastructure_Quantity__c,
+              Infrastructure_Cost_per_Charger_from_PRF__c,
+              Charger_Cost_Includes_Installation__c,
+              Infrastructure_Owner_Contact_ID__c,
+            } = prf2023InfrastructureRecord;
+
+            const ownerRecord = prf2023ContactsQuery.find((contact) => {
+              return contact.Id === Infrastructure_Owner_Contact_ID__c;
+            });
+
+            return {
+              infra_type: Infrastructure_Type__c,
+              infra_other_type: Infrastructure_Type_Other__c,
+              infra_other_desc: Description_of_Work__c,
+              infra_other_cost: Other_Eligible_Infra_Cost_from_PRF__c,
+              infra_evse_max_output_power: EVSE_Maximum_Output_Power_kW__c,
+              infra_evse_manufacturer: EVSE_Manufacturer__c,
+              infra_evse_manufacturer_other: EVSE_Manufacturer_if_Other__c,
+              infra_evse_model: EVSE_Model__c,
+              infra_evse_manufacture_date: EVSE_Date_of_Manufacture__c,
+              infra_evse_number_plugs: Number_of_Plugs_on_EVSE__c,
+              infra_evse_bidirectional_charging: Capable_of_Bidirectional_Charging__c, // prettier-ignore
+              infra_evse_bidirectional_planning: Planning_to_Use_Bidirectional_Charging__c, // prettier-ignore
+              infra_evse_energy_star: EVSE_Energy_Star__c,
+              infra_evse_baba_compliant: Charger_Infra_Materials_BABA_Compliant__c, // prettier-ignore
+              infra_evse_quantity: Charger_Infrastructure_Quantity__c,
+              infra_evse_cost_charger: Infrastructure_Cost_per_Charger_from_PRF__c, // prettier-ignore
+              infra_evse_includes_installion: Charger_Cost_Includes_Installation__c, // prettier-ignore
+              infra_owner: {
+                org_id: ownerRecord?.Account?.Id,
+                org_name: ownerRecord?.Account?.Name,
+                org_contact_id: ownerRecord?.Id,
+                org_contact_fname: ownerRecord?.FirstName,
+                org_contact_lname: ownerRecord?.LastName,
+              },
+              infra_address: ownerRecord?.Account?.BillingStreet,
+              infra_city: ownerRecord?.Account?.BillingCity,
+              infra_state: ownerRecord?.Account?.BillingState,
+              infra_zip: ownerRecord?.Account?.BillingPostalCode,
+              infra_county: ownerRecord?.Account?.County__c,
+            };
+          },
+        );
 
         return {
           data: {
-            /* TODO */
+            _bap_entity_combo_key: comboKey,
+            _bap_rebate_id: rebateId,
+            _user_email: email,
+            _user_title: title,
+            _user_name: name,
+            _bap_applicant_email: email,
+            _bap_applicant_title: title,
+            _bap_applicant_name: name,
+            _bap_applicant_efti: ENTITY_EFT_INDICATOR__c || "0000",
+            _bap_applicant_uei: UNIQUE_ENTITY_ID__c,
+            _bap_applicant_organization_id: Applicant_Organization__r?.Id,
+            _bap_applicant_organization_name: LEGAL_BUSINESS_NAME__c,
+            _bap_applicant_street_address_1: PHYSICAL_ADDRESS_LINE_1__c,
+            _bap_applicant_street_address_2: PHYSICAL_ADDRESS_LINE_2__c,
+            _bap_applicant_county: Applicant_Organization__r?.County__c,
+            _bap_applicant_city: PHYSICAL_ADDRESS_CITY__c,
+            _bap_applicant_state: PHYSICAL_ADDRESS_PROVINCE_OR_STATE__c,
+            _bap_applicant_zip: PHYSICAL_ADDRESS_ZIPPOSTAL_CODE__c,
+            _bap_elec_bus_poc_email: ELEC_BUS_POC_EMAIL__c,
+            _bap_alt_elec_bus_poc_email: ALT_ELEC_BUS_POC_EMAIL__c,
+            _bap_govt_bus_poc_email: GOVT_BUS_POC_EMAIL__c,
+            _bap_alt_govt_bus_poc_email: ALT_GOVT_BUS_POC_EMAIL__c,
+            _bap_primary_id: Primary_Applicant__r?.Id,
+            _bap_primary_recordtype: Primary_Applicant__r?.Record_Type_Name__c,
+            _bap_primary_fname: Primary_Applicant__r?.FirstName,
+            _bap_primary_lname: Primary_Applicant__r?.LastName,
+            _bap_primary_title: Primary_Applicant__r?.Title,
+            _bap_primary_email: Primary_Applicant__r?.Email,
+            _bap_primary_phone: Primary_Applicant__r?.Phone,
+            _bap_alternate_id: Alternate_Applicant__r?.Id,
+            _bap_alternate_recordtype: Alternate_Applicant__r?.Record_Type_Name__c, // prettier-ignore
+            _bap_alternate_fname: Alternate_Applicant__r?.FirstName,
+            _bap_alternate_lname: Alternate_Applicant__r?.LastName,
+            _bap_alternate_title: Alternate_Applicant__r?.Title,
+            _bap_alternate_email: Alternate_Applicant__r?.Email,
+            _bap_alternate_phone: Alternate_Applicant__r?.Phone,
+            _bap_district_id: CSB_School_District__r?.Id,
+            _bap_district_nces_id: CSB_NCES_ID__c,
+            _bap_district_name: CSB_School_District__r?.Name,
+            _bap_district_address_1: schoolDistrictStreetAddress1 || "",
+            _bap_district_address_2: schoolDistrictStreetAddress2 || "",
+            _bap_district_city: CSB_School_District__r?.BillingCity,
+            _bap_district_state: CSB_School_District__r?.BillingState,
+            _bap_district_zip: CSB_School_District__r?.BillingPostalCode,
+            _bap_district_priority: Org_District_Prioritized__c,
+            _bap_district_priority_reason: {
+              highNeed: Prioritized_as_High_Need__c,
+              tribal: Prioritized_as_Tribal__c,
+              rural: Prioritized_as_Rural__c,
+            },
+            _bap_district_self_certify: Self_Certification_Category__c,
+            _bap_district_contact_id: School_District_Contact__r?.Id,
+            _bap_district_contact_recordtype: School_District_Contact__r?.Record_Type_Name__c, // prettier-ignore
+            _bap_district_contact_fname: School_District_Contact__r?.FirstName,
+            _bap_district_contact_lname: School_District_Contact__r?.LastName,
+            _bap_district_contact_title: School_District_Contact__r?.Title,
+            _bap_district_contact_email: School_District_Contact__r?.Email,
+            _bap_district_contact_phone: School_District_Contact__r?.Phone,
+            _bap_bus_frf_requested: Num_Of_Buses_Requested_From_Application__c,
+            _bap_bus_prf_total_costs: Total_Price_All_Buses__c,
+            _bap_bus_prf_total_rebate_received: Total_Bus_Rebate_Amount__c,
+            _bap_infra_prf_total_costs: Total_All_Eligible_Infrastructure_Costs__c, // prettier-ignore
+            _bap_infra_total_rebate_received: Total_Infrastructure_Rebate__c,
+            _bap_infra_total_level2_charger: Total_Level_2_Charger_Costs__c,
+            _bap_infra_total_dc_fast_charger: Total_DC_Fast_Charger_Costs__c,
+            _bap_infra_total_other_costs: Total_Other_Infrastructure_Costs__c,
+            _bap_infra_funding: Funding_Alloc_for_Eligible_Infra_Costs__c,
+            org_organizations,
+            bus_buses,
+            infra_infrastructure,
           },
           /** Add custom metadata to track formio submissions from wrapper. */
           metadata: { ...formioCSBMetadata },

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -18,6 +18,7 @@ const {
   getBapDataFor2023PRF,
   getBapDataFor2024PRF,
   getBapDataFor2022CRF,
+  getBapDataFor2023CRF,
   checkFormSubmissionPeriodAndBapStatus,
 } = require("../utilities/bap");
 const { checkUserData } = require("../utilities/user");
@@ -1036,14 +1037,29 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
   }
 
   if (rebateYear === "2023") {
-    return {
-      data: {
-        /* TODO */
-      },
-      /** Add custom metadata to track formio submissions from wrapper. */
-      metadata: { ...formioCSBMetadata },
-      state: "draft",
-    };
+    return getBapDataFor2023CRF(req, frfReviewItemId, prfReviewItemId)
+      .then((results) => {
+        const {
+          frf2023RecordQuery,
+          prf2023RecordQuery,
+          prf2023busRecordsQuery,
+        } = results;
+
+        return {
+          data: {
+            /* TODO */
+          },
+          /** Add custom metadata to track formio submissions from wrapper. */
+          metadata: { ...formioCSBMetadata },
+          state: "draft",
+        };
+      })
+      .catch((error) => {
+        // NOTE: logged in bap verifyBapConnection
+        const errorStatus = 500;
+        const errorMessage = `Error getting data for a new 2023 Close Out form submission from the BAP.`;
+        return res.status(errorStatus).json({ message: errorMessage });
+      });
   }
 
   if (rebateYear === "2024") {

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -1036,7 +1036,14 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
   }
 
   if (rebateYear === "2023") {
-    // TODO
+    return {
+      data: {
+        /* TODO */
+      },
+      /** Add custom metadata to track formio submissions from wrapper. */
+      metadata: { ...formioCSBMetadata },
+      state: "draft",
+    };
   }
 
   if (rebateYear === "2024") {

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -888,7 +888,7 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
         const {
           frf2022RecordQuery,
           prf2022RecordQuery,
-          prf2022busRecordsQuery,
+          prf2022BusRecordsQuery,
         } = results;
 
         const {
@@ -924,7 +924,7 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
           Total_Other_Infrastructure_Costs__c,
         } = prf2022RecordQuery[0];
 
-        const busInfo = prf2022busRecordsQuery.map((prf2022BusRecord) => {
+        const busInfo = prf2022BusRecordsQuery.map((prf2022BusRecord) => {
           const {
             Rebate_Item_num__c,
             CSB_VIN__c,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-604

## Main Changes:
* Add initial support for the 2023 CRF.

## Steps To Test:
1. Navigate to the dashboard. Change the rebate year to 2023.
2. Ensure you have an accepted 2023 PRF, and click the "New Close Out" button.
3. Ensure you're directed to the 2023 CRF with data from the 2023 PRF carried over.

## TODO:
- [ ] Add a server app API endpoint for the VIN duplicates check.
