### PR TITLE
Feature/add school district info lookup

### DIFF
--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -8,6 +8,7 @@ const {
 const {
   checkVIN,
   searchNcesData,
+  getRebateSchoolDistrictInfo,
   getRebateContacts,
   //
   downloadFileFromS3,
@@ -51,6 +52,11 @@ router.get("/check-vin{/:vin}", (req, res) => {
 // --- search 2023 NCES data with the provided NCES ID and return a match
 router.get("/nces{/:searchText}", (req, res) => {
   searchNcesData({ rebateYear, req, res });
+});
+
+// --- get the school district info associated with a provided CSB Rebate ID
+router.get("/district/:formType{/:rebateId}", (req, res) => {
+  getRebateSchoolDistrictInfo({ rebateYear, req, res });
 });
 
 // --- get contacts associated with a provided CSB Rebate ID

--- a/app/server/app/routes/formio2024.js
+++ b/app/server/app/routes/formio2024.js
@@ -7,6 +7,7 @@ const {
 } = require("../middleware");
 const {
   searchNcesData,
+  getRebateSchoolDistrictInfo,
   //
   downloadFileFromS3,
   uploadFileToS3,
@@ -44,6 +45,11 @@ router.use(ensureAuthenticated);
 // --- search 2024 NCES data with the provided NCES ID and return a match
 router.get("/nces{/:searchText}", (req, res) => {
   searchNcesData({ rebateYear, req, res });
+});
+
+// --- get the school district info associated with a provided CSB Rebate ID
+router.get("/district/:formType{/:rebateId}", (req, res) => {
+  getRebateSchoolDistrictInfo({ rebateYear, req, res });
 });
 
 // --- download Formio file attachment from S3

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -594,6 +594,33 @@ const { submissionPeriodOpen } = require("../config/formio");
 
 /**
  * @typedef {{
+ *  attributes: { type: "Order_Request__c", url: string }
+ *  Id: string
+ *  CSB_NCES_ID__c: string
+ *  CSB_School_District__r: {
+ *    attributes: { type: "Account", url: string }
+ *    Id: string
+ *    Name: string
+ *    BillingStreet: string
+ *    BillingCity: string
+ *    BillingState: string
+ *    BillingPostalCode: string
+ *  }
+ *  School_District_Contact__r: {
+ *    attributes: { type: "Contact", url: string }
+ *    Id: string
+ *    Record_Type_Name__c: string
+ *    FirstName: string
+ *    LastName: string
+ *    Title: string
+ *    Email: string
+ *    Phone: string
+ *  }
+ * }} CSBRebateSchoolDistrictInfo
+ */
+
+/**
+ * @typedef {{
  *  rebateId: string
  *  rolesApplied: string[]
  *  count: number
@@ -657,6 +684,66 @@ const {
   BAP_USER,
   BAP_PASSWORD,
 } = process.env;
+
+/**
+ * Get 'DeveloperName' field value for use in BAP queries, based on rebate year
+ * and form type.
+ *
+ * @param {Object} param
+ * @param {RebateYear} param.rebateYear
+ * @param {FormType} param.formType
+ */
+function getDeveloperNameField({ rebateYear, formType }) {
+  const developerNameField = {
+    2022: {
+      frf: "CSB_Funding_Request",
+      prf: "CSB_Payment_Request",
+      crf: "CSB_Closeout_Request",
+    },
+    2023: {
+      frf: "CSB_Funding_Request_2023",
+      prf: "CSB_Payment_Request_2023",
+      crf: "CSB_Closeout_Request_2023",
+    },
+    2024: {
+      frf: "CSB_Funding_Request_2024",
+      prf: "CSB_Payment_Request_2024",
+      crf: "CSB_Closeout_Request_2024",
+    },
+  };
+
+  return developerNameField[rebateYear][formType];
+}
+
+/**
+ * Get 'Record_Type_Name__c' field value for use in BAP queries, based on rebate
+ * year and form type.
+ *
+ * @param {Object} param
+ * @param {RebateYear} param.rebateYear
+ * @param {FormType} param.formType
+ */
+function getRecordTypeNameField({ rebateYear, formType }) {
+  const recordTypeNameField = {
+    2022: {
+      frf: "CSB Funding Request",
+      prf: "CSB Payment Request",
+      crf: "CSB Close Out Request",
+    },
+    2023: {
+      frf: "CSB Funding Request 2023",
+      prf: "CSB Payment Request 2023",
+      crf: "CSB Close Out Request 2023",
+    },
+    2024: {
+      frf: "CSB Funding Request 2024",
+      prf: "CSB Payment Request 2024",
+      crf: "CSB Close Out Request 2024",
+    },
+  };
+
+  return recordTypeNameField[rebateYear][formType];
+}
 
 /**
  * Sets up the BAP connection and stores it in the Express app's locals object.
@@ -812,25 +899,7 @@ async function queryForBapFormSubmissionData(
   /** @type {{ bapConnection: jsforce.Connection }} */
   const { bapConnection } = req.app.locals;
 
-  const developerNameField = {
-    2022: {
-      frf: "CSB_Funding_Request",
-      prf: "CSB_Payment_Request",
-      crf: "CSB_Closeout_Request",
-    },
-    2023: {
-      frf: "CSB_Funding_Request_2023",
-      prf: "CSB_Payment_Request_2023",
-      crf: "CSB_Closeout_Request_2023",
-    },
-    2024: {
-      frf: "CSB_Funding_Request_2024",
-      prf: "CSB_Payment_Request_2024",
-      crf: "CSB_Closeout_Request_2024",
-    },
-  };
-
-  const developerName = developerNameField[rebateYear][formType];
+  const developerName = getDeveloperNameField({ rebateYear, formType });
 
   if (!developerName) return null;
 
@@ -2498,15 +2567,101 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
 }
 
 /**
+ * Uses cached JSforce connection to query the BAP for school district info
+ * associated with a rebate year, form type, and CSB Rebate ID.
+ *
+ * @param {express.Request} req
+ * @param {RebateYear} rebateYear
+ * @param {FormType} formType
+ * @param {string} rebateId
+ * @returns {Promise<CSBRebateSchoolDistrictInfo>}
+ */
+async function queryForCSBRebateSchoolDistrictInfo(
+  req,
+  rebateYear,
+  formType,
+  rebateId,
+) {
+  const logMessage =
+    `Querying the BAP for school district info associated with ` +
+    `${rebateYear} ${formType.toUpperCase()} submission with ` +
+    `CSB Rebate ID: '${rebateId}'.`;
+  log({ level: "info", message: logMessage, req });
+
+  /** @type {{ bapConnection: jsforce.Connection }} */
+  const { bapConnection } = req.app.locals;
+
+  const recordTypeName = getRecordTypeNameField({ rebateYear, formType });
+
+  if (!recordTypeName) return null;
+
+  // `SELECT
+  //   Id,
+  //   CSB_NCES_ID__c,
+  //   CSB_School_District__r.Id,
+  //   CSB_School_District__r.Name,
+  //   CSB_School_District__r.BillingStreet,
+  //   CSB_School_District__r.BillingCity,
+  //   CSB_School_District__r.BillingState,
+  //   CSB_School_District__r.BillingPostalCode,
+  //   School_District_Contact__r.Id,
+  //   School_District_Contact__r.Record_Type_Name__c,
+  //   School_District_Contact__r.FirstName,
+  //   School_District_Contact__r.LastName,
+  //   School_District_Contact__r.Title,
+  //   School_District_Contact__r.Email,
+  //   School_District_Contact__r.Phone,
+  // FROM
+  //   Order_Request__c
+  // WHERE
+  //   Record_Type_Name__c = '${recordTypeName}' AND
+  //   Parent_Rebate_ID__c = '${rebateId}' AND
+  //   Latest_Version__c = TRUE`
+
+  const schoolDistrictInfoQuery = await bapConnection
+    .sobject("Order_Request__c")
+    .find(
+      {
+        Record_Type_Name__c: recordTypeName,
+        Parent_Rebate_ID__c: rebateId,
+        Latest_Version__c: true,
+      },
+      {
+        // "*": 1,
+        Id: 1, // Salesforce record ID
+        CSB_NCES_ID__c: 1,
+        "CSB_School_District__r.Id": 1,
+        "CSB_School_District__r.Name": 1,
+        "CSB_School_District__r.BillingStreet": 1,
+        "CSB_School_District__r.BillingCity": 1,
+        "CSB_School_District__r.BillingState": 1,
+        "CSB_School_District__r.BillingPostalCode": 1,
+        "School_District_Contact__r.Id": 1,
+        "School_District_Contact__r.Record_Type_Name__c": 1,
+        "School_District_Contact__r.FirstName": 1,
+        "School_District_Contact__r.LastName": 1,
+        "School_District_Contact__r.Title": 1,
+        "School_District_Contact__r.Phone": 1,
+        "School_District_Contact__r.Email": 1,
+      },
+    )
+    .execute(async (err, records) => ((await err) ? err : records));
+
+  return schoolDistrictInfoQuery?.[0] || {};
+}
+
+/**
  * Uses cached JSforce connection to query the BAP for contacts associated with
  * a CSB Rebate ID.
  *
  * @param {express.Request} req
- * @param {string} rebateId CSB Rebate ID
+ * @param {string} rebateId
  * @returns {Promise<CSBRebateContacts>}
  */
 async function queryForCSBRebateContacts(req, rebateId) {
-  const logMessage = `Querying the BAP for contacts associated with CSB Rebate ID: '${rebateId}'.`;
+  const logMessage =
+    `Querying the BAP for contacts associated with ` +
+    `CSB Rebate ID: '${rebateId}'.`;
   log({ level: "info", message: logMessage, req });
 
   /** @type {{ bapConnection: jsforce.Connection }} */
@@ -2743,6 +2898,29 @@ function getBapDataFor2023CRF(req, prfReviewItemId) {
 }
 
 /**
+ * Fetches school district info associated with a provided a rebate year, form
+ * type, and CSB Rebate ID.
+ *
+ * @param {Object} param
+ * @param {RebateYear} param.rebateYear
+ * @param {FormType} param.formType
+ * @param {string} param.rebateId
+ * @param {express.Request} param.req
+ * @returns {ReturnType<queryForCSBRebateSchoolDistrictInfo>}
+ */
+function getCSBRebateSchoolDistrictInfo({
+  rebateYear,
+  formType,
+  rebateId,
+  req,
+}) {
+  return verifyBapConnection(req, {
+    name: queryForCSBRebateSchoolDistrictInfo,
+    args: [req, rebateYear, formType, rebateId],
+  });
+}
+
+/**
  * Fetches contacts associated with a provided CSB Rebate ID.
  *
  * @param {express.Request} req
@@ -2840,6 +3018,7 @@ module.exports = {
   getBapDataFor2024PRF,
   getBapDataFor2022CRF,
   getBapDataFor2023CRF,
+  getCSBRebateSchoolDistrictInfo,
   getCSBRebateContacts,
   checkForBapDuplicates,
   checkForVinDuplicates,

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -20,6 +20,7 @@ const {
   getBapDataFor2024PRF,
   getBapDataFor2022CRF,
   getBapDataFor2023CRF,
+  getCSBRebateSchoolDistrictInfo,
   getCSBRebateContacts,
   checkForVinDuplicates,
   checkFormSubmissionPeriodAndBapStatus,
@@ -31,6 +32,10 @@ const { NODE_ENV } = process.env;
 
 /**
  * @typedef {'2022' | '2023' | '2024'} RebateYear
+ */
+
+/**
+ * @typedef {'frf' | 'prf' | 'crf'} FormType
  */
 
 /**
@@ -255,6 +260,51 @@ function searchNcesData({ rebateYear, req, res }) {
   log({ level: "info", message: logMessage, req });
 
   return res.json({ ...result });
+}
+
+/**
+ * @param {Object} param
+ * @param {RebateYear} param.rebateYear
+ * @param {express.Request} param.req
+ * @param {express.Response} param.res
+ */
+function getRebateSchoolDistrictInfo({ rebateYear, req, res }) {
+  const { formType, rebateId } = req.params;
+
+  // NOTE: included to support EPA API scan
+  if (rebateId === formioExampleRebateId) {
+    return res.json({});
+  }
+
+  if (!rebateId) {
+    const logMessage = `No Rebate ID passed to CSB Rebate School District info lookup.`;
+    log({ level: "info", message: logMessage, req });
+
+    return res.json({});
+  }
+
+  if (rebateId.length !== 6) {
+    const logMessage = `Invalid Rebate ID '${rebateId}' passed to CSB Rebate School District info lookup.`;
+    log({ level: "info", message: logMessage, req });
+
+    return res.json({});
+  }
+
+  return getCSBRebateSchoolDistrictInfo({
+    rebateYear,
+    formType,
+    rebateId,
+    req,
+  })
+    .then((json) => {
+      res.json(json);
+    })
+    .catch((_error) => {
+      // NOTE: logged in bap verifyBapConnection
+      const errorStatus = 500;
+      const errorMessage = `Error getting CSB Rebate School District Info from the BAP.`;
+      return res.status(errorStatus).json({ message: errorMessage });
+    });
 }
 
 /**
@@ -2995,6 +3045,7 @@ function fetchChangeRequest({ rebateYear, req, res }) {
 module.exports = {
   checkVIN,
   searchNcesData,
+  getRebateSchoolDistrictInfo,
   getRebateContacts,
   getRebateIdFieldName,
   //

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -860,19 +860,40 @@
         }
       }
     },
+    "/api/formio/2023/district/{formType}/{rebateId}": {
+      "get": {
+        "summary": "Get the school district info associated with a provided CSB Rebate ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/formType"
+          },
+          {
+            "$ref": "#/components/parameters/rebateId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An object containing school district info associated with the CSB Rebate ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
     "/api/formio/2023/contacts/{rebateId}": {
       "get": {
         "summary": "Get contacts associated with a provided CSB Rebate ID",
         "parameters": [
           {
-            "in": "path",
-            "name": "rebateId",
-            "description": "The CSB Rebate ID",
-            "required": true,
-            "example": "000000",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/rebateId"
           }
         ],
         "responses": {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-616

## Main Changes:
Add wrapper app endpoint for fetching school district info from the BAP when provided the rebate year, form type, and CSB Rebate Id.

## Steps To Test:
1. Run the app locally and test manually in Postman: `http://localhost:3000/api/formio/2023/district/frf/000000` (replace `000000` with a valid CSB Rebate Id for the environment you're testing, and `2023` and `frf` with whatever rebate year and form type you're testing.
2. Later (once the API lookup is integrated within the 2023 CRF), you'll be able to advance to the "School District Info" section/page of the 2023 CRF and see the request/response occur from the browser's dev tools network tab.
