### PR TITLE
Feature/update school district query

### DIFF
--- a/app/server/app/routes/formio2022.js
+++ b/app/server/app/routes/formio2022.js
@@ -6,6 +6,8 @@ const {
   verifyMongoObjectId,
 } = require("../middleware");
 const {
+  getRebateSchoolDistrictInfo,
+  //
   downloadFileFromS3,
   uploadFileToS3,
   deleteFileFromS3,
@@ -38,6 +40,11 @@ const rebateYear = "2022";
 const router = express.Router();
 
 router.use(ensureAuthenticated);
+
+// --- get the school district info associated with a provided CSB Rebate ID
+router.get("/district{/:rebateId}", (req, res) => {
+  getRebateSchoolDistrictInfo({ rebateYear, req, res });
+});
 
 // --- download Formio file attachment from S3
 router.get(

--- a/app/server/app/routes/formio2023.js
+++ b/app/server/app/routes/formio2023.js
@@ -55,7 +55,7 @@ router.get("/nces{/:searchText}", (req, res) => {
 });
 
 // --- get the school district info associated with a provided CSB Rebate ID
-router.get("/district/:formType{/:rebateId}", (req, res) => {
+router.get("/district{/:rebateId}", (req, res) => {
   getRebateSchoolDistrictInfo({ rebateYear, req, res });
 });
 

--- a/app/server/app/routes/formio2024.js
+++ b/app/server/app/routes/formio2024.js
@@ -48,7 +48,7 @@ router.get("/nces{/:searchText}", (req, res) => {
 });
 
 // --- get the school district info associated with a provided CSB Rebate ID
-router.get("/district/:formType{/:rebateId}", (req, res) => {
+router.get("/district{/:rebateId}", (req, res) => {
   getRebateSchoolDistrictInfo({ rebateYear, req, res });
 });
 

--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -594,9 +594,10 @@ const { submissionPeriodOpen } = require("../config/formio");
 
 /**
  * @typedef {{
- *  attributes: { type: "Order_Request__c", url: string }
+ *  attributes: { type: "Application__c", url: string }
  *  Id: string
- *  CSB_School_District__r: {
+ *  CSB_School_District_ID_NCES__c: string
+ *  School_District__r: {
  *    attributes: { type: "Account", url: string }
  *    Id: string
  *    Name: string
@@ -605,22 +606,38 @@ const { submissionPeriodOpen } = require("../config/formio");
  *    BillingState: string
  *    BillingPostalCode: string
  *  }
- *  School_District_Contact__r: {
- *    attributes: { type: "Contact", url: string }
- *    Id: string
- *    Record_Type_Name__c: string
- *    FirstName: string
- *    LastName: string
- *    Title: string
- *    Email: string
- *    Phone: string
+ *  Object_Item_Contacts__r: {
+ *    totalSize: 1
+ *    done: true
+ *    records: {
+ *      attributes: { type: "Application_Contact__c", url: string }
+ *      Id: string
+ *      Name: string
+ *      Contact__r: {
+ *        attributes: { type: "Contact", url: string }
+ *        Id: string
+ *        FirstName: string
+ *        LastName: string
+ *        Title: string
+ *        Email: string
+ *        Phone: string
+ *      }
+ *    }[]
  *  }
- *  CSB_NCES_ID__c: string
- *  Org_District_Prioritized__c: string
- *  Self_Certification_Category__c: string
- *  Prioritized_as_High_Need__c: boolean
- *  Prioritized_as_Tribal__c: boolean
- *  Prioritized_as_Rural__c: boolean
+ *  Order_Requests__r: {
+ *    totalSize: 1
+ *    done: true
+ *    records: {
+ *      attributes: { type: "Order_Request__c", url: string }
+ *      Id: string
+ *      CSB_NCES_ID__c: string
+ *      Org_District_Prioritized__c: string
+ *      Self_Certification_Category__c: string
+ *      Prioritized_as_High_Need__c: boolean
+ *      Prioritized_as_Tribal__c: boolean
+ *      Prioritized_as_Rural__c: boolean
+ *    }[]
+ *  }
  * }} CSBRebateSchoolDistrictInfo
  */
 
@@ -2573,93 +2590,125 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
 
 /**
  * Uses cached JSforce connection to query the BAP for school district info
- * associated with a rebate year, form type, and CSB Rebate ID.
+ * associated with a CSB Rebate ID.
  *
  * @param {express.Request} req
- * @param {RebateYear} rebateYear
- * @param {FormType} formType
  * @param {string} rebateId
  * @returns {Promise<CSBRebateSchoolDistrictInfo>}
  */
-async function queryForCSBRebateSchoolDistrictInfo(
-  req,
-  rebateYear,
-  formType,
-  rebateId,
-) {
+async function queryForCSBRebateSchoolDistrictInfo(req, rebateId) {
   const logMessage =
     `Querying the BAP for school district info associated with ` +
-    `${rebateYear} ${formType.toUpperCase()} submission with ` +
     `CSB Rebate ID: '${rebateId}'.`;
   log({ level: "info", message: logMessage, req });
 
   /** @type {{ bapConnection: jsforce.Connection }} */
   const { bapConnection } = req.app.locals;
 
-  const recordTypeName = getRecordTypeNameField({ rebateYear, formType });
-
-  if (!recordTypeName) return null;
-
-  // `SELECT
+  // SELECT
   //   Id,
-  //   CSB_School_District__r.Id,
-  //   CSB_School_District__r.Name,
-  //   CSB_School_District__r.BillingStreet,
-  //   CSB_School_District__r.BillingCity,
-  //   CSB_School_District__r.BillingState,
-  //   CSB_School_District__r.BillingPostalCode,
-  //   School_District_Contact__r.Id,
-  //   School_District_Contact__r.Record_Type_Name__c,
-  //   School_District_Contact__r.FirstName,
-  //   School_District_Contact__r.LastName,
-  //   School_District_Contact__r.Title,
-  //   School_District_Contact__r.Email,
-  //   School_District_Contact__r.Phone,
-  //   CSB_NCES_ID__c,
-  //   Org_District_Prioritized__c,
-  //   Self_Certification_Category__c,
-  //   Prioritized_as_High_Need__c,
-  //   Prioritized_as_Tribal__c,
-  //   Prioritized_as_Rural__c
+  //   CSB_School_District_ID_NCES__c,
+  //   School_District__r.Id,
+  //   School_District__r.Name,
+  //   School_District__r.BillingStreet,
+  //   School_District__r.BillingCity,
+  //   School_District__r.BillingState,
+  //   School_District__r.BillingPostalCode,
+  //   (
+  //     SELECT
+  //       Id,
+  //       Name,
+  //       Contact__r.Id,
+  //       Contact__r.FirstName,
+  //       Contact__r.LastName,
+  //       Contact__r.Title,
+  //       Contact__r.Email,
+  //       Contact__r.Phone
+  //     FROM
+  //       Object_Item_Contacts__r
+  //     WHERE
+  //       Contact_Type__c = 'School District Contact'
+  //     ORDER BY
+  //       CreatedDate DESC
+  //     LIMIT 1
+  //   ),
+  //   (
+  //     SELECT
+  //       Id,
+  //       CSB_NCES_ID__c,
+  //       Org_District_Prioritized__c,
+  //       Self_Certification_Category__c,
+  //       Prioritized_as_High_Need__c,
+  //       Prioritized_as_Tribal__c,
+  //       Prioritized_as_Rural__c
+  //     FROM
+  //       Order_Requests__r
+  //     WHERE
+  //       Record_Type_Name__c = 'CSB Change Request' AND
+  //       Latest_Version__c = TRUE
+  //     ORDER BY
+  //       CreatedDate DESC
+  //     LIMIT 1
+  //   )
   // FROM
-  //   Order_Request__c
+  //   Application__c
   // WHERE
-  //   Record_Type_Name__c = '${recordTypeName}' AND
-  //   Parent_Rebate_ID__c = '${rebateId}' AND
-  //   Latest_Version__c = TRUE`
+  //   RecordType.DeveloperName = 'CSB_Rebate' AND
+  //   CSB_Rebate_ID__c = '${rebateId}'
 
   const schoolDistrictInfoQuery = await bapConnection
-    .sobject("Order_Request__c")
-    .find(
-      {
-        Record_Type_Name__c: recordTypeName,
-        Parent_Rebate_ID__c: rebateId,
-        Latest_Version__c: true,
-      },
-      {
-        // "*": 1,
-        Id: 1, // Salesforce record ID
-        "CSB_School_District__r.Id": 1,
-        "CSB_School_District__r.Name": 1,
-        "CSB_School_District__r.BillingStreet": 1,
-        "CSB_School_District__r.BillingCity": 1,
-        "CSB_School_District__r.BillingState": 1,
-        "CSB_School_District__r.BillingPostalCode": 1,
-        "School_District_Contact__r.Id": 1,
-        "School_District_Contact__r.Record_Type_Name__c": 1,
-        "School_District_Contact__r.FirstName": 1,
-        "School_District_Contact__r.LastName": 1,
-        "School_District_Contact__r.Title": 1,
-        "School_District_Contact__r.Phone": 1,
-        "School_District_Contact__r.Email": 1,
-        CSB_NCES_ID__c: 1,
-        Org_District_Prioritized__c: 1,
-        Self_Certification_Category__c: 1,
-        Prioritized_as_High_Need__c: 1,
-        Prioritized_as_Tribal__c: 1,
-        Prioritized_as_Rural__c: 1,
-      },
-    )
+    .sobject("Application__c")
+    .select({
+      // "*": 1,
+      Id: 1, // Salesforce record ID
+      CSB_School_District_ID_NCES__c: 1,
+      "School_District__r.Id": 1,
+      "School_District__r.Name": 1,
+      "School_District__r.BillingStreet": 1,
+      "School_District__r.BillingCity": 1,
+      "School_District__r.BillingState": 1,
+      "School_District__r.BillingPostalCode": 1,
+    })
+    .where({
+      "RecordType.DeveloperName": "CSB_Rebate",
+      CSB_Rebate_ID__c: rebateId,
+    })
+    .include("Object_Item_Contacts__r")
+    .select({
+      // "*": 1,
+      Id: 1, // Salesforce record ID
+      Name: 1,
+      "Contact__r.Id": 1,
+      "Contact__r.FirstName": 1,
+      "Contact__r.LastName": 1,
+      "Contact__r.Title": 1,
+      "Contact__r.Email": 1,
+      "Contact__r.Phone": 1,
+    })
+    .where({
+      Contact_Type__c: "School District Contact",
+    })
+    .sort({ CreatedDate: -1 })
+    .limit(1)
+    .end()
+    .include("Order_Requests__r")
+    .select({
+      // "*": 1,
+      Id: 1, // Salesforce record ID
+      CSB_NCES_ID__c: 1,
+      Org_District_Prioritized__c: 1,
+      Self_Certification_Category__c: 1,
+      Prioritized_as_High_Need__c: 1,
+      Prioritized_as_Tribal__c: 1,
+      Prioritized_as_Rural__c: 1,
+    })
+    .where({
+      Record_Type_Name__c: "CSB Change Request",
+      Latest_Version__c: true,
+    })
+    .sort({ CreatedDate: -1 })
+    .limit(1)
+    .end()
     .execute(async (err, records) => ((await err) ? err : records));
 
   return schoolDistrictInfoQuery?.[0] || {};
@@ -2913,25 +2962,17 @@ function getBapDataFor2023CRF(req, prfReviewItemId) {
 }
 
 /**
- * Fetches school district info associated with a provided a rebate year, form
- * type, and CSB Rebate ID.
+ * Fetches school district info associated with a provided CSB Rebate ID.
  *
  * @param {Object} param
- * @param {RebateYear} param.rebateYear
- * @param {FormType} param.formType
  * @param {string} param.rebateId
  * @param {express.Request} param.req
  * @returns {ReturnType<queryForCSBRebateSchoolDistrictInfo>}
  */
-function getCSBRebateSchoolDistrictInfo({
-  rebateYear,
-  formType,
-  rebateId,
-  req,
-}) {
+function getCSBRebateSchoolDistrictInfo({ rebateId, req }) {
   return verifyBapConnection(req, {
     name: queryForCSBRebateSchoolDistrictInfo,
-    args: [req, rebateYear, formType, rebateId],
+    args: [req, rebateId],
   });
 }
 

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -224,7 +224,7 @@ function searchNcesData({ rebateYear, req, res }) {
  * @param {express.Response} param.res
  */
 function getRebateSchoolDistrictInfo({ rebateYear, req, res }) {
-  const { formType, rebateId } = req.params;
+  const { rebateId } = req.params;
 
   // NOTE: included to support EPA API scan
   if (rebateId === formioExampleRebateId) {
@@ -245,12 +245,7 @@ function getRebateSchoolDistrictInfo({ rebateYear, req, res }) {
     return res.json({});
   }
 
-  return getCSBRebateSchoolDistrictInfo({
-    rebateYear,
-    formType,
-    rebateId,
-    req,
-  })
+  return getCSBRebateSchoolDistrictInfo({ rebateId, req })
     .then((json) => {
       res.json(json);
     })

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -309,6 +309,31 @@
         }
       }
     },
+    "/api/formio/2022/district/{rebateId}": {
+      "get": {
+        "summary": "Get the school district info associated with a provided CSB Rebate ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/rebateId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An object containing school district info associated with the CSB Rebate ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
     "/api/formio/2022/s3/{formType}/{mongoId}/{comboKey}/storage/s3": {
       "get": {
         "summary": "Download Formio file attachment from S3 for a 2022 submission.",
@@ -969,13 +994,10 @@
         }
       }
     },
-    "/api/formio/2023/district/{formType}/{rebateId}": {
+    "/api/formio/2023/district/{rebateId}": {
       "get": {
         "summary": "Get the school district info associated with a provided CSB Rebate ID",
         "parameters": [
-          {
-            "$ref": "#/components/parameters/formType"
-          },
           {
             "$ref": "#/components/parameters/rebateId"
           }
@@ -1619,6 +1641,31 @@
         "responses": {
           "200": {
             "description": "An object containing the matched NCES data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/formio/2024/district/{rebateId}": {
+      "get": {
+        "summary": "Get the school district info associated with a provided CSB Rebate ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/rebateId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An object containing school district info associated with the CSB Rebate ID.",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Related Issues:
* CSBAPP-616

## Main Changes:
Follow up to #619 – updates school district BAP query to get school district info from location BAP team provided, and adds the API route to the 2022 formio routes.

## Steps To Test:
Same testing steps as before (NOTE the API route changed since #619):
1. Run the app locally and test manually in Postman: http://localhost:3000/api/formio/2023/district/000000 (replace 000000 with a valid CSB Rebate Id for the environment you're testing, and 2023 with whatever rebate year and form type you're testing.
2. Later (once the API lookup is updated within the 2023 CRF), you'll be able to advance to the "School District Info" section/page of the 2023 CRF and see the request/response occur from the browser's dev tools network tab.
