### PR TITLE
Feature/add rebate contacts api endpoint

### DIFF
--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -8,6 +8,7 @@ const {
 const {
   checkVIN,
   searchNcesData,
+  getRebateContacts,
   //
   downloadFileFromS3,
   uploadFileToS3,
@@ -50,6 +51,11 @@ router.get("/check-vin{/:vin}", (req, res) => {
 // --- search 2023 NCES data with the provided NCES ID and return a match
 router.get("/nces{/:searchText}", (req, res) => {
   searchNcesData({ rebateYear, req, res });
+});
+
+// --- get contacts associated with a provided CSB Rebate ID
+router.get("/contacts/:rebateId", (req, res) => {
+  getRebateContacts({ rebateYear, req, res });
 });
 
 // --- download Formio file attachment from S3

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -592,6 +592,29 @@ const { submissionPeriodOpen } = require("../config/formio");
  */
 
 /**
+ * @typedef {{
+ *  rebateId: string
+ *  rolesApplied: string[]
+ *  count: number
+ *  data: {
+ *    contactRole: string
+ *    contactType: string
+ *    salesforceId: string
+ *    salesforceOrgId: string
+ *    salesforceCreatedDate: string
+ *    salesforceLastModifiedDate: string
+ *    firstName: string
+ *    middleName: string
+ *    lastName: string
+ *    suffix: null
+ *    title: string
+ *    businessPhoneNumber: string
+ *    businessEmail: string
+ *  }[]
+ * }} CSBRebateContacts
+ */
+
+/**
  * @typedef {Object.<string, {
  *  dupeList: {
  *    Id: string
@@ -2471,6 +2494,26 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
 }
 
 /**
+ * Uses cached JSforce connection to query the BAP for contacts associated with
+ * a CSB Rebate ID.
+ *
+ * @param {express.Request} req
+ * @param {string} rebateId CSB Rebate ID
+ * @returns {Promise<CSBRebateContacts>}
+ */
+async function queryForCSBRebateContacts(req, rebateId) {
+  const logMessage = `Querying the BAP for contacts associated with CSB Rebate ID: '${rebateId}'.`;
+  log({ level: "info", message: logMessage, req });
+
+  /** @type {{ bapConnection: jsforce.Connection }} */
+  const { bapConnection } = req.app.locals;
+
+  const url = `/csb/v1/rebates/${rebateId}/contacts`;
+
+  return bapConnection.apex.get(url, (_err, res) => res);
+}
+
+/**
  * Uses cached JSforce connection to query the BAP for duplicate contacts or
  * organizations.
  *
@@ -2696,6 +2739,20 @@ function getBapDataFor2023CRF(req, prfReviewItemId) {
 }
 
 /**
+ * Fetches contacts associated with a provided CSB Rebate ID.
+ *
+ * @param {express.Request} req
+ * @param {string} rebateId
+ * @returns {ReturnType<queryForCSBRebateContacts>}
+ */
+function getCSBRebateContacts(req, rebateId) {
+  return verifyBapConnection(req, {
+    name: queryForCSBRebateContacts,
+    args: [req, rebateId],
+  });
+}
+
+/**
  * Checks for duplicate contacts or organizations in the BAP.
  *
  * @param {express.Request} req
@@ -2710,7 +2767,7 @@ function checkForBapDuplicates(req) {
 
 /**
  * Checks the BAP for duplicate VINs associated with a provided VIN and optional
- * rebate ID.
+ * CSB Rebate ID.
  *
  * @param {express.Request} req
  * @param {string} vin
@@ -2779,6 +2836,7 @@ module.exports = {
   getBapDataFor2024PRF,
   getBapDataFor2022CRF,
   getBapDataFor2023CRF,
+  getCSBRebateContacts,
   checkForBapDuplicates,
   checkForVinDuplicates,
   checkFormSubmissionPeriodAndBapStatus,

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -20,6 +20,7 @@ const {
   getBapDataFor2024PRF,
   getBapDataFor2022CRF,
   getBapDataFor2023CRF,
+  getCSBRebateContacts,
   checkForVinDuplicates,
   checkFormSubmissionPeriodAndBapStatus,
 } = require("../utilities/bap");
@@ -191,6 +192,33 @@ function searchNcesData({ rebateYear, req, res }) {
   log({ level: "info", message: logMessage, req });
 
   return res.json({ ...result });
+}
+
+/**
+ * @param {Object} param
+ * @param {RebateYear} param.rebateYear
+ * @param {express.Request} param.req
+ * @param {express.Response} param.res
+ */
+function getRebateContacts({ rebateYear, req, res }) {
+  const { rebateId } = req.params;
+
+  // NOTE: included to support EPA API scan
+  if (rebateId === formioExampleRebateId) {
+    return res.json([]);
+  }
+
+  return getCSBRebateContacts(req, rebateId)
+    .then((json) => {
+      const results = json.data || [];
+      res.json(results);
+    })
+    .catch((_error) => {
+      // NOTE: logged in bap verifyBapConnection
+      const errorStatus = 500;
+      const errorMessage = `Error getting CSB Rebate Contacts from the BAP.`;
+      return res.status(errorStatus).json({ message: errorMessage });
+    });
 }
 
 /**
@@ -2882,6 +2910,7 @@ function fetchChangeRequest({ rebateYear, req, res }) {
 module.exports = {
   checkVIN,
   searchNcesData,
+  getRebateContacts,
   getRebateIdFieldName,
   //
   downloadFileFromS3,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-609

## Main Changes:
Add's a server API endpoint for querying the BAP for contacts related to a CSB Rebate Id.

## Steps To Test:
1. Once the BAP team grants our API user access to their endpoint, and the 2023 Change Request form integrates the endpoint, we'll be able to test it via the change request form.

## TODO:
- [ ] Check with the BAP team on the BAP web service URL, as it includes a "/csb" prefix in front of the "/v1" endpoint, which wasn't there in the other Apex class based web services they created previously (e.g., VIN lookup).
- [ ] Update the returned data to reflect the shape the BAP returns, as this is just based on the OpenAPI spec they provided before they began development.
