### PR TITLE
Feature/standardize use of rebate id and combo key

### DIFF
--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -104,7 +104,8 @@ function CloseOutRequestForm(props: { email: string }) {
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { access, schema, submission } = query.data ?? {};
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const crfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 

--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -229,7 +229,7 @@ function CloseOutRequestForm(props: { email: string }) {
         </li>
       </ul>
 
-      {submission?._id && (
+      {mongoId && (
         <p>
           <button
             className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"

--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -105,7 +105,7 @@ function CloseOutRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = submission?.data?.[comboKeyFieldName] || "";
+  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 
   const pdfQuery = useSubmissionPDFQuery({

--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -105,7 +105,7 @@ function CloseOutRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
+  const crfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 
   const pdfQuery = useSubmissionPDFQuery({
@@ -181,9 +181,11 @@ function CloseOutRequestForm(props: { email: string }) {
     (submission.state === "submitted" || !crfSubmissionPeriodOpen) &&
     !crfNeedsEdits;
 
-  /** matched SAM.gov entity for the Close Out submission */
+  /**
+   * Matched SAM.gov entity for the CRF submission.
+   */
   const entity = bapSamData.entities.find((entity) => {
-    return entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entity.ENTITY_COMBO_KEY__c === crfComboKey;
   });
 
   if (!entity) {
@@ -277,7 +279,7 @@ function CloseOutRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={schema}
-          url={`${serverUrl}/api/formio/2022/s3/crf/${mongoId}/${comboKey}`}
+          url={`${serverUrl}/api/formio/2022/s3/crf/${mongoId}/${crfComboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
+  getComboKeyFieldName,
   getData,
   postData,
   useContentData,
@@ -83,6 +84,8 @@ export function CRF2022() {
 function CloseOutRequestForm(props: { email: string }) {
   const { email } = props;
 
+  const rebateYear = "2022";
+
   const navigate = useNavigate();
   const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
 
@@ -95,19 +98,20 @@ function CloseOutRequestForm(props: { email: string }) {
     dismissNotification,
   } = useNotificationsActions();
 
-  const submissionsQueries = useSubmissionsQueries("2022");
-  const submissions = useSubmissions("2022");
+  const submissionsQueries = useSubmissionsQueries(rebateYear);
+  const submissions = useSubmissions(rebateYear);
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { access, schema, submission } = query.data ?? {};
 
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKey = submission?.data?.[comboKeyFieldName] || "";
   const mongoId = submission?._id || "";
-  const comboKey = submission?.data.bap_hidden_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
-    rebateYear: "2022",
+    rebateYear,
     formType: "crf",
-    mongoId: submission?._id || "",
+    mongoId,
   });
 
   /**
@@ -170,7 +174,8 @@ function CloseOutRequestForm(props: { email: string }) {
         bap: rebate.crf.bap,
       });
 
-  const crfSubmissionPeriodOpen = configData.submissionPeriodOpen["2022"].crf;
+  const crfSubmissionPeriodOpen =
+    configData.submissionPeriodOpen[rebateYear].crf;
 
   const formIsReadOnly =
     (submission.state === "submitted" || !crfSubmissionPeriodOpen) &&
@@ -178,8 +183,7 @@ function CloseOutRequestForm(props: { email: string }) {
 
   /** matched SAM.gov entity for the Close Out submission */
   const entity = bapSamData.entities.find((entity) => {
-    const { ENTITY_COMBO_KEY__c } = entity;
-    return ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key;
+    return entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
   if (!entity) {

--- a/app/client/src/routes/crf2023.tsx
+++ b/app/client/src/routes/crf2023.tsx
@@ -105,7 +105,7 @@ function CloseOutRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
+  const crfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 
   const pdfQuery = useSubmissionPDFQuery({
@@ -181,9 +181,11 @@ function CloseOutRequestForm(props: { email: string }) {
     (submission.state === "submitted" || !crfSubmissionPeriodOpen) &&
     !crfNeedsEdits;
 
-  /** matched SAM.gov entity for the Close Out submission */
+  /**
+   * Matched SAM.gov entity for the CRF submission.
+   */
   const entity = bapSamData.entities.find((entity) => {
-    return entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entity.ENTITY_COMBO_KEY__c === crfComboKey;
   });
 
   if (!entity) {
@@ -284,7 +286,7 @@ function CloseOutRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={schema}
-          url={`${serverUrl}/api/formio/2023/s3/crf/${mongoId}/${comboKey}`}
+          url={`${serverUrl}/api/formio/2023/s3/crf/${mongoId}/${crfComboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/crf2023.tsx
+++ b/app/client/src/routes/crf2023.tsx
@@ -104,7 +104,8 @@ function CloseOutRequestForm(props: { email: string }) {
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { access, schema, submission } = query.data ?? {};
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const crfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 

--- a/app/client/src/routes/crf2023.tsx
+++ b/app/client/src/routes/crf2023.tsx
@@ -105,7 +105,7 @@ function CloseOutRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = submission?.data?.[comboKeyFieldName] || "";
+  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 
   const pdfQuery = useSubmissionPDFQuery({

--- a/app/client/src/routes/crf2023.tsx
+++ b/app/client/src/routes/crf2023.tsx
@@ -236,7 +236,7 @@ function CloseOutRequestForm(props: { email: string }) {
         </li>
       </ul>
 
-      {submission?._id && (
+      {mongoId && (
         <p>
           <button
             className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"

--- a/app/client/src/routes/crf2023.tsx
+++ b/app/client/src/routes/crf2023.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
+  getComboKeyFieldName,
   getData,
   postData,
   useContentData,
@@ -83,6 +84,8 @@ export function CRF2023() {
 function CloseOutRequestForm(props: { email: string }) {
   const { email } = props;
 
+  const rebateYear = "2023";
+
   const navigate = useNavigate();
   const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
 
@@ -95,19 +98,20 @@ function CloseOutRequestForm(props: { email: string }) {
     dismissNotification,
   } = useNotificationsActions();
 
-  const submissionsQueries = useSubmissionsQueries("2023");
-  const submissions = useSubmissions("2023");
+  const submissionsQueries = useSubmissionsQueries(rebateYear);
+  const submissions = useSubmissions(rebateYear);
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { access, schema, submission } = query.data ?? {};
 
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKey = submission?.data?.[comboKeyFieldName] || "";
   const mongoId = submission?._id || "";
-  const comboKey = submission?.data._bap_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
-    rebateYear: "2023",
+    rebateYear,
     formType: "crf",
-    mongoId: submission?._id || "",
+    mongoId,
   });
 
   /**
@@ -170,7 +174,8 @@ function CloseOutRequestForm(props: { email: string }) {
         bap: rebate.crf.bap,
       });
 
-  const crfSubmissionPeriodOpen = configData.submissionPeriodOpen["2023"].crf;
+  const crfSubmissionPeriodOpen =
+    configData.submissionPeriodOpen[rebateYear].crf;
 
   const formIsReadOnly =
     (submission.state === "submitted" || !crfSubmissionPeriodOpen) &&
@@ -178,8 +183,7 @@ function CloseOutRequestForm(props: { email: string }) {
 
   /** matched SAM.gov entity for the Close Out submission */
   const entity = bapSamData.entities.find((entity) => {
-    const { ENTITY_COMBO_KEY__c } = entity;
-    return ENTITY_COMBO_KEY__c === submission.data._bap_entity_combo_key;
+    return entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
   if (!entity) {

--- a/app/client/src/routes/dashboard.tsx
+++ b/app/client/src/routes/dashboard.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/config";
 import {
   getComboKeyFieldName,
+  getRebateIdFieldName,
   postData,
   useContentData,
   useConfigData,
@@ -408,8 +409,10 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+  const rebateIdFieldName = getRebateIdFieldName(rebateYear);
 
   const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
+  const prfRebateId = String(prf.formio?.data?.[rebateIdFieldName] ?? "");
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -525,7 +528,7 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
   // return if a Payment Request submission has not been created for this rebate
   if (!prf.formio) return null;
 
-  const { hidden_current_user_email, hidden_bap_rebate_id } = prf.formio.data;
+  const { hidden_current_user_email } = prf.formio.data;
 
   const date = new Date(prf.formio.modified).toLocaleDateString();
   const time = new Date(prf.formio.modified).toLocaleTimeString();
@@ -558,7 +561,7 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
 
   const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
 
-  const prfUrl = `/prf/2022/${hidden_bap_rebate_id}`;
+  const prfUrl = `/prf/2022/${prfRebateId}`;
 
   return (
     <tr
@@ -626,8 +629,10 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+  const rebateIdFieldName = getRebateIdFieldName(rebateYear);
 
   const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
+  const crfRebateId = String(crf.formio?.data?.[rebateIdFieldName] ?? "");
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -743,7 +748,7 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
   // return if a Close Out submission has not been created for this rebate
   if (!crf.formio) return null;
 
-  const { hidden_current_user_email, hidden_bap_rebate_id } = crf.formio.data;
+  const { hidden_current_user_email } = crf.formio.data;
 
   const date = new Date(crf.formio.modified).toLocaleDateString();
   const time = new Date(crf.formio.modified).toLocaleTimeString();
@@ -778,7 +783,7 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
 
   const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
 
-  const crfUrl = `/crf/2022/${hidden_bap_rebate_id}`;
+  const crfUrl = `/crf/2022/${crfRebateId}`;
 
   return (
     <tr
@@ -914,7 +919,9 @@ function Submissions2022() {
 /* --- 2023 Submissions --- */
 
 function ChangeRequests2023() {
-  const changeRequests = useChangeRequests("2023");
+  const rebateYear = "2023";
+
+  const changeRequests = useChangeRequests(rebateYear);
 
   if (!changeRequests || changeRequests.length === 0) return null;
 
@@ -1290,9 +1297,11 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+  const rebateIdFieldName = getRebateIdFieldName(rebateYear);
 
   const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
   const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
+  const prfRebateId = String(prf.formio?.data?.[rebateIdFieldName] ?? "");
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -1410,7 +1419,6 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
 
   const {
     _user_email,
-    _bap_rebate_id,
     _bap_applicant_name,
     _bap_district_name,
     _bap_district_state,
@@ -1447,7 +1455,7 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
 
   const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
 
-  const prfUrl = `/prf/2023/${_bap_rebate_id}`;
+  const prfUrl = `/prf/2023/${prfRebateId}`;
 
   return (
     <tr
@@ -1512,7 +1520,7 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
           data={{
             formType: "prf",
             comboKey: prfComboKey,
-            rebateId: _bap_rebate_id,
+            rebateId: prfRebateId,
             mongoId: prf.formio._id,
             state: prf.formio.state || "",
             email,
@@ -1533,9 +1541,11 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+  const rebateIdFieldName = getRebateIdFieldName(rebateYear);
 
   const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
   const crfComboKey = String(crf.formio?.data?.[comboKeyFieldName] ?? "");
+  const crfRebateId = String(crf.formio?.data?.[rebateIdFieldName] ?? "");
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -1653,7 +1663,6 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
 
   const {
     _user_email,
-    _bap_rebate_id,
     _bap_applicant_name,
     _bap_district_name,
     _bap_district_state,
@@ -1692,7 +1701,7 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
 
   const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
 
-  const crfUrl = `/crf/2023/${_bap_rebate_id}`;
+  const crfUrl = `/crf/2023/${crfRebateId}`;
 
   return (
     <tr
@@ -1761,7 +1770,7 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
           data={{
             formType: "crf",
             comboKey: crfComboKey,
-            rebateId: _bap_rebate_id,
+            rebateId: crfRebateId,
             mongoId: crf.formio._id,
             state: crf.formio.state || "",
             email,
@@ -1855,7 +1864,9 @@ function Submissions2023() {
 /* --- 2024 Submissions --- */
 
 function ChangeRequests2024() {
-  const changeRequests = useChangeRequests("2024");
+  const rebateYear = "2024";
+
+  const changeRequests = useChangeRequests(rebateYear);
 
   if (!changeRequests || changeRequests.length === 0) return null;
 
@@ -2216,9 +2227,11 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 //   const { rebateYear, frf, prf, crf } = rebate;
 
 //   const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+//   const rebateIdFieldName = getRebateIdFieldName(rebateYear);
 
 //   const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 //   const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
+//   const prfRebateId = String(prf.formio?.data?.[rebateIdFieldName] ?? "");
 
 //   const navigate = useNavigate();
 //   const { email } = useOutletContext<{ email: string }>();
@@ -2334,7 +2347,6 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
 //   const {
 //     _user_email,
-//     _bap_rebate_id,
 //     _bap_applicant_name,
 //     _bap_district_name,
 //     _bap_district_state,
@@ -2371,7 +2383,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
 //   const hiddenTableCellClassNames = "tw:!hidden tw:min-[30rem]:!table-cell";
 
-//   const prfUrl = `/prf/2024/${_bap_rebate_id}`;
+//   const prfUrl = `/prf/2024/${prfRebateId}`;
 
 //   return (
 //     <tr
@@ -2436,7 +2448,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 //           data={{
 //             formType: "prf",
 //             comboKey: prfComboKey,
-//             rebateId: _bap_rebate_id,
+//             rebateId: prfRebateId,
 //             mongoId: prf.formio._id,
 //             state: prf.formio.state || "",
 //             email,

--- a/app/client/src/routes/dashboard.tsx
+++ b/app/client/src/routes/dashboard.tsx
@@ -174,7 +174,8 @@ function FRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebate } = props;
   const { rebateYear, frf, prf, crf } = rebate;
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 
   const configData = useConfigData();
@@ -406,7 +407,8 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebate } = props;
   const { rebateYear, frf, prf, crf } = rebate;
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 
   const navigate = useNavigate();
@@ -623,7 +625,8 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebate } = props;
   const { rebateYear, frf, prf, crf } = rebate;
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
 
   const navigate = useNavigate();
@@ -1055,7 +1058,8 @@ function FRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebate } = props;
   const { rebateYear, frf, prf, crf } = rebate;
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 
   const { email } = useOutletContext<{ email: string }>();
@@ -1285,7 +1289,8 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebate } = props;
   const { rebateYear, frf, prf, crf } = rebate;
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
   const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
 
@@ -1527,7 +1532,8 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebate } = props;
   const { rebateYear, frf, prf, crf } = rebate;
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
   const crfComboKey = String(crf.formio?.data?.[comboKeyFieldName] ?? "");
 
@@ -1993,7 +1999,8 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
   const { rebate } = props;
   const { rebateYear, frf, prf, crf } = rebate;
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 
   const { email } = useOutletContext<{ email: string }>();
@@ -2208,7 +2215,8 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 //   const { rebate } = props;
 //   const { rebateYear, frf, prf, crf } = rebate;
 
-//   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+//   const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
 //   const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 //   const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
 

--- a/app/client/src/routes/dashboard.tsx
+++ b/app/client/src/routes/dashboard.tsx
@@ -182,7 +182,9 @@ function FRF2022Submission(props: { rebate: Rebate2022 }) {
 
   if (!configData || !bapSamData) return null;
 
-  /** matched SAM.gov entity for the FRF submission */
+  /**
+   * Matched SAM.gov entity for the FRF submission.
+   */
   const entity = bapSamData.entities.find((entity) => {
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
@@ -422,7 +424,10 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
 
   if (!configData || !bapSamData) return null;
 
-  /** matched SAM.gov entity for the FRF submission */
+  /**
+   * Matched SAM.gov entity for the FRF submission
+   * (as the PRF might not have been created yet).
+   */
   const entity = bapSamData.entities.find((entity) => {
     const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
@@ -636,7 +641,10 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
 
   if (!configData || !bapSamData) return null;
 
-  /** matched SAM.gov entity for the PRF submission */
+  /**
+   * Matched SAM.gov entity for the PRF submission
+   * (as the CRF might not have been created yet).
+   */
   const entity = bapSamData.entities.find((entity) => {
     const comboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
@@ -1057,7 +1065,9 @@ function FRF2023Submission(props: { rebate: Rebate2023 }) {
 
   if (!configData || !bapSamData) return null;
 
-  /** matched SAM.gov entity for the FRF submission */
+  /**
+   * Matched SAM.gov entity for the FRF submission.
+   */
   const entity = bapSamData.entities.find((entity) => {
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
@@ -1293,7 +1303,10 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
 
   if (!configData || !bapSamData) return null;
 
-  /** matched SAM.gov entity for the FRF submission */
+  /**
+   * Matched SAM.gov entity for the FRF submission
+   * (as the PRF might not have been created yet).
+   */
   const entity = bapSamData.entities.find((entity) => {
     const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
@@ -1532,7 +1545,10 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
 
   if (!configData || !bapSamData) return null;
 
-  /** matched SAM.gov entity for the PRF submission */
+  /**
+   * Matched SAM.gov entity for the PRF submission
+   * (as the CRF might not have been created yet).
+   */
   const entity = bapSamData.entities.find((entity) => {
     const comboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
@@ -1987,7 +2003,9 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
   if (!configData || !bapSamData) return null;
 
-  /** matched SAM.gov entity for the FRF submission */
+  /**
+   * Matched SAM.gov entity for the FRF submission.
+   */
   const entity = bapSamData.entities.find((entity) => {
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
@@ -2208,7 +2226,10 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
 //   if (!configData || !bapSamData) return null;
 
-//   /** matched SAM.gov entity for the FRF submission */
+//   /**
+//    * Matched SAM.gov entity for the FRF submission
+//    * (as the PRF might not have been created yet).
+//    */
 //   const entity = bapSamData.entities.find((entity) => {
 //     const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 //     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;

--- a/app/client/src/routes/dashboard.tsx
+++ b/app/client/src/routes/dashboard.tsx
@@ -175,7 +175,7 @@ function FRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
+  const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 
   const configData = useConfigData();
   const bapSamData = useBapSamData();
@@ -186,7 +186,7 @@ function FRF2022Submission(props: { rebate: Rebate2022 }) {
    * Matched SAM.gov entity for the FRF submission.
    */
   const entity = bapSamData.entities.find((entity) => {
-    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === frfComboKey;
   });
 
   if (!entity) return null;
@@ -407,6 +407,7 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -429,8 +430,7 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
    * (as the PRF might not have been created yet).
    */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
-    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === frfComboKey;
   });
 
   if (!entity) return null;
@@ -624,6 +624,7 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -646,8 +647,7 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
    * (as the CRF might not have been created yet).
    */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
-    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === prfComboKey;
   });
 
   if (!entity) return null;
@@ -1056,7 +1056,7 @@ function FRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
+  const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 
   const { email } = useOutletContext<{ email: string }>();
 
@@ -1069,7 +1069,7 @@ function FRF2023Submission(props: { rebate: Rebate2023 }) {
    * Matched SAM.gov entity for the FRF submission.
    */
   const entity = bapSamData.entities.find((entity) => {
-    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === frfComboKey;
   });
 
   if (!entity) return null;
@@ -1264,7 +1264,7 @@ handle when it's value is an empty string. */}
         <ChangeRequest2023Button
           data={{
             formType: "frf",
-            comboKey,
+            comboKey: frfComboKey,
             rebateId: frf.bap?.rebateId || null,
             mongoId: frf.formio._id,
             state: frf.formio.state || "",
@@ -1286,6 +1286,8 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
+  const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -1308,8 +1310,7 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
    * (as the PRF might not have been created yet).
    */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
-    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === frfComboKey;
   });
 
   if (!entity) return null;
@@ -1404,7 +1405,6 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
 
   const {
     _user_email,
-    _bap_entity_combo_key,
     _bap_rebate_id,
     _bap_applicant_name,
     _bap_district_name,
@@ -1506,7 +1506,7 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
         <ChangeRequest2023Button
           data={{
             formType: "prf",
-            comboKey: _bap_entity_combo_key,
+            comboKey: prfComboKey,
             rebateId: _bap_rebate_id,
             mongoId: prf.formio._id,
             state: prf.formio.state || "",
@@ -1528,6 +1528,8 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
+  const crfComboKey = String(crf.formio?.data?.[comboKeyFieldName] ?? "");
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -1550,8 +1552,7 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
    * (as the CRF might not have been created yet).
    */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
-    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === prfComboKey;
   });
 
   if (!entity) return null;
@@ -1646,7 +1647,6 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
 
   const {
     _user_email,
-    _bap_entity_combo_key,
     _bap_rebate_id,
     _bap_applicant_name,
     _bap_district_name,
@@ -1754,7 +1754,7 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
         <ChangeRequest2023Button
           data={{
             formType: "crf",
-            comboKey: _bap_entity_combo_key,
+            comboKey: crfComboKey,
             rebateId: _bap_rebate_id,
             mongoId: crf.formio._id,
             state: crf.formio.state || "",
@@ -1994,7 +1994,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
+  const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 
   const { email } = useOutletContext<{ email: string }>();
 
@@ -2007,7 +2007,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
    * Matched SAM.gov entity for the FRF submission.
    */
   const entity = bapSamData.entities.find((entity) => {
-    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === frfComboKey;
   });
 
   if (!entity) return null;
@@ -2187,7 +2187,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
         <ChangeRequest2024Button
           data={{
             formType: "frf",
-            comboKey,
+            comboKey: frfComboKey,
             rebateId: frf.bap?.rebateId || null,
             mongoId: frf.formio._id,
             state: frf.formio.state || "",
@@ -2209,6 +2209,8 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 //   const { rebateYear, frf, prf, crf } = rebate;
 
 //   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+//   const frfComboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
+//   const prfComboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
 
 //   const navigate = useNavigate();
 //   const { email } = useOutletContext<{ email: string }>();
@@ -2231,8 +2233,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 //    * (as the PRF might not have been created yet).
 //    */
 //   const entity = bapSamData.entities.find((entity) => {
-//     const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
-//     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
+//     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === frfComboKey;
 //   });
 
 //   if (!entity) return null;
@@ -2325,7 +2326,6 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
 //   const {
 //     _user_email,
-//     _bap_entity_combo_key,
 //     _bap_rebate_id,
 //     _bap_applicant_name,
 //     _bap_district_name,
@@ -2427,7 +2427,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 //         <ChangeRequest2024Button
 //           data={{
 //             formType: "prf",
-//             comboKey: _bap_entity_combo_key,
+//             comboKey: prfComboKey,
 //             rebateId: _bap_rebate_id,
 //             mongoId: prf.formio._id,
 //             state: prf.formio.state || "",

--- a/app/client/src/routes/dashboard.tsx
+++ b/app/client/src/routes/dashboard.tsx
@@ -175,6 +175,7 @@ function FRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 
   const configData = useConfigData();
   const bapSamData = useBapSamData();
@@ -183,7 +184,6 @@ function FRF2022Submission(props: { rebate: Rebate2022 }) {
 
   /** matched SAM.gov entity for the FRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -424,7 +424,7 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
 
   /** matched SAM.gov entity for the FRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
+    const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -638,7 +638,7 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
 
   /** matched SAM.gov entity for the PRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = prf.formio?.data?.[comboKeyFieldName] || "";
+    const comboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -1048,6 +1048,7 @@ function FRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 
   const { email } = useOutletContext<{ email: string }>();
 
@@ -1058,7 +1059,6 @@ function FRF2023Submission(props: { rebate: Rebate2023 }) {
 
   /** matched SAM.gov entity for the FRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -1070,7 +1070,6 @@ function FRF2023Submission(props: { rebate: Rebate2023 }) {
 
   const {
     _user_email,
-    _bap_entity_combo_key,
     _bap_applicant_name,
     appInfo_uei,
     appInfo_efti,
@@ -1255,7 +1254,7 @@ handle when it's value is an empty string. */}
         <ChangeRequest2023Button
           data={{
             formType: "frf",
-            comboKey: _bap_entity_combo_key,
+            comboKey,
             rebateId: frf.bap?.rebateId || null,
             mongoId: frf.formio._id,
             state: frf.formio.state || "",
@@ -1296,7 +1295,7 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
 
   /** matched SAM.gov entity for the FRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
+    const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -1535,7 +1534,7 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
 
   /** matched SAM.gov entity for the PRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = prf.formio?.data?.[comboKeyFieldName] || "";
+    const comboKey = String(prf.formio?.data?.[comboKeyFieldName] ?? "");
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -1979,6 +1978,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
   const { rebateYear, frf, prf, crf } = rebate;
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 
   const { email } = useOutletContext<{ email: string }>();
 
@@ -1989,7 +1989,6 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
   /** matched SAM.gov entity for the FRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -2001,7 +2000,6 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
   const {
     _user_email,
-    _bap_entity_combo_key,
     _bap_applicant_name,
     _formio_schoolDistrictName,
     appInfo_uei,
@@ -2171,7 +2169,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
         <ChangeRequest2024Button
           data={{
             formType: "frf",
-            comboKey: _bap_entity_combo_key,
+            comboKey,
             rebateId: frf.bap?.rebateId || null,
             mongoId: frf.formio._id,
             state: frf.formio.state || "",
@@ -2212,7 +2210,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
 //   /** matched SAM.gov entity for the FRF submission */
 //   const entity = bapSamData.entities.find((entity) => {
-//     const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
+//     const comboKey = String(frf.formio.data?.[comboKeyFieldName] ?? "");
 //     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
 //   });
 

--- a/app/client/src/routes/dashboard.tsx
+++ b/app/client/src/routes/dashboard.tsx
@@ -23,6 +23,7 @@ import {
   statusIconMap,
 } from "@/config";
 import {
+  getComboKeyFieldName,
   postData,
   useContentData,
   useConfigData,
@@ -171,7 +172,9 @@ function SubmissionsTableHeader(props: { rebateYear: RebateYear }) {
 
 function FRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebate } = props;
-  const { frf, prf, crf } = rebate;
+  const { rebateYear, frf, prf, crf } = rebate;
+
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
 
   const configData = useConfigData();
   const bapSamData = useBapSamData();
@@ -180,7 +183,7 @@ function FRF2022Submission(props: { rebate: Rebate2022 }) {
 
   /** matched SAM.gov entity for the FRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = frf.formio.data.bap_hidden_entity_combo_key;
+    const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -399,7 +402,9 @@ save the form for the EFT indicator to be displayed. */
 
 function PRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebate } = props;
-  const { frf, prf, crf } = rebate;
+  const { rebateYear, frf, prf, crf } = rebate;
+
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -419,7 +424,7 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
 
   /** matched SAM.gov entity for the FRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = frf.formio.data.bap_hidden_entity_combo_key;
+    const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -611,7 +616,9 @@ function PRF2022Submission(props: { rebate: Rebate2022 }) {
 
 function CRF2022Submission(props: { rebate: Rebate2022 }) {
   const { rebate } = props;
-  const { frf, prf, crf } = rebate;
+  const { rebateYear, frf, prf, crf } = rebate;
+
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -631,7 +638,7 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
 
   /** matched SAM.gov entity for the PRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = prf.formio?.data.bap_hidden_entity_combo_key;
+    const comboKey = prf.formio?.data?.[comboKeyFieldName] || "";
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -828,9 +835,11 @@ function CRF2022Submission(props: { rebate: Rebate2022 }) {
 }
 
 function Submissions2022() {
+  const rebateYear = "2022";
+
   const content = useContentData();
-  const submissionsQueries = useSubmissionsQueries("2022");
-  const submissions = useSubmissions("2022");
+  const submissionsQueries = useSubmissionsQueries(rebateYear);
+  const submissions = useSubmissions(rebateYear);
 
   if (submissionsQueries.some((query) => query.isFetching)) {
     return <Loading />;
@@ -861,10 +870,10 @@ function Submissions2022() {
           aria-label="Your 2022 Rebate Forms"
           className="usa-table usa-table--stacked usa-table--borderless width-full"
         >
-          <SubmissionsTableHeader rebateYear="2022" />
+          <SubmissionsTableHeader rebateYear={rebateYear} />
           <tbody className={clsx("tw:[&_:is(th,td)]:text-[15px]")}>
             {submissions.map((rebate, index) => {
-              return rebate.rebateYear === "2022" ? (
+              return rebate.rebateYear === rebateYear ? (
                 <Fragment key={rebate.rebateId}>
                   <FRF2022Submission rebate={rebate} />
                   <PRF2022Submission rebate={rebate} />
@@ -1036,7 +1045,9 @@ function ChangeRequests2023() {
 
 function FRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebate } = props;
-  const { frf, prf, crf } = rebate;
+  const { rebateYear, frf, prf, crf } = rebate;
+
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
 
   const { email } = useOutletContext<{ email: string }>();
 
@@ -1047,7 +1058,7 @@ function FRF2023Submission(props: { rebate: Rebate2023 }) {
 
   /** matched SAM.gov entity for the FRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = frf.formio.data._bap_entity_combo_key;
+    const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -1263,7 +1274,9 @@ handle when it's value is an empty string. */}
 
 function PRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebate } = props;
-  const { frf, prf, crf } = rebate;
+  const { rebateYear, frf, prf, crf } = rebate;
+
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -1283,7 +1296,7 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
 
   /** matched SAM.gov entity for the FRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = frf.formio.data._bap_entity_combo_key;
+    const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -1500,7 +1513,9 @@ function PRF2023Submission(props: { rebate: Rebate2023 }) {
 
 function CRF2023Submission(props: { rebate: Rebate2023 }) {
   const { rebate } = props;
-  const { frf, prf, crf } = rebate;
+  const { rebateYear, frf, prf, crf } = rebate;
+
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
 
   const navigate = useNavigate();
   const { email } = useOutletContext<{ email: string }>();
@@ -1520,7 +1535,7 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
 
   /** matched SAM.gov entity for the PRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = prf.formio?.data._bap_entity_combo_key;
+    const comboKey = prf.formio?.data?.[comboKeyFieldName] || "";
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -1742,10 +1757,12 @@ function CRF2023Submission(props: { rebate: Rebate2023 }) {
 }
 
 function Submissions2023() {
+  const rebateYear = "2023";
+
   const content = useContentData();
-  const changeRequestsQuery = useChangeRequestsQuery("2023");
-  const submissionsQueries = useSubmissionsQueries("2023");
-  const submissions = useSubmissions("2023");
+  const changeRequestsQuery = useChangeRequestsQuery(rebateYear);
+  const submissionsQueries = useSubmissionsQueries(rebateYear);
+  const submissions = useSubmissions(rebateYear);
 
   if (
     changeRequestsQuery.isLoading ||
@@ -1784,10 +1801,10 @@ function Submissions2023() {
           aria-label="Your 2023 Rebate Forms"
           className="usa-table usa-table--stacked usa-table--borderless width-full"
         >
-          <SubmissionsTableHeader rebateYear="2023" />
+          <SubmissionsTableHeader rebateYear={rebateYear} />
           <tbody className={clsx("tw:[&_:is(th,td)]:text-[15px]")}>
             {submissions.map((rebate, index) => {
-              return rebate.rebateYear === "2023" ? (
+              return rebate.rebateYear === rebateYear ? (
                 <Fragment key={rebate.rebateId}>
                   <FRF2023Submission rebate={rebate} />
                   <PRF2023Submission rebate={rebate} />
@@ -1959,7 +1976,9 @@ function ChangeRequests2024() {
 
 function FRF2024Submission(props: { rebate: Rebate2024 }) {
   const { rebate } = props;
-  const { frf, prf, crf } = rebate;
+  const { rebateYear, frf, prf, crf } = rebate;
+
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
 
   const { email } = useOutletContext<{ email: string }>();
 
@@ -1970,7 +1989,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
   /** matched SAM.gov entity for the FRF submission */
   const entity = bapSamData.entities.find((entity) => {
-    const comboKey = frf.formio.data._bap_entity_combo_key;
+    const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
@@ -2171,7 +2190,9 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
 // function PRF2024Submission(props: { rebate: Rebate2024 }) {
 //   const { rebate } = props;
-//   const { frf, prf, crf } = rebate;
+//   const { rebateYear, frf, prf, crf } = rebate;
+
+//   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
 
 //   const navigate = useNavigate();
 //   const { email } = useOutletContext<{ email: string }>();
@@ -2191,7 +2212,7 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 
 //   /** matched SAM.gov entity for the FRF submission */
 //   const entity = bapSamData.entities.find((entity) => {
-//     const comboKey = frf.formio.data._bap_entity_combo_key;
+//     const comboKey = frf.formio.data?.[comboKeyFieldName] || "";
 //     return entityIsActive(entity) && entity.ENTITY_COMBO_KEY__c === comboKey;
 //   });
 
@@ -2409,10 +2430,12 @@ function FRF2024Submission(props: { rebate: Rebate2024 }) {
 // }
 
 function Submissions2024() {
+  const rebateYear = "2024";
+
   const content = useContentData();
-  const changeRequestsQuery = useChangeRequestsQuery("2024");
-  const submissionsQueries = useSubmissionsQueries("2024");
-  const submissions = useSubmissions("2024");
+  const changeRequestsQuery = useChangeRequestsQuery(rebateYear);
+  const submissionsQueries = useSubmissionsQueries(rebateYear);
+  const submissions = useSubmissions(rebateYear);
 
   if (
     changeRequestsQuery.isLoading ||
@@ -2451,10 +2474,10 @@ function Submissions2024() {
           aria-label="Your 2024 Rebate Forms"
           className="usa-table usa-table--stacked usa-table--borderless width-full"
         >
-          <SubmissionsTableHeader rebateYear="2024" />
+          <SubmissionsTableHeader rebateYear={rebateYear} />
           <tbody className={clsx("tw:[&_:is(th,td)]:text-[15px]")}>
             {submissions.map((rebate, index) => {
-              return rebate.rebateYear === "2024" ? (
+              return rebate.rebateYear === rebateYear ? (
                 <Fragment key={rebate.rebateId}>
                   <FRF2024Submission rebate={rebate} />
                   {/* <PRF2024Submission rebate={rebate} /> */}

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -121,7 +121,7 @@ function FundingRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = submission?.data?.[comboKeyFieldName] || "";
+  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear,
@@ -305,7 +305,7 @@ function FundingRequestForm(props: { email: string }) {
         postData(url, {
           mongoId: prf._id,
           rebateId: prf.data.hidden_bap_rebate_id,
-          comboKey: prf.data[comboKeyFieldName],
+          comboKey: String(prf.data[comboKeyFieldName] ?? ""),
         })
           .then((_res) => {
             window.location.reload();

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -120,7 +120,8 @@ function FundingRequestForm(props: { email: string }) {
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { access, schema, submission } = query.data ?? {};
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const frfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
   const pdfQuery = useSubmissionPDFQuery({
@@ -268,6 +269,7 @@ function FundingRequestForm(props: { email: string }) {
       confirmText: "Delete Payment Request Form Submission",
       confirmedAction: () => {
         const prf = rebate.prf.formio;
+
         const prfComboKey = String(prf?.data?.[comboKeyFieldName] ?? "");
 
         if (!prf) {

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
+  getComboKeyFieldName,
   getData,
   postData,
   useContentData,
@@ -97,6 +98,8 @@ export function FRF2022() {
 function FundingRequestForm(props: { email: string }) {
   const { email } = props;
 
+  const rebateYear = "2022";
+
   const navigate = useNavigate();
   const { id: mongoId } = useParams<"id">(); // MongoDB ObjectId string
 
@@ -111,16 +114,17 @@ function FundingRequestForm(props: { email: string }) {
     dismissNotification,
   } = useNotificationsActions();
 
-  const submissionsQueries = useSubmissionsQueries("2022");
-  const submissions = useSubmissions("2022");
+  const submissionsQueries = useSubmissionsQueries(rebateYear);
+  const submissions = useSubmissions(rebateYear);
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { access, schema, submission } = query.data ?? {};
 
-  const comboKey = submission?.data.bap_hidden_entity_combo_key || "";
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKey = submission?.data?.[comboKeyFieldName] || "";
 
   const pdfQuery = useSubmissionPDFQuery({
-    rebateYear: "2022",
+    rebateYear,
     formType: "frf",
     mongoId,
   });
@@ -185,7 +189,8 @@ function FundingRequestForm(props: { email: string }) {
         bap: rebate.frf.bap,
       });
 
-  const frfSubmissionPeriodOpen = configData.submissionPeriodOpen["2022"].frf;
+  const frfSubmissionPeriodOpen =
+    configData.submissionPeriodOpen[rebateYear].frf;
 
   const formIsReadOnly =
     (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
@@ -193,8 +198,7 @@ function FundingRequestForm(props: { email: string }) {
 
   /** matched SAM.gov entity for the Application submission */
   const entity = bapSamData.entities.find((entity) => {
-    const { ENTITY_COMBO_KEY__c } = entity;
-    return ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key;
+    return entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
   if (!entity) {
@@ -301,7 +305,7 @@ function FundingRequestForm(props: { email: string }) {
         postData(url, {
           mongoId: prf._id,
           rebateId: prf.data.hidden_bap_rebate_id,
-          comboKey: prf.data.bap_hidden_entity_combo_key,
+          comboKey: prf.data[comboKeyFieldName],
         })
           .then((_res) => {
             window.location.reload();

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -15,6 +15,7 @@ import {
 import { serverUrl, messages } from "@/config";
 import {
   getComboKeyFieldName,
+  getRebateIdFieldName,
   getData,
   postData,
   useContentData,
@@ -121,6 +122,7 @@ function FundingRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+  const rebateIdFieldName = getRebateIdFieldName(rebateYear);
 
   const frfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
@@ -271,6 +273,7 @@ function FundingRequestForm(props: { email: string }) {
         const prf = rebate.prf.formio;
 
         const prfComboKey = String(prf?.data?.[comboKeyFieldName] ?? "");
+        const prfRebateId = String(prf?.data?.[rebateIdFieldName] ?? "");
 
         if (!prf) {
           displayErrorNotification({
@@ -309,7 +312,7 @@ function FundingRequestForm(props: { email: string }) {
 
         postData(url, {
           mongoId: prf._id,
-          rebateId: prf.data.hidden_bap_rebate_id,
+          rebateId: prfRebateId,
           comboKey: prfComboKey,
         })
           .then((_res) => {

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -121,7 +121,7 @@ function FundingRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
+  const frfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear,
@@ -196,9 +196,11 @@ function FundingRequestForm(props: { email: string }) {
     (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
     !frfNeedsEdits;
 
-  /** matched SAM.gov entity for the Application submission */
+  /**
+   * Matched SAM.gov entity for the FRF submission.
+   */
   const entity = bapSamData.entities.find((entity) => {
-    return entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entity.ENTITY_COMBO_KEY__c === frfComboKey;
   });
 
   if (!entity) {
@@ -266,6 +268,7 @@ function FundingRequestForm(props: { email: string }) {
       confirmText: "Delete Payment Request Form Submission",
       confirmedAction: () => {
         const prf = rebate.prf.formio;
+        const prfComboKey = String(prf?.data?.[comboKeyFieldName] ?? "");
 
         if (!prf) {
           displayErrorNotification({
@@ -305,7 +308,7 @@ function FundingRequestForm(props: { email: string }) {
         postData(url, {
           mongoId: prf._id,
           rebateId: prf.data.hidden_bap_rebate_id,
-          comboKey: String(prf.data[comboKeyFieldName] ?? ""),
+          comboKey: prfComboKey,
         })
           .then((_res) => {
             window.location.reload();
@@ -429,7 +432,7 @@ function FundingRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={schema}
-          url={`${serverUrl}/api/formio/2022/s3/frf/${mongoId}/${comboKey}`}
+          url={`${serverUrl}/api/formio/2022/s3/frf/${mongoId}/${frfComboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -105,7 +105,7 @@ function FundingRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = submission?.data?.[comboKeyFieldName] || "";
+  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear,
@@ -289,7 +289,7 @@ function FundingRequestForm(props: { email: string }) {
         postData(url, {
           mongoId: prf._id,
           rebateId: prf.data._bap_rebate_id,
-          comboKey: prf.data[comboKeyFieldName],
+          comboKey: String(prf.data[comboKeyFieldName] ?? ""),
         })
           .then((_res) => {
             window.location.reload();

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -104,7 +104,8 @@ function FundingRequestForm(props: { email: string }) {
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { access, schema, submission } = query.data ?? {};
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const frfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
   const pdfQuery = useSubmissionPDFQuery({
@@ -252,6 +253,7 @@ function FundingRequestForm(props: { email: string }) {
       confirmText: "Delete Payment Request Form Submission",
       confirmedAction: () => {
         const prf = rebate.prf.formio;
+
         const prfComboKey = String(prf?.data?.[comboKeyFieldName] ?? "");
 
         if (!prf) {

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
+  getComboKeyFieldName,
   getData,
   postData,
   useContentData,
@@ -81,6 +82,8 @@ export function FRF2023() {
 function FundingRequestForm(props: { email: string }) {
   const { email } = props;
 
+  const rebateYear = "2023";
+
   const navigate = useNavigate();
   const { id: mongoId } = useParams<"id">(); // MongoDB ObjectId string
 
@@ -95,16 +98,17 @@ function FundingRequestForm(props: { email: string }) {
     dismissNotification,
   } = useNotificationsActions();
 
-  const submissionsQueries = useSubmissionsQueries("2023");
-  const submissions = useSubmissions("2023");
+  const submissionsQueries = useSubmissionsQueries(rebateYear);
+  const submissions = useSubmissions(rebateYear);
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { access, schema, submission } = query.data ?? {};
 
-  const comboKey = submission?.data._bap_entity_combo_key || "";
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKey = submission?.data?.[comboKeyFieldName] || "";
 
   const pdfQuery = useSubmissionPDFQuery({
-    rebateYear: "2023",
+    rebateYear,
     formType: "frf",
     mongoId,
   });
@@ -169,7 +173,8 @@ function FundingRequestForm(props: { email: string }) {
         bap: rebate.frf.bap,
       });
 
-  const frfSubmissionPeriodOpen = configData.submissionPeriodOpen["2023"].frf;
+  const frfSubmissionPeriodOpen =
+    configData.submissionPeriodOpen[rebateYear].frf;
 
   const formIsReadOnly =
     (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
@@ -177,8 +182,7 @@ function FundingRequestForm(props: { email: string }) {
 
   /** matched SAM.gov entity for the Application submission */
   const entity = bapSamData.entities.find((entity) => {
-    const { ENTITY_COMBO_KEY__c } = entity;
-    return ENTITY_COMBO_KEY__c === submission.data._bap_entity_combo_key;
+    return entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
   if (!entity) {
@@ -285,7 +289,7 @@ function FundingRequestForm(props: { email: string }) {
         postData(url, {
           mongoId: prf._id,
           rebateId: prf.data._bap_rebate_id,
-          comboKey: prf.data._bap_entity_combo_key,
+          comboKey: prf.data[comboKeyFieldName],
         })
           .then((_res) => {
             window.location.reload();

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -105,7 +105,7 @@ function FundingRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
+  const frfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear,
@@ -180,9 +180,11 @@ function FundingRequestForm(props: { email: string }) {
     (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
     !frfNeedsEdits;
 
-  /** matched SAM.gov entity for the Application submission */
+  /**
+   * Matched SAM.gov entity for the FRF submission.
+   */
   const entity = bapSamData.entities.find((entity) => {
-    return entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entity.ENTITY_COMBO_KEY__c === frfComboKey;
   });
 
   if (!entity) {
@@ -250,6 +252,7 @@ function FundingRequestForm(props: { email: string }) {
       confirmText: "Delete Payment Request Form Submission",
       confirmedAction: () => {
         const prf = rebate.prf.formio;
+        const prfComboKey = String(prf?.data?.[comboKeyFieldName] ?? "");
 
         if (!prf) {
           displayErrorNotification({
@@ -289,7 +292,7 @@ function FundingRequestForm(props: { email: string }) {
         postData(url, {
           mongoId: prf._id,
           rebateId: prf.data._bap_rebate_id,
-          comboKey: String(prf.data[comboKeyFieldName] ?? ""),
+          comboKey: prfComboKey,
         })
           .then((_res) => {
             window.location.reload();
@@ -413,7 +416,7 @@ function FundingRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={schema}
-          url={`${serverUrl}/api/formio/2023/s3/frf/${mongoId}/${comboKey}`}
+          url={`${serverUrl}/api/formio/2023/s3/frf/${mongoId}/${frfComboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -14,6 +14,7 @@ import {
 import { serverUrl, messages } from "@/config";
 import {
   getComboKeyFieldName,
+  getRebateIdFieldName,
   getData,
   postData,
   useContentData,
@@ -105,6 +106,7 @@ function FundingRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+  const rebateIdFieldName = getRebateIdFieldName(rebateYear);
 
   const frfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
@@ -255,6 +257,7 @@ function FundingRequestForm(props: { email: string }) {
         const prf = rebate.prf.formio;
 
         const prfComboKey = String(prf?.data?.[comboKeyFieldName] ?? "");
+        const prfRebateId = String(prf?.data?.[rebateIdFieldName] ?? "");
 
         if (!prf) {
           displayErrorNotification({
@@ -293,7 +296,7 @@ function FundingRequestForm(props: { email: string }) {
 
         postData(url, {
           mongoId: prf._id,
-          rebateId: prf.data._bap_rebate_id,
+          rebateId: prfRebateId,
           comboKey: prfComboKey,
         })
           .then((_res) => {

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -105,7 +105,7 @@ function FundingRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
+  const frfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear,
@@ -180,9 +180,11 @@ function FundingRequestForm(props: { email: string }) {
     (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
     !frfNeedsEdits;
 
-  /** matched SAM.gov entity for the Application submission */
+  /**
+   * Matched SAM.gov entity for the FRF submission.
+   */
   const entity = bapSamData.entities.find((entity) => {
-    return entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entity.ENTITY_COMBO_KEY__c === frfComboKey;
   });
 
   if (!entity) {
@@ -250,6 +252,7 @@ function FundingRequestForm(props: { email: string }) {
       confirmText: "Delete Payment Request Form Submission",
       confirmedAction: () => {
         const prf = rebate.prf.formio;
+        const prfComboKey = String(prf?.data?.[comboKeyFieldName] ?? "");
 
         if (!prf) {
           displayErrorNotification({
@@ -289,7 +292,7 @@ function FundingRequestForm(props: { email: string }) {
         postData(url, {
           mongoId: prf._id,
           rebateId: prf.data._bap_rebate_id,
-          comboKey: String(prf[comboKeyFieldName] ?? ""),
+          comboKey: prfComboKey,
         })
           .then((_res) => {
             window.location.reload();
@@ -413,7 +416,7 @@ function FundingRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={schema}
-          url={`${serverUrl}/api/formio/2024/s3/frf/${mongoId}/${comboKey}`}
+          url={`${serverUrl}/api/formio/2024/s3/frf/${mongoId}/${frfComboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -105,7 +105,7 @@ function FundingRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = submission?.data?.[comboKeyFieldName] || "";
+  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
   const pdfQuery = useSubmissionPDFQuery({
     rebateYear,
@@ -289,7 +289,7 @@ function FundingRequestForm(props: { email: string }) {
         postData(url, {
           mongoId: prf._id,
           rebateId: prf.data._bap_rebate_id,
-          comboKey: prf[comboKeyFieldName],
+          comboKey: String(prf[comboKeyFieldName] ?? ""),
         })
           .then((_res) => {
             window.location.reload();

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
+  getComboKeyFieldName,
   getData,
   postData,
   useContentData,
@@ -81,6 +82,8 @@ export function FRF2024() {
 function FundingRequestForm(props: { email: string }) {
   const { email } = props;
 
+  const rebateYear = "2024";
+
   const navigate = useNavigate();
   const { id: mongoId } = useParams<"id">(); // MongoDB ObjectId string
 
@@ -95,16 +98,17 @@ function FundingRequestForm(props: { email: string }) {
     dismissNotification,
   } = useNotificationsActions();
 
-  const submissionsQueries = useSubmissionsQueries("2024");
-  const submissions = useSubmissions("2024");
+  const submissionsQueries = useSubmissionsQueries(rebateYear);
+  const submissions = useSubmissions(rebateYear);
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { access, schema, submission } = query.data ?? {};
 
-  const comboKey = submission?.data._bap_entity_combo_key || "";
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKey = submission?.data?.[comboKeyFieldName] || "";
 
   const pdfQuery = useSubmissionPDFQuery({
-    rebateYear: "2024",
+    rebateYear,
     formType: "frf",
     mongoId,
   });
@@ -169,7 +173,8 @@ function FundingRequestForm(props: { email: string }) {
         bap: rebate.frf.bap,
       });
 
-  const frfSubmissionPeriodOpen = configData.submissionPeriodOpen["2024"].frf;
+  const frfSubmissionPeriodOpen =
+    configData.submissionPeriodOpen[rebateYear].frf;
 
   const formIsReadOnly =
     (submission.state === "submitted" || !frfSubmissionPeriodOpen) &&
@@ -177,8 +182,7 @@ function FundingRequestForm(props: { email: string }) {
 
   /** matched SAM.gov entity for the Application submission */
   const entity = bapSamData.entities.find((entity) => {
-    const { ENTITY_COMBO_KEY__c } = entity;
-    return ENTITY_COMBO_KEY__c === submission.data._bap_entity_combo_key;
+    return entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
   if (!entity) {
@@ -285,7 +289,7 @@ function FundingRequestForm(props: { email: string }) {
         postData(url, {
           mongoId: prf._id,
           rebateId: prf.data._bap_rebate_id,
-          comboKey: prf.data._bap_entity_combo_key,
+          comboKey: prf[comboKeyFieldName],
         })
           .then((_res) => {
             window.location.reload();

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -104,7 +104,8 @@ function FundingRequestForm(props: { email: string }) {
   const { query, mutation } = useFormioSubmissionQueryAndMutation(mongoId);
   const { access, schema, submission } = query.data ?? {};
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const frfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
   const pdfQuery = useSubmissionPDFQuery({
@@ -252,6 +253,7 @@ function FundingRequestForm(props: { email: string }) {
       confirmText: "Delete Payment Request Form Submission",
       confirmedAction: () => {
         const prf = rebate.prf.formio;
+
         const prfComboKey = String(prf?.data?.[comboKeyFieldName] ?? "");
 
         if (!prf) {

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -14,6 +14,7 @@ import {
 import { serverUrl, messages } from "@/config";
 import {
   getComboKeyFieldName,
+  getRebateIdFieldName,
   getData,
   postData,
   useContentData,
@@ -105,6 +106,7 @@ function FundingRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+  const rebateIdFieldName = getRebateIdFieldName(rebateYear);
 
   const frfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
 
@@ -255,6 +257,7 @@ function FundingRequestForm(props: { email: string }) {
         const prf = rebate.prf.formio;
 
         const prfComboKey = String(prf?.data?.[comboKeyFieldName] ?? "");
+        const prfRebateId = String(prf?.data?.[rebateIdFieldName] ?? "");
 
         if (!prf) {
           displayErrorNotification({
@@ -293,7 +296,7 @@ function FundingRequestForm(props: { email: string }) {
 
         postData(url, {
           mongoId: prf._id,
-          rebateId: prf.data._bap_rebate_id,
+          rebateId: prfRebateId,
           comboKey: prfComboKey,
         })
           .then((_res) => {

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -250,7 +250,7 @@ function PaymentRequestForm(props: { email: string }) {
         </li>
       </ul>
 
-      {submission?._id && (
+      {mongoId && (
         <p>
           <button
             className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -105,7 +105,7 @@ function PaymentRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = submission?.data?.[comboKeyFieldName] || "";
+  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 
   const pdfQuery = useSubmissionPDFQuery({

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -105,7 +105,7 @@ function PaymentRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
+  const prfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 
   const pdfQuery = useSubmissionPDFQuery({
@@ -189,9 +189,11 @@ function PaymentRequestForm(props: { email: string }) {
     ((submission.state === "submitted" || !prfSubmissionPeriodOpen) &&
       !prfNeedsEdits);
 
-  /** matched SAM.gov entity for the Payment Request submission */
+  /**
+   * Matched SAM.gov entity for the PRF submission.
+   */
   const entity = bapSamData.entities.find((entity) => {
-    return entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entity.ENTITY_COMBO_KEY__c === prfComboKey;
   });
 
   if (!entity) {
@@ -298,7 +300,7 @@ function PaymentRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={schema}
-          url={`${serverUrl}/api/formio/2022/s3/prf/${mongoId}/${comboKey}`}
+          url={`${serverUrl}/api/formio/2022/s3/prf/${mongoId}/${prfComboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -104,7 +104,8 @@ function PaymentRequestForm(props: { email: string }) {
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { access, schema, submission } = query.data ?? {};
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const prfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
+  getComboKeyFieldName,
   getData,
   postData,
   useContentData,
@@ -83,6 +84,8 @@ export function PRF2022() {
 function PaymentRequestForm(props: { email: string }) {
   const { email } = props;
 
+  const rebateYear = "2022";
+
   const navigate = useNavigate();
   const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
 
@@ -95,19 +98,20 @@ function PaymentRequestForm(props: { email: string }) {
     dismissNotification,
   } = useNotificationsActions();
 
-  const submissionsQueries = useSubmissionsQueries("2022");
-  const submissions = useSubmissions("2022");
+  const submissionsQueries = useSubmissionsQueries(rebateYear);
+  const submissions = useSubmissions(rebateYear);
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { access, schema, submission } = query.data ?? {};
 
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKey = submission?.data?.[comboKeyFieldName] || "";
   const mongoId = submission?._id || "";
-  const comboKey = submission?.data.bap_hidden_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
-    rebateYear: "2022",
+    rebateYear,
     formType: "prf",
-    mongoId: submission?._id || "",
+    mongoId,
   });
 
   /**
@@ -177,7 +181,8 @@ function PaymentRequestForm(props: { email: string }) {
         bap: rebate.prf.bap,
       });
 
-  const prfSubmissionPeriodOpen = configData.submissionPeriodOpen["2022"].prf;
+  const prfSubmissionPeriodOpen =
+    configData.submissionPeriodOpen[rebateYear].prf;
 
   const formIsReadOnly =
     frfNeedsEdits ||
@@ -186,8 +191,7 @@ function PaymentRequestForm(props: { email: string }) {
 
   /** matched SAM.gov entity for the Payment Request submission */
   const entity = bapSamData.entities.find((entity) => {
-    const { ENTITY_COMBO_KEY__c } = entity;
-    return ENTITY_COMBO_KEY__c === submission.data.bap_hidden_entity_combo_key;
+    return entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
   if (!entity) {

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -248,7 +248,7 @@ function PaymentRequestForm(props: { email: string }) {
         </li>
       </ul>
 
-      {submission?._id && (
+      {mongoId && (
         <p>
           <button
             className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -105,7 +105,7 @@ function PaymentRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = submission?.data?.[comboKeyFieldName] || "";
+  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 
   const pdfQuery = useSubmissionPDFQuery({

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
+  getComboKeyFieldName,
   getData,
   postData,
   useContentData,
@@ -83,6 +84,8 @@ export function PRF2023() {
 function PaymentRequestForm(props: { email: string }) {
   const { email } = props;
 
+  const rebateYear = "2023";
+
   const navigate = useNavigate();
   const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
 
@@ -95,19 +98,20 @@ function PaymentRequestForm(props: { email: string }) {
     dismissNotification,
   } = useNotificationsActions();
 
-  const submissionsQueries = useSubmissionsQueries("2023");
-  const submissions = useSubmissions("2023");
+  const submissionsQueries = useSubmissionsQueries(rebateYear);
+  const submissions = useSubmissions(rebateYear);
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { access, schema, submission } = query.data ?? {};
 
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKey = submission?.data?.[comboKeyFieldName] || "";
   const mongoId = submission?._id || "";
-  const comboKey = submission?.data._bap_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
-    rebateYear: "2023",
+    rebateYear,
     formType: "prf",
-    mongoId: submission?._id || "",
+    mongoId,
   });
 
   /**
@@ -177,7 +181,8 @@ function PaymentRequestForm(props: { email: string }) {
         bap: rebate.prf.bap,
       });
 
-  const prfSubmissionPeriodOpen = configData.submissionPeriodOpen["2023"].prf;
+  const prfSubmissionPeriodOpen =
+    configData.submissionPeriodOpen[rebateYear].prf;
 
   const formIsReadOnly =
     frfNeedsEdits ||
@@ -186,8 +191,7 @@ function PaymentRequestForm(props: { email: string }) {
 
   /** matched SAM.gov entity for the Payment Request submission */
   const entity = bapSamData.entities.find((entity) => {
-    const { ENTITY_COMBO_KEY__c } = entity;
-    return ENTITY_COMBO_KEY__c === submission.data._bap_entity_combo_key;
+    return entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
   if (!entity) {

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -105,7 +105,7 @@ function PaymentRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
+  const prfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 
   const pdfQuery = useSubmissionPDFQuery({
@@ -189,9 +189,11 @@ function PaymentRequestForm(props: { email: string }) {
     ((submission.state === "submitted" || !prfSubmissionPeriodOpen) &&
       !prfNeedsEdits);
 
-  /** matched SAM.gov entity for the Payment Request submission */
+  /**
+   * Matched SAM.gov entity for the PRF submission.
+   */
   const entity = bapSamData.entities.find((entity) => {
-    return entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entity.ENTITY_COMBO_KEY__c === prfComboKey;
   });
 
   if (!entity) {
@@ -296,7 +298,7 @@ function PaymentRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={schema}
-          url={`${serverUrl}/api/formio/2023/s3/prf/${mongoId}/${comboKey}`}
+          url={`${serverUrl}/api/formio/2023/s3/prf/${mongoId}/${prfComboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -104,7 +104,8 @@ function PaymentRequestForm(props: { email: string }) {
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { access, schema, submission } = query.data ?? {};
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const prfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -248,7 +248,7 @@ function PaymentRequestForm(props: { email: string }) {
         </li>
       </ul>
 
-      {submission?._id && (
+      {mongoId && (
         <p>
           <button
             className="usa-button font-sans-2xs margin-right-0 padding-x-105 padding-y-1"

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -105,7 +105,7 @@ function PaymentRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = submission?.data?.[comboKeyFieldName] || "";
+  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 
   const pdfQuery = useSubmissionPDFQuery({

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -105,7 +105,7 @@ function PaymentRequestForm(props: { email: string }) {
   const { access, schema, submission } = query.data ?? {};
 
   const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
-  const comboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
+  const prfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 
   const pdfQuery = useSubmissionPDFQuery({
@@ -189,9 +189,11 @@ function PaymentRequestForm(props: { email: string }) {
     ((submission.state === "submitted" || !prfSubmissionPeriodOpen) &&
       !prfNeedsEdits);
 
-  /** matched SAM.gov entity for the Payment Request submission */
+  /**
+   * Matched SAM.gov entity for the PRF submission.
+   */
   const entity = bapSamData.entities.find((entity) => {
-    return entity.ENTITY_COMBO_KEY__c === comboKey;
+    return entity.ENTITY_COMBO_KEY__c === prfComboKey;
   });
 
   if (!entity) {
@@ -296,7 +298,7 @@ function PaymentRequestForm(props: { email: string }) {
       <div className="csb-form">
         <Form
           src={schema}
-          url={`${serverUrl}/api/formio/2024/s3/prf/${mongoId}/${comboKey}`}
+          url={`${serverUrl}/api/formio/2024/s3/prf/${mongoId}/${prfComboKey}`}
           submission={{
             /**
              * NOTE: The `csb-form-submission-state` metadata field's value is

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/types";
 import { serverUrl, messages } from "@/config";
 import {
+  getComboKeyFieldName,
   getData,
   postData,
   useContentData,
@@ -83,6 +84,8 @@ export function PRF2024() {
 function PaymentRequestForm(props: { email: string }) {
   const { email } = props;
 
+  const rebateYear = "2024";
+
   const navigate = useNavigate();
   const { id: rebateId } = useParams<"id">(); // CSB Rebate ID (6 digits)
 
@@ -95,19 +98,20 @@ function PaymentRequestForm(props: { email: string }) {
     dismissNotification,
   } = useNotificationsActions();
 
-  const submissionsQueries = useSubmissionsQueries("2024");
-  const submissions = useSubmissions("2024");
+  const submissionsQueries = useSubmissionsQueries(rebateYear);
+  const submissions = useSubmissions(rebateYear);
 
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { access, schema, submission } = query.data ?? {};
 
+  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKey = submission?.data?.[comboKeyFieldName] || "";
   const mongoId = submission?._id || "";
-  const comboKey = submission?.data._bap_entity_combo_key || "";
 
   const pdfQuery = useSubmissionPDFQuery({
-    rebateYear: "2024",
+    rebateYear,
     formType: "prf",
-    mongoId: submission?._id || "",
+    mongoId,
   });
 
   /**
@@ -177,7 +181,8 @@ function PaymentRequestForm(props: { email: string }) {
         bap: rebate.prf.bap,
       });
 
-  const prfSubmissionPeriodOpen = configData.submissionPeriodOpen["2024"].prf;
+  const prfSubmissionPeriodOpen =
+    configData.submissionPeriodOpen[rebateYear].prf;
 
   const formIsReadOnly =
     frfNeedsEdits ||
@@ -186,8 +191,7 @@ function PaymentRequestForm(props: { email: string }) {
 
   /** matched SAM.gov entity for the Payment Request submission */
   const entity = bapSamData.entities.find((entity) => {
-    const { ENTITY_COMBO_KEY__c } = entity;
-    return ENTITY_COMBO_KEY__c === submission.data._bap_entity_combo_key;
+    return entity.ENTITY_COMBO_KEY__c === comboKey;
   });
 
   if (!entity) {

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -104,7 +104,8 @@ function PaymentRequestForm(props: { email: string }) {
   const { query, mutation } = useFormioSubmissionQueryAndMutation(rebateId);
   const { access, schema, submission } = query.data ?? {};
 
-  const comboKeyFieldName = getComboKeyFieldName({ rebateYear });
+  const comboKeyFieldName = getComboKeyFieldName(rebateYear);
+
   const prfComboKey = String(submission?.data?.[comboKeyFieldName] ?? "");
   const mongoId = submission?._id || "";
 

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -69,11 +69,7 @@ type RebateByYear<Year> =
   Year extends "2024" ? Rebate2024 :
   never;
 
-export function getComboKeyFieldName({
-  rebateYear,
-}: {
-  rebateYear: RebateYear;
-}) {
+export function getComboKeyFieldName(rebateYear: RebateYear) {
   return rebateYear === "2022"
     ? "bap_hidden_entity_combo_key"
     : rebateYear === "2023"
@@ -83,11 +79,7 @@ export function getComboKeyFieldName({
         : "";
 }
 
-export function getRebateIdFieldName({
-  rebateYear,
-}: {
-  rebateYear: RebateYear;
-}) {
+export function getRebateIdFieldName(rebateYear: RebateYear) {
   return rebateYear === "2022"
     ? "hidden_bap_rebate_id"
     : rebateYear === "2023"

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -69,24 +69,30 @@ type RebateByYear<Year> =
   Year extends "2024" ? Rebate2024 :
   never;
 
-export function getComboKeyFieldName(rebateYear: RebateYear) {
-  return rebateYear === "2022"
-    ? "bap_hidden_entity_combo_key"
-    : rebateYear === "2023"
-      ? "_bap_entity_combo_key"
-      : rebateYear === "2024"
-        ? "_bap_entity_combo_key"
-        : "";
+/** Formio SAM.gov entity combo key field name by rebate year. */
+const comboKeyFieldNamesByYear = {
+  "2022": "bap_hidden_entity_combo_key",
+  "2023": "_bap_entity_combo_key",
+  "2024": "_bap_entity_combo_key",
+} as const;
+
+/** Formio CSB Rebate Id field name by rebate year. */
+const rebateIdFieldNamesByYear = {
+  "2022": "hidden_bap_rebate_id",
+  "2023": "_bap_rebate_id",
+  "2024": "_bap_rebate_id",
+} as const;
+
+export function getComboKeyFieldName<
+  Year extends keyof typeof comboKeyFieldNamesByYear,
+>(rebateYear: Year): (typeof comboKeyFieldNamesByYear)[Year] {
+  return comboKeyFieldNamesByYear[rebateYear];
 }
 
-export function getRebateIdFieldName(rebateYear: RebateYear) {
-  return rebateYear === "2022"
-    ? "hidden_bap_rebate_id"
-    : rebateYear === "2023"
-      ? "_bap_rebate_id"
-      : rebateYear === "2024"
-        ? "_bap_rebate_id"
-        : "";
+export function getRebateIdFieldName<
+  Year extends keyof typeof rebateIdFieldNamesByYear,
+>(rebateYear: Year): (typeof rebateIdFieldNamesByYear)[Year] {
+  return rebateIdFieldNamesByYear[rebateYear];
 }
 
 async function fetchData<T = unknown>(url: string, options: RequestInit) {

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -69,6 +69,34 @@ type RebateByYear<Year> =
   Year extends "2024" ? Rebate2024 :
   never;
 
+export function getComboKeyFieldName({
+  rebateYear,
+}: {
+  rebateYear: RebateYear;
+}) {
+  return rebateYear === "2022"
+    ? "bap_hidden_entity_combo_key"
+    : rebateYear === "2023"
+      ? "_bap_entity_combo_key"
+      : rebateYear === "2024"
+        ? "_bap_entity_combo_key"
+        : "";
+}
+
+export function getRebateIdFieldName({
+  rebateYear,
+}: {
+  rebateYear: RebateYear;
+}) {
+  return rebateYear === "2022"
+    ? "hidden_bap_rebate_id"
+    : rebateYear === "2023"
+      ? "_bap_rebate_id"
+      : rebateYear === "2024"
+        ? "_bap_rebate_id"
+        : "";
+}
+
 async function fetchData<T = unknown>(url: string, options: RequestInit) {
   try {
     const response = await fetch(url, options);


### PR DESCRIPTION
## Related Issues:
* CSBAPP-608

## Main Changes:
Updates the use of getting and using combo key and rebate id fields and values across all forms. This should result in no functional change, but the code should be easier to reason about, due to more explicit naming of variables and narrowing of the fields themselves via the TypeScript logic.

More documentation is also provided in certain places – for example, in the `PRF2022Submission` component used in the `Dashboard` component, an explanation is provided on why the FRF submission's combo key value is used in matching the SAM.gov entity instead of the PRF's combo key value (answer: because the PRF might not have been created yet).

## Steps To Test:
1. Navigate to the dashboard.
2. Interact with the app (visit all form submissions).
3. All should function normally.
