### PR TITLE
Feature/update 2023 crf data query

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -543,6 +543,7 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  Bus_Shipping_Costs__c: number | null
  *  Eligible_ADA_Compliance_Rebate__c: number | null
  *  Eligible_Bus_Shipping_Rebate__c: number | null
+ *  New_Bus_Dealer__c: string | null
  *  New_Bus_Owner_Contact_ID__c: string | null
  *  Old_Bus_Owner_Contact_ID__c: string | null
  * }[]} prf2023BusRecordsQuery
@@ -2297,6 +2298,7 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
   //   Bus_Shipping_Costs__c,
   //   Eligible_ADA_Compliance_Rebate__c,
   //   Eligible_Bus_Shipping_Rebate__c,
+  //   New_Bus_Dealer__c,
   //   New_Bus_Owner_Contact_ID__c,
   //   Old_Bus_Owner_Contact_ID__c
   // FROM
@@ -2348,6 +2350,7 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
         Bus_Shipping_Costs__c: 1,
         Eligible_ADA_Compliance_Rebate__c: 1,
         Eligible_Bus_Shipping_Rebate__c: 1,
+        New_Bus_Dealer__c: 1,
         New_Bus_Owner_Contact_ID__c: 1,
         Old_Bus_Owner_Contact_ID__c: 1,
       },
@@ -2417,9 +2420,10 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
     .execute(async (err, records) => ((await err) ? err : records));
 
   const contactIdFields = [
-    "Infrastructure_Owner_Contact_ID__c",
+    "New_Bus_Dealer__c",
     "New_Bus_Owner_Contact_ID__c",
     "Old_Bus_Owner_Contact_ID__c",
+    "Infrastructure_Owner_Contact_ID__c",
   ];
 
   // Unique contact IDs from both bus and infrastructure records


### PR DESCRIPTION
## Related Issues:
* CSBAPP-614

## Main Changes:
Update BAP query for 2023 CRF data (`queryBapFor2023CRFData`) to fetch the 'New Bus Dealer' contact id (in addition to the "New Bus Owner" and 'Old Bus Owner' contact ids)

## Steps To Test:
1. Navigate to the dashboard.
2. Ensure you have a 2023 PRF submission with an organization that's been tagged as a "New Bus Dealer".
3. In that same PRF, ensure you add a bus and use the org as the "New Bus Dealer" and importantly, not as the "Existing Bus Owner" or "New Bus Owner" (those can be the primary applicant and/or the school district).
4. After the PRF has been accepted in the BAP, create a new CRF and ensure the organization is included in the new 2023 CRF. With this change it now should be. Previously it wouldn't have been as the org wasn't used as the "New Bus Owner" or "Existing Bus Owner" for any of the buses.
