### PR TITLE
Feature/revert formio updates

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -9,11 +9,11 @@
       "version": "8.0.0",
       "license": "CC0-1.0",
       "dependencies": {
-        "@formio/bootstrap": "3.1.2",
-        "@formio/js": "5.2.2",
-        "@formio/premium": "3.0.7",
+        "@formio/bootstrap": "3.1.1",
+        "@formio/js": "5.1.1",
+        "@formio/premium": "3.0.5",
         "@formio/react": "6.1.0",
-        "@formio/uswds": "2.6.1",
+        "@formio/uswds": "2.6.0",
         "@fortawesome/fontawesome-free": "7.0.1",
         "@headlessui/react": "2.2.9",
         "@heroicons/react": "2.2.0",
@@ -56,6 +56,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -678,16 +687,28 @@
       "license": "MIT"
     },
     "node_modules/@formio/bootstrap": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.2.tgz",
-      "integrity": "sha512-1t0IgfxDr9+bPulLRGmirwj2R2fTTtohy1F2A+9g+7LCMRoKs8U0N4alVSy7qSTrruEsOe1JXiCbSPrD/gyZ9A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.1.tgz",
+      "integrity": "sha512-VXm5P5Ic3q7d5tkWaweIRAaPtBjDoov6Vv28y5aHKbR2Ri8ykMINtQJ70NwPHghW+csZmjmtKDDGDXENQVhIbA==",
       "license": "MIT"
+    },
+    "node_modules/@formio/choices.js": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@formio/choices.js/-/choices.js-10.2.1.tgz",
+      "integrity": "sha512-NCE5u7jG3XGokJP16MyAbVSUptKu/mpJYAxd4PPIoLiO/l9Do5uoOQ0MgNb9qG9qABJiOX+qNRE8q8RybY/SwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "fuse.js": "^6.6.2",
+        "redux": "^4.2.0"
+      }
     },
     "node_modules/@formio/core": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.5.1.tgz",
       "integrity": "sha512-J1lICbVQPdKtWvjNvO2aGYog3rv0r3lkpZmUjxgnCQFeausiqR+CnivRz2G/Rexkv9y5jV46BuDHFkNS01ssAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "browser-cookies": "^1.2.0",
         "core-js": "^3.39.0",
@@ -703,13 +724,14 @@
       }
     },
     "node_modules/@formio/js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.2.2.tgz",
-      "integrity": "sha512-tMB1kH51FhJ4TK1KpdR+KtU9/yS4NpgwZblFUME9ILKE57B2KRUeYs2nK8XHFeD8rFOax5WSL+NdXBKH0pG1IA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.1.1.tgz",
+      "integrity": "sha512-dslkDKe9ppyt3gVkQWlFcJFfdtHUvaUl7mCVdGKmk/fVGamUsH2rObLZIqHnTy4ruEr269echkILyN2l+2bfUw==",
       "license": "MIT",
       "dependencies": {
-        "@formio/bootstrap": "3.1.2",
-        "@formio/core": "2.5.1",
+        "@formio/bootstrap": "3.1.0",
+        "@formio/choices.js": "^10.2.1",
+        "@formio/core": "2.4.0",
         "@formio/text-mask-addons": "^3.8.0-formio.4",
         "@formio/vanilla-text-mask": "^5.1.1-formio.1",
         "abortcontroller-polyfill": "^1.7.5",
@@ -717,8 +739,7 @@
         "bootstrap": "^5.3.3",
         "browser-cookies": "^1.2.0",
         "browser-md5-file": "^1.1.1",
-        "choices.js": "^11.0.6",
-        "compare-versions": "^6.1.1",
+        "compare-versions": "^6.0.0-rc.2",
         "core-js": "^3.37.1",
         "dialog-polyfill": "^0.5.6",
         "dom-autoscroller": "^2.3.4",
@@ -743,6 +764,31 @@
         "tippy.js": "^6.3.7",
         "uuid": "^9.0.0",
         "vanilla-picker": "^2.12.3"
+      }
+    },
+    "node_modules/@formio/js/node_modules/@formio/bootstrap": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.0.tgz",
+      "integrity": "sha512-BaH74g+0N9Ddrp7wTn6Ej5Lk/nbKj8h5eqzA6s0I3pvqAgmqTYITlKMXhtWAESWOUA34n18rumpyZIdpB5B35g==",
+      "license": "MIT"
+    },
+    "node_modules/@formio/js/node_modules/@formio/core": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-JUEyDSQv39EfvL5EURKnSYWPz+T1Csc29WiZ+4aQNjsuskhbHOWcmHmPFrdv2JD8xct16g2bLHHne+Bowy5RDw==",
+      "license": "MIT",
+      "dependencies": {
+        "browser-cookies": "^1.2.0",
+        "core-js": "^3.39.0",
+        "dayjs": "^1.11.12",
+        "dompurify": "^3.2.4",
+        "eventemitter3": "^5.0.0",
+        "fast-json-patch": "^3.1.1",
+        "fetch-ponyfill": "^7.1.0",
+        "inputmask": "5.0.9",
+        "json-logic-js": "^2.0.5",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4"
       }
     },
     "node_modules/@formio/js/node_modules/autocompleter": {
@@ -770,9 +816,9 @@
       "license": "MIT"
     },
     "node_modules/@formio/premium": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.0.7.tgz",
