### PR TITLE
Feature/optimize change request data fetching

### DIFF
--- a/app/client/src/components/change2022New.tsx
+++ b/app/client/src/components/change2022New.tsx
@@ -234,7 +234,13 @@ function ChangeRequest2022Form(props: {
     dismissNotification,
   } = useNotificationsActions();
 
-  const changeRequestsQuery = useChangeRequestsQuery("2022", false);
+  const changeRequestsQuery = useChangeRequestsQuery({
+    rebateYear: "2022",
+    enabled: false,
+  });
+
+  const { query } = useFormioSchemaQuery();
+  const { mutation } = useFormioSubmissionMutation();
 
   const schema = query.data;
 

--- a/app/client/src/components/change2022New.tsx
+++ b/app/client/src/components/change2022New.tsx
@@ -234,10 +234,7 @@ function ChangeRequest2022Form(props: {
     dismissNotification,
   } = useNotificationsActions();
 
-  const changeRequestsQuery = useChangeRequestsQuery("2022");
-
-  const { query } = useFormioSchemaQuery();
-  const { mutation } = useFormioSubmissionMutation();
+  const changeRequestsQuery = useChangeRequestsQuery("2022", false);
 
   const schema = query.data;
 

--- a/app/client/src/components/change2022New.tsx
+++ b/app/client/src/components/change2022New.tsx
@@ -35,24 +35,15 @@ type SubmissionData = {
   districtState: string;
 };
 
-type Response = FormType;
-
-/** Custom hook to fetch Formio schema */
-function useFormioSchemaQuery() {
+/** Custom hook to fetch Formio schema and update Formio submission data */
+function useFormioSchemaQueryAndSubmissionMutation() {
   const url = `${serverUrl}/api/formio/2022/change`;
 
   const query = useQuery({
     queryKey: ["formio/2022/change"],
-    queryFn: () => getData<Response>(url),
+    queryFn: () => getData<FormType>(url),
     refetchOnWindowFocus: false,
   });
-
-  return { query };
-}
-
-/** Custom hook to update Formio submission submission data */
-function useFormioSubmissionMutation() {
-  const url = `${serverUrl}/api/formio/2022/change/`;
 
   const mutation = useMutation({
     mutationFn: (submission: Submission) => {
@@ -60,7 +51,7 @@ function useFormioSubmissionMutation() {
     },
   });
 
-  return { mutation };
+  return { query, mutation };
 }
 
 export function ChangeRequest2022Button(props: {
@@ -239,8 +230,7 @@ function ChangeRequest2022Form(props: {
     enabled: false,
   });
 
-  const { query } = useFormioSchemaQuery();
-  const { mutation } = useFormioSubmissionMutation();
+  const { query, mutation } = useFormioSchemaQueryAndSubmissionMutation();
 
   const schema = query.data;
 

--- a/app/client/src/components/change2023New.tsx
+++ b/app/client/src/components/change2023New.tsx
@@ -234,7 +234,7 @@ function ChangeRequest2023Form(props: {
     dismissNotification,
   } = useNotificationsActions();
 
-  const changeRequestsQuery = useChangeRequestsQuery("2023");
+  const changeRequestsQuery = useChangeRequestsQuery("2023", false);
 
   const { query } = useFormioSchemaQuery();
   const { mutation } = useFormioSubmissionMutation();

--- a/app/client/src/components/change2023New.tsx
+++ b/app/client/src/components/change2023New.tsx
@@ -35,24 +35,15 @@ type SubmissionData = {
   districtState: string;
 };
 
-type Response = FormType;
-
-/** Custom hook to fetch Formio schema */
-function useFormioSchemaQuery() {
+/** Custom hook to fetch Formio schema and update Formio submission data */
+function useFormioSchemaQueryAndSubmissionMutation() {
   const url = `${serverUrl}/api/formio/2023/change`;
 
   const query = useQuery({
     queryKey: ["formio/2023/change"],
-    queryFn: () => getData<Response>(url),
+    queryFn: () => getData<FormType>(url),
     refetchOnWindowFocus: false,
   });
-
-  return { query };
-}
-
-/** Custom hook to update Formio submission submission data */
-function useFormioSubmissionMutation() {
-  const url = `${serverUrl}/api/formio/2023/change/`;
 
   const mutation = useMutation({
     mutationFn: (submission: Submission) => {
@@ -60,7 +51,7 @@ function useFormioSubmissionMutation() {
     },
   });
 
-  return { mutation };
+  return { query, mutation };
 }
 
 export function ChangeRequest2023Button(props: {
@@ -239,8 +230,7 @@ function ChangeRequest2023Form(props: {
     enabled: false,
   });
 
-  const { query } = useFormioSchemaQuery();
-  const { mutation } = useFormioSubmissionMutation();
+  const { query, mutation } = useFormioSchemaQueryAndSubmissionMutation();
 
   const schema = query.data;
 

--- a/app/client/src/components/change2023New.tsx
+++ b/app/client/src/components/change2023New.tsx
@@ -234,7 +234,10 @@ function ChangeRequest2023Form(props: {
     dismissNotification,
   } = useNotificationsActions();
 
-  const changeRequestsQuery = useChangeRequestsQuery("2023", false);
+  const changeRequestsQuery = useChangeRequestsQuery({
+    rebateYear: "2023",
+    enabled: false,
+  });
 
   const { query } = useFormioSchemaQuery();
   const { mutation } = useFormioSubmissionMutation();

--- a/app/client/src/components/change2024New.tsx
+++ b/app/client/src/components/change2024New.tsx
@@ -234,7 +234,10 @@ function ChangeRequest2024Form(props: {
     dismissNotification,
   } = useNotificationsActions();
 
-  const changeRequestsQuery = useChangeRequestsQuery("2024", false);
+  const changeRequestsQuery = useChangeRequestsQuery({
+    rebateYear: "2024",
+    enabled: false,
+  });
 
   const { query } = useFormioSchemaQuery();
   const { mutation } = useFormioSubmissionMutation();

--- a/app/client/src/components/change2024New.tsx
+++ b/app/client/src/components/change2024New.tsx
@@ -234,7 +234,7 @@ function ChangeRequest2024Form(props: {
     dismissNotification,
   } = useNotificationsActions();
 
-  const changeRequestsQuery = useChangeRequestsQuery("2024");
+  const changeRequestsQuery = useChangeRequestsQuery("2024", false);
 
   const { query } = useFormioSchemaQuery();
   const { mutation } = useFormioSubmissionMutation();

--- a/app/client/src/components/change2024New.tsx
+++ b/app/client/src/components/change2024New.tsx
@@ -35,24 +35,15 @@ type SubmissionData = {
   districtState: string;
 };
 
-type Response = FormType;
-
-/** Custom hook to fetch Formio schema */
-function useFormioSchemaQuery() {
+/** Custom hook to fetch Formio schema and update Formio submission data */
+function useFormioSchemaQueryAndSubmissionMutation() {
   const url = `${serverUrl}/api/formio/2024/change`;
 
   const query = useQuery({
     queryKey: ["formio/2024/change"],
-    queryFn: () => getData<Response>(url),
+    queryFn: () => getData<FormType>(url),
     refetchOnWindowFocus: false,
   });
-
-  return { query };
-}
-
-/** Custom hook to update Formio submission submission data */
-function useFormioSubmissionMutation() {
-  const url = `${serverUrl}/api/formio/2024/change/`;
 
   const mutation = useMutation({
     mutationFn: (submission: Submission) => {
@@ -60,7 +51,7 @@ function useFormioSubmissionMutation() {
     },
   });
 
-  return { mutation };
+  return { query, mutation };
 }
 
 export function ChangeRequest2024Button(props: {
@@ -239,8 +230,7 @@ function ChangeRequest2024Form(props: {
     enabled: false,
   });
 
-  const { query } = useFormioSchemaQuery();
-  const { mutation } = useFormioSubmissionMutation();
+  const { query, mutation } = useFormioSchemaQueryAndSubmissionMutation();
 
   const schema = query.data;
 

--- a/app/client/src/routes/dashboard.tsx
+++ b/app/client/src/routes/dashboard.tsx
@@ -1060,7 +1060,7 @@ function Submissions2022() {
   const rebateYear = "2022";
 
   const content = useContentData();
-  const changeRequestsQuery = useChangeRequestsQuery(rebateYear);
+  const changeRequestsQuery = useChangeRequestsQuery({ rebateYear });
   const submissionsQueries = useSubmissionsQueries(rebateYear);
   const submissions = useSubmissions(rebateYear);
 
@@ -2008,7 +2008,7 @@ function Submissions2023() {
   const rebateYear = "2023";
 
   const content = useContentData();
-  const changeRequestsQuery = useChangeRequestsQuery(rebateYear);
+  const changeRequestsQuery = useChangeRequestsQuery({ rebateYear });
   const submissionsQueries = useSubmissionsQueries(rebateYear);
   const submissions = useSubmissions(rebateYear);
 
@@ -2692,7 +2692,7 @@ function Submissions2024() {
   const rebateYear = "2024";
 
   const content = useContentData();
-  const changeRequestsQuery = useChangeRequestsQuery(rebateYear);
+  const changeRequestsQuery = useChangeRequestsQuery({ rebateYear });
   const submissionsQueries = useSubmissionsQueries(rebateYear);
   const submissions = useSubmissions(rebateYear);
 

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -298,10 +298,13 @@ export function useSubmissionPDFQuery(options: {
 }
 
 /** Custom hook to fetch Change Request form submissions from Formio. */
-export function useChangeRequestsQuery<Year extends RebateYear>(
-  rebateYear: Year,
+export function useChangeRequestsQuery<Year extends RebateYear>({
+  rebateYear,
   enabled = true,
-): UseQueryResult<FormioChangeRequestsByYear<Year>> {
+}: {
+  rebateYear: Year;
+  enabled?: boolean;
+}): UseQueryResult<FormioChangeRequestsByYear<Year>> {
   const changeRequest2022Query = {
     queryKey: ["formio/2022/changes"],
     queryFn: () => {

--- a/app/client/src/utilities.ts
+++ b/app/client/src/utilities.ts
@@ -300,6 +300,7 @@ export function useSubmissionPDFQuery(options: {
 /** Custom hook to fetch Change Request form submissions from Formio. */
 export function useChangeRequestsQuery<Year extends RebateYear>(
   rebateYear: Year,
+  enabled = true,
 ): UseQueryResult<FormioChangeRequestsByYear<Year>> {
   const changeRequest2022Query = {
     queryKey: ["formio/2022/changes"],
@@ -307,6 +308,7 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
       const url = `${serverUrl}/api/formio/2022/changes`;
       return getData<FormioChange2022DashboardSubmission[]>(url);
     },
+    enabled,
     refetchOnWindowFocus: false,
   };
 
@@ -316,6 +318,7 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
       const url = `${serverUrl}/api/formio/2023/changes`;
       return getData<FormioChange2023DashboardSubmission[]>(url);
     },
+    enabled,
     refetchOnWindowFocus: false,
   };
 
@@ -325,6 +328,7 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
       const url = `${serverUrl}/api/formio/2024/changes`;
       return getData<FormioChange2024DashboardSubmission[]>(url);
     },
+    enabled,
     refetchOnWindowFocus: false,
   };
 
@@ -332,6 +336,7 @@ export function useChangeRequestsQuery<Year extends RebateYear>(
   const changeRequestFallbackQuery = {
     queryKey: ["formio/changes"],
     queryFn: () => Promise.resolve([]),
+    enabled,
     refetchOnWindowFocus: false,
   };
 


### PR DESCRIPTION
## Related Issues:
* CSBAPP-608

## Main Changes:
Update change request forms to not fetch change request form submissions when a new change request form is initially created (but still fetch them after it's been submitted, so the new submission is displayed on the user's dashboard).

Also combines the change request form query and mutation custom hooks into a single hook that returns both (similar to what's done on the other Formio form pages).

## Steps To Test:
1. Navigate to the dashboard.
2. Open the network panel of the developer tools.
3. Click "Change" to begin a new change request form submission.
4. Ensure there isn't a request made to fetch the user's change request form submissions (/changes).
5. Submit the change request form.
6. Ensure the request is made to fetch the user's change request form submissions (/changes) and the new submission is shown in the user's dashboard.
