### PR TITLE
Feature/update school district api query

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -2645,6 +2645,7 @@ async function queryForCSBRebateSchoolDistrictInfo(req, rebateId) {
   //       Order_Requests__r
   //     WHERE
   //       Record_Type_Name__c = 'CSB Change Request' AND
+  //       Request_Type__c = 'School District Changes' AND
   //       Latest_Version__c = TRUE
   //     ORDER BY
   //       CreatedDate DESC
@@ -2704,6 +2705,7 @@ async function queryForCSBRebateSchoolDistrictInfo(req, rebateId) {
     })
     .where({
       Record_Type_Name__c: "CSB Change Request",
+      Request_Type__c: "School District Changes",
       Latest_Version__c: true,
     })
     .sort({ CreatedDate: -1 })


### PR DESCRIPTION
## Related Issues:
* CSBAPP-616

## Main Changes:
Follow up to #625: Update BAP school district info query with additional field in the where clause.

## Steps To Test:
Same testing steps as before:
1. Run the app locally and test manually in Postman: http://localhost:3000/api/formio/2023/district/000000 (replace 000000 with a valid CSB Rebate Id for the environment you're testing, and 2023 with whatever rebate year and form type you're testing.
2. Later (once the API lookup is updated within the 2023 CRF), you'll be able to advance to the "School District Info" section/page of the 2023 CRF and see the request/response occur from the browser's dev tools network tab.