-      "integrity": "sha512-7sBazNVhzIj35/bFVmJa69J5HdRNRuwjoNtd0ci/3erCoh1Qle+P+u+GSL9/kd0lIRauxsJtjB0bIflk49LLZw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.0.5.tgz",
+      "integrity": "sha512-3B/5Mt0UQi9cLA6Bnzm63ediYRG2auoQ4SBXphWYPXQjEF+03k7p/LdovRtwlpkLPwkTf8Y2izqrfiE7Ac2oDg==",
       "license": "UNLICENSED",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
@@ -782,6 +828,7 @@
         "papaparse": "^5.3.1",
         "tooltip.js": "^1.3.3",
         "two.js": "^0.7.13",
+        "uuid": "^9.0.1",
         "vanilla-picker": "^2.12.3"
       },
       "peerDependencies": {
@@ -813,13 +860,10 @@
       "license": "Unlicense"
     },
     "node_modules/@formio/uswds": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.6.1.tgz",
-      "integrity": "sha512-lBd5siMq5FzaDHKpdHqCZkN9Wx4s8gCos0fZ6IoI9TJX/dNJB5e+1b5iG+9QnsGi4iKAQurOxSmN5vKPX1W6yg==",
-      "license": "OSLv3",
-      "peerDependencies": {
-        "@formio/js": "^5.2.1"
-      }
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.6.0.tgz",
+      "integrity": "sha512-tB6BXZkyYiN5ZzeDZXnnOAS2Yr4itaXgl1LBBY7JwMIPRICHxtjLty8aGDldt2pO789GGOwdPT1aojJsQqeiYw==",
+      "license": "OSLv3"
     },
     "node_modules/@formio/vanilla-text-mask": {
       "version": "5.1.1",
@@ -3089,15 +3133,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/choices.js": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-11.1.0.tgz",
-      "integrity": "sha512-mIt0uLhedHg2ea/K2PACrVpt391vRGHuOoctPAiHcyemezwzNMxj7jOzNEk8e7EbjLh0S0sspDkSCADOKz9kcw==",
-      "license": "MIT",
-      "dependencies": {
-        "fuse.js": "^7.0.0"
-      }
-    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -3266,6 +3301,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.2",
@@ -3819,9 +3863,9 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
-      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
@@ -5862,6 +5906,15 @@
         "object-assign": "^4.1.0"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -6721,6 +6774,11 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="
+    },
     "@esbuild/aix-ppc64": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
@@ -7025,14 +7083,25 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
     "@formio/bootstrap": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.2.tgz",
