### PR TITLE
Feature/remove change request 2022 route

### DIFF
--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -29,7 +29,7 @@ import { Notifications } from "@/components/notifications";
 import { Helpdesk } from "@/routes/helpdesk";
 import { Dashboard } from "@/routes/dashboard";
 import { FRFNew } from "@/routes/frfNew";
-import { Change2022 } from "@/routes/change2022";
+// import { Change2022 } from "@/routes/change2022";
 import { FRF2022 } from "@/routes/frf2022";
 import { PRF2022 } from "@/routes/prf2022";
 import { CRF2022 } from "@/routes/crf2022";
@@ -262,7 +262,7 @@ export function App() {
 
         <Route path="frf/new" element={<FRFNew />} />
 
-        <Route path="change/2022/:id" element={<Change2022 />} />
+        {/* <Route path="change/2022/:id" element={<Change2022 />} /> */}
         <Route path="frf/2022/:id" element={<FRF2022 />} />
         <Route path="prf/2022/:id" element={<PRF2022 />} />
         <Route path="crf/2022/:id" element={<CRF2022 />} />


### PR DESCRIPTION
## Related Issues:
* CSBAPP-617

## Main Changes:
Follow up to #630 – Remove 2022 change request form submission client app route

## Steps To Test:
Same as #630, only also ensure `/change/2022/:id` now redirects to user dashboard

## TODO:
Same as #630 – re-add 2022 change request form support after v8.0.0 release.