### PR TITLE
Feature/add fields to 2023 crf

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -506,6 +506,8 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  Total_DC_Fast_Charger_Costs__c: number
  *  Total_Other_Infrastructure_Costs__c: number
  *  Funding_Alloc_for_Eligible_Infra_Costs__c: number
+ *  Original_CSB_Funds_Requested__c: number
+ *  Total_Bus_And_Infrastructure_Rebate__c: number
  * }[]} prf2023RecordQuery
  * @property {{
  *  attributes: { type: "Line_Item__c", url: string }
@@ -2136,7 +2138,9 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
   //   Total_Level_2_Charger_Costs__c,
   //   Total_DC_Fast_Charger_Costs__c,
   //   Total_Other_Infrastructure_Costs__c,
-  //   Funding_Alloc_for_Eligible_Infra_Costs__c
+  //   Funding_Alloc_for_Eligible_Infra_Costs__c,
+  //   Original_CSB_Funds_Requested__c,
+  //   Total_Bus_And_Infrastructure_Rebate__c
   // FROM
   //   Order_Request__c
   // WHERE
@@ -2202,6 +2206,8 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
         Total_DC_Fast_Charger_Costs__c: 1,
         Total_Other_Infrastructure_Costs__c: 1,
         Funding_Alloc_for_Eligible_Infra_Costs__c: 1,
+        Original_CSB_Funds_Requested__c: 1,
+        Total_Bus_And_Infrastructure_Rebate__c: 1,
       },
     )
     .execute(async (err, records) => ((await err) ? err : records));

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -1123,6 +1123,8 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
           Total_DC_Fast_Charger_Costs__c,
           Total_Other_Infrastructure_Costs__c,
           Funding_Alloc_for_Eligible_Infra_Costs__c,
+          Original_CSB_Funds_Requested__c,
+          Total_Bus_And_Infrastructure_Rebate__c,
         } = prf2023RecordQuery[0];
 
         const prf2023RecordJson = JSON.parse(CSB_Snapshot__r.JSON_Snapshot__c);
@@ -1423,6 +1425,8 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
             _bap_infra_total_dc_fast_charger: Total_DC_Fast_Charger_Costs__c,
             _bap_infra_total_other_costs: Total_Other_Infrastructure_Costs__c,
             _bap_infra_funding: Funding_Alloc_for_Eligible_Infra_Costs__c,
+            _bap_requested_funds: Original_CSB_Funds_Requested__c,
+            _bap_received_funds: Total_Bus_And_Infrastructure_Rebate__c,
             org_organizations,
             bus_buses,
             infra_infrastructure,
@@ -2660,6 +2664,7 @@ function updateCRFSubmission({ rebateYear, req, res }) {
           const errorStatus = error.response?.status || 500;
           const errorMessage = `Error updating Formio ${rebateYear} Close Out form submission '${rebateId}'.`;
           return res.status(errorStatus).json({ message: errorMessage });
+          // return res.status(errorStatus).json(error.response.data);
         });
     })
     .catch((_error) => {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-604

## Main Changes:
Follow up to #597: Add requested and received funds to the 2023 CRF query and injected new submission data.

## Steps To Test:
1. Same general 2023 CRF testing as in #595, but ensure the new `_bap_requested_funds` and `_bap_received_funds` fields in a new 2023 CRF submission have the correct values.