-      "integrity": "sha512-1t0IgfxDr9+bPulLRGmirwj2R2fTTtohy1F2A+9g+7LCMRoKs8U0N4alVSy7qSTrruEsOe1JXiCbSPrD/gyZ9A=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.1.tgz",
+      "integrity": "sha512-VXm5P5Ic3q7d5tkWaweIRAaPtBjDoov6Vv28y5aHKbR2Ri8ykMINtQJ70NwPHghW+csZmjmtKDDGDXENQVhIbA=="
+    },
+    "@formio/choices.js": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@formio/choices.js/-/choices.js-10.2.1.tgz",
+      "integrity": "sha512-NCE5u7jG3XGokJP16MyAbVSUptKu/mpJYAxd4PPIoLiO/l9Do5uoOQ0MgNb9qG9qABJiOX+qNRE8q8RybY/SwQ==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "fuse.js": "^6.6.2",
+        "redux": "^4.2.0"
+      }
     },
     "@formio/core": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.5.1.tgz",
       "integrity": "sha512-J1lICbVQPdKtWvjNvO2aGYog3rv0r3lkpZmUjxgnCQFeausiqR+CnivRz2G/Rexkv9y5jV46BuDHFkNS01ssAg==",
+      "peer": true,
       "requires": {
         "browser-cookies": "^1.2.0",
         "core-js": "^3.39.0",
@@ -7048,12 +7117,13 @@
       }
     },
     "@formio/js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.2.2.tgz",
-      "integrity": "sha512-tMB1kH51FhJ4TK1KpdR+KtU9/yS4NpgwZblFUME9ILKE57B2KRUeYs2nK8XHFeD8rFOax5WSL+NdXBKH0pG1IA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.1.1.tgz",
+      "integrity": "sha512-dslkDKe9ppyt3gVkQWlFcJFfdtHUvaUl7mCVdGKmk/fVGamUsH2rObLZIqHnTy4ruEr269echkILyN2l+2bfUw==",
       "requires": {
-        "@formio/bootstrap": "3.1.2",
-        "@formio/core": "2.5.1",
+        "@formio/bootstrap": "3.1.0",
+        "@formio/choices.js": "^10.2.1",
+        "@formio/core": "2.4.0",
         "@formio/text-mask-addons": "^3.8.0-formio.4",
         "@formio/vanilla-text-mask": "^5.1.1-formio.1",
         "abortcontroller-polyfill": "^1.7.5",
@@ -7061,8 +7131,7 @@
         "bootstrap": "^5.3.3",
         "browser-cookies": "^1.2.0",
         "browser-md5-file": "^1.1.1",
-        "choices.js": "^11.0.6",
-        "compare-versions": "^6.1.1",
+        "compare-versions": "^6.0.0-rc.2",
         "core-js": "^3.37.1",
         "dialog-polyfill": "^0.5.6",
         "dom-autoscroller": "^2.3.4",
@@ -7089,6 +7158,29 @@
         "vanilla-picker": "^2.12.3"
       },
       "dependencies": {
+        "@formio/bootstrap": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.0.tgz",
+          "integrity": "sha512-BaH74g+0N9Ddrp7wTn6Ej5Lk/nbKj8h5eqzA6s0I3pvqAgmqTYITlKMXhtWAESWOUA34n18rumpyZIdpB5B35g=="
+        },
+        "@formio/core": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.4.0.tgz",
+          "integrity": "sha512-JUEyDSQv39EfvL5EURKnSYWPz+T1Csc29WiZ+4aQNjsuskhbHOWcmHmPFrdv2JD8xct16g2bLHHne+Bowy5RDw==",
+          "requires": {
+            "browser-cookies": "^1.2.0",
+            "core-js": "^3.39.0",
+            "dayjs": "^1.11.12",
+            "dompurify": "^3.2.4",
+            "eventemitter3": "^5.0.0",
+            "fast-json-patch": "^3.1.1",
+            "fetch-ponyfill": "^7.1.0",
+            "inputmask": "5.0.9",
+            "json-logic-js": "^2.0.5",
+            "lodash": "^4.17.21",
+            "moment": "^2.29.4"
+          }
+        },
         "autocompleter": {
           "version": "8.0.4",
           "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-8.0.4.tgz",
@@ -7112,9 +7204,9 @@
       }
     },
     "@formio/premium": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.0.7.tgz",
