### PR TITLE
Feature/update vin lookup early return logic

### DIFF
--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -129,21 +129,21 @@ function checkVIN({ rebateYear, req, res }) {
 
   // NOTE: included to support EPA API scan
   if (vin === formioExampleVin) {
-    return true;
+    return res.json(true);
   }
 
   if (!vin) {
     const logMessage = `No VIN passed to VIN duplicates lookup.`;
     log({ level: "info", message: logMessage, req });
 
-    return false;
+    return res.json(false);
   }
 
   if (vin.length !== 17) {
     const logMessage = `Invalid VIN '${vin}' passed to VIN duplicates lookup.`;
     log({ level: "info", message: logMessage, req });
 
-    return false;
+    return res.json(false);
   }
 
   return checkForVinDuplicates(req, vin, rebateId)


### PR DESCRIPTION
## Related Issues:
* CSBAPP-582

## Main Changes:
Follow up to #596: Update VIN lookup web service to return the boolean values as JSON in the early return checks

## Steps To Test:
1. Same as before: Once it's been implemented into 2023 CRF, ensure the lookup returns the results you'd expect (will be called from the form itself, and the response will inform the form to display a warning message for duplicate VINs found in the BAP).
