### PR TITLE
Feature/add vin duplicates check

### DIFF
--- a/app/server/app/config/formio.js
+++ b/app/server/app/config/formio.js
@@ -150,6 +150,9 @@ const formioCSBMetadata = {
   "csb-app-cloud-origin": SERVER_URL || "localhost",
 };
 
+/** Example VIN value used in OpenAPI docs (used by EPA API scan) */
+const formioExampleVin = "00000000000000000";
+
 /** Example mongoId value used in OpenAPI docs (used by EPA API scan) */
 const formioExampleMongoId = "000000000000000000000000";
 
@@ -175,6 +178,7 @@ module.exports = {
   formIntroSubstring,
   submissionPeriodOpen,
   formioCSBMetadata,
+  formioExampleVin,
   formioExampleMongoId,
   formioExampleRebateId,
   formioExampleComboKey,

--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -6,6 +6,7 @@ const {
   verifyMongoObjectId,
 } = require("../middleware");
 const {
+  checkVIN,
   searchNcesData,
   //
   downloadFileFromS3,
@@ -40,6 +41,11 @@ const rebateYear = "2023";
 const router = express.Router();
 
 router.use(ensureAuthenticated);
+
+// --- check for duplicate VINs in the BAP
+router.get("/check-vin{/:vin}", (req, res) => {
+  checkVIN({ rebateYear, req, res });
+});
 
 // --- search 2023 NCES data with the provided NCES ID and return a match
 router.get("/nces{/:searchText}", (req, res) => {

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -620,6 +620,20 @@ const { submissionPeriodOpen } = require("../config/formio");
  * }>} BapDuplicates
  */
 
+/**
+ * @typedef {{
+ *  timestamp: string
+ *  results: {
+ *    vin: string
+ *    validFormat: boolean
+ *    sourceRecordKeys: string[]
+ *    sourceExclusions: string[]
+ *    hitSources: string[]
+ *    hit: boolean
+ *  }[]
+ * }} VinDuplicates
+ */
+
 const {
   SERVER_URL,
   BAP_REST_API_VERSION,
@@ -2519,7 +2533,7 @@ async function queryBapForDuplicates(req) {
  * @param {string} vin VIN provided to check for duplicates against
  * @param {string | undefined} rebateId CSB Rebate ID (optional)
  * @param {boolean | undefined} debug Show debug info (optional)
- * @returns {Promise<BapDuplicates>}
+ * @returns {Promise<VinDuplicates>}
  */
 async function queryForVinDuplicates(req, vin, rebateId, debug) {
   const logMessage =
@@ -2737,7 +2751,7 @@ function checkForBapDuplicates(req) {
  * @param {string} vin
  * @param {string | undefined} rebateId
  * @param {boolean | undefined} debug
- * @returns {ReturnType<queryBapForDuplicates>}
+ * @returns {ReturnType<queryForVinDuplicates>}
  */
 function checkForVinDuplicates(req, vin, rebateId, debug) {
   return verifyBapConnection(req, {

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -2513,6 +2513,32 @@ async function queryBapForDuplicates(req) {
 }
 
 /**
+ * Uses cached JSforce connection to query the BAP for duplicate VINs.
+ *
+ * @param {express.Request} req
+ * @param {string} vin VIN provided to check for duplicates against
+ * @param {string | undefined} rebateId CSB Rebate ID (optional)
+ * @param {boolean | undefined} debug Show debug info (optional)
+ * @returns {Promise<BapDuplicates>}
+ */
+async function queryForVinDuplicates(req, vin, rebateId, debug) {
+  const logMessage =
+    `Querying the BAP for duplicate buses with VIN: '${vin}'` +
+    (rebateId ? ` and CSB Rebate ID: '${rebateId}'.` : ".");
+  log({ level: "info", message: logMessage, req });
+
+  /** @type {{ bapConnection: jsforce.Connection }} */
+  const { bapConnection } = req.app.locals;
+
+  const url =
+    `/v1/check-vin?vin=${vin}` +
+    (rebateId ? `&rebate=${rebateId}` : "") +
+    (debug ? `&debug=${debug}` : "");
+
+  return bapConnection.apex.get(url, (_err, res) => res);
+}
+
+/**
  * Verifies the BAP connection has been setup, then calls the provided callback
  * function with the provided arguments.
  *
@@ -2704,6 +2730,23 @@ function checkForBapDuplicates(req) {
 }
 
 /**
+ * Checks the BAP for duplicate VINs associated with a provided VIN and optional
+ * rebate ID.
+ *
+ * @param {express.Request} req
+ * @param {string} vin
+ * @param {string | undefined} rebateId
+ * @param {boolean | undefined} debug
+ * @returns {ReturnType<queryBapForDuplicates>}
+ */
+function checkForVinDuplicates(req, vin, rebateId, debug) {
+  return verifyBapConnection(req, {
+    name: queryForVinDuplicates,
+    args: [req, vin, rebateId, debug],
+  });
+}
+
+/**
  * Returns a resolved or rejected promise, depending on if the given form's
  * submission period is open (as set via environment variables), and if the form
  * submission has the status of "Edits Requested" or not (as stored in and
@@ -2758,5 +2801,6 @@ module.exports = {
   getBapDataFor2022CRF,
   getBapDataFor2023CRF,
   checkForBapDuplicates,
+  checkForVinDuplicates,
   checkFormSubmissionPeriodAndBapStatus,
 };

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -7,6 +7,7 @@ const {
   formUrl,
   submissionPeriodOpen,
   formioCSBMetadata,
+  formioExampleVin,
   formioExampleMongoId,
   formioExampleRebateId,
   formioExampleComboKey,
@@ -19,6 +20,7 @@ const {
   getBapDataFor2024PRF,
   getBapDataFor2022CRF,
   getBapDataFor2023CRF,
+  checkForVinDuplicates,
   checkFormSubmissionPeriodAndBapStatus,
 } = require("../utilities/bap");
 const { checkUserData } = require("../utilities/user");
@@ -108,6 +110,53 @@ const formDataFieldNames = {
     ],
   },
 };
+
+/**
+ * @param {Object} param
+ * @param {RebateYear} param.rebateYear
+ * @param {express.Request} param.req
+ * @param {express.Response} param.res
+ *
+ * @example Example URLs:
+ * - /api/formio/2023/check-vin/11111111111111111
+ * - /api/formio/2023/check-vin/22222222222222222?rebateId=123456
+ * - /api/formio/2023/check-vin/33333333333333333?rebateId=123456&debug=true
+ */
+function checkVIN({ rebateYear, req, res }) {
+  const { vin } = req.params;
+  const { rebateId } = req.query;
+
+  // NOTE: included to support EPA API scan
+  if (vin === formioExampleVin) {
+    return true;
+  }
+
+  if (!vin) {
+    const logMessage = `No VIN passed to VIN duplicates lookup.`;
+    log({ level: "info", message: logMessage, req });
+
+    return false;
+  }
+
+  if (vin.length !== 17) {
+    const logMessage = `Invalid VIN '${vin}' passed to VIN duplicates lookup.`;
+    log({ level: "info", message: logMessage, req });
+
+    return false;
+  }
+
+  return checkForVinDuplicates(req, vin, rebateId)
+    .then((json) => {
+      const results = json.results[0];
+      res.json(results.hit || false);
+    })
+    .catch((_error) => {
+      // NOTE: logged in bap verifyBapConnection
+      const errorStatus = 500;
+      const errorMessage = `Error checking VIN duplicates from the BAP.`;
+      return res.status(errorStatus).json({ message: errorMessage });
+    });
+}
 
 /**
  * @param {Object} param
@@ -2826,6 +2875,7 @@ function fetchChangeRequest({ rebateYear, req, res }) {
 }
 
 module.exports = {
+  checkVIN,
   searchNcesData,
   getRebateIdFieldName,
   //

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -776,6 +776,58 @@
         }
       }
     },
+    "/api/formio/2023/check-vin/{vin}": {
+      "get": {
+        "summary": "check for duplicate VINs in the BAP.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vin",
+            "description": "The bus VIN to search for.",
+            "required": true,
+            "example": "11111111111111111",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rebateId",
+            "description": "The CSB Rebate ID of the current submission.",
+            "required": false,
+            "example": "123456",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "debug",
+            "description": "Return debug info from the BAP in the response.",
+            "required": false,
+            "example": true,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An object containing the duplicate VIN data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
     "/api/formio/2023/nces/{searchText}": {
       "get": {
         "summary": "search 2023 NCES data with the provided NCES ID and return a match.",


### PR DESCRIPTION
## Related Issues:
* CSBAPP-582

## Main Changes:
* Add support for the BAP's duplicate VIN lookup

## Steps To Test:
1. Once it's been implemented into 2023 CRF, ensure the lookup returns the results you'd expect (will be called from the form itself, and the response will inform the form to display a warning message for duplicate VINs found in the BAP).