-      "integrity": "sha512-7sBazNVhzIj35/bFVmJa69J5HdRNRuwjoNtd0ci/3erCoh1Qle+P+u+GSL9/kd0lIRauxsJtjB0bIflk49LLZw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.0.5.tgz",
+      "integrity": "sha512-3B/5Mt0UQi9cLA6Bnzm63ediYRG2auoQ4SBXphWYPXQjEF+03k7p/LdovRtwlpkLPwkTf8Y2izqrfiE7Ac2oDg==",
       "requires": {
         "@juggle/resize-observer": "^3.4.0",
         "@zxing/library": "^0.21.2",
@@ -7123,6 +7215,7 @@
         "papaparse": "^5.3.1",
         "tooltip.js": "^1.3.3",
         "two.js": "^0.7.13",
+        "uuid": "^9.0.1",
         "vanilla-picker": "^2.12.3"
       }
     },
@@ -7143,10 +7236,9 @@
       "integrity": "sha512-vhkeIyuL+1rtC9S4IW8O3JCwroPtvJrkrcMO4wyELNqMIgQRKbiyBAitZfUP4tY04xdB5lxAinbzdwb+NMdX6w=="
     },
     "@formio/uswds": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.6.1.tgz",
-      "integrity": "sha512-lBd5siMq5FzaDHKpdHqCZkN9Wx4s8gCos0fZ6IoI9TJX/dNJB5e+1b5iG+9QnsGi4iKAQurOxSmN5vKPX1W6yg==",
-      "requires": {}
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.6.0.tgz",
+      "integrity": "sha512-tB6BXZkyYiN5ZzeDZXnnOAS2Yr4itaXgl1LBBY7JwMIPRICHxtjLty8aGDldt2pO789GGOwdPT1aojJsQqeiYw=="
     },
     "@formio/vanilla-text-mask": {
       "version": "5.1.1",
@@ -8412,14 +8504,6 @@
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
       "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
     },
-    "choices.js": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-11.1.0.tgz",
-      "integrity": "sha512-mIt0uLhedHg2ea/K2PACrVpt391vRGHuOoctPAiHcyemezwzNMxj7jOzNEk8e7EbjLh0S0sspDkSCADOKz9kcw==",
-      "requires": {
-        "fuse.js": "^7.0.0"
-      }
-    },
     "chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -8544,6 +8628,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
     },
     "dequal": {
       "version": "2.0.2",
@@ -8951,9 +9040,9 @@
       "optional": true
     },
     "fuse.js": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
-      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ=="
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
     },
     "glob-parent": {
       "version": "6.0.2",
@@ -10200,6 +10289,14 @@
         "keyboardevent-key-polyfill": "^1.0.2",
         "matches-selector": "^1.0.0",
         "object-assign": "^4.1.0"
+      }
+    },
+    "redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "remark-gfm": {

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -36,11 +36,11 @@
     "vite": "7.1.7"
   },
   "dependencies": {
-    "@formio/bootstrap": "3.1.2",
-    "@formio/js": "5.2.2",
-    "@formio/premium": "3.0.7",
+    "@formio/bootstrap": "3.1.1",
+    "@formio/js": "5.1.1",
+    "@formio/premium": "3.0.5",
     "@formio/react": "6.1.0",
-    "@formio/uswds": "2.6.1",
+    "@formio/uswds": "2.6.0",
     "@fortawesome/fontawesome-free": "7.0.1",
     "@headlessui/react": "2.2.9",
     "@heroicons/react": "2.2.0",


### PR DESCRIPTION
## Related Issues:
* CSBAPP-608

## Main Changes:
* Follow up to #602 (in particular https://github.com/USEPA/csb-rebate-forms-app/commit/9abc3e3468a62cf50bc2360ae95f884a96f14ae9) – revert formio package updates for now, as they conflict with select/choicejs dropdowns.

## Steps To Test:
1. Run app – all should still function as normal (including select/dropdowns within forms)

## TODO:
- [ ] Investigate if the issue is around the forms themselves, or a temporary mismatch with formio versions on the server and client that would be resolved when the CDX team updates the Formio API server in the future.
