### PR TITLE
Feature/update bap query for 2023 crf infrastructure data

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -569,6 +569,11 @@ const { submissionPeriodOpen } = require("../config/formio");
  *  Infrastructure_Cost_per_Charger_from_PRF__c: number | null
  *  Charger_Cost_Includes_Installation__c: boolean
  *  Infrastructure_Owner_Contact_ID__c: string | null
+ *  Vendor_Address__c: string | null
+ *  Vendor_City__c: string | null
+ *  Vendor_State_Abbreviation__c: string | null
+ *  Vendor_Zip__c: string | null
+ *  County__c: string | null
  * }[]} prf2023InfrastructureRecordsQuery
  * @property {{
  *  attributes: { type: "Contact", url: string }
@@ -583,11 +588,6 @@ const { submissionPeriodOpen } = require("../config/formio");
  *    attributes: { type: "Account", url: string }
  *    Id: string
  *    Name: string
- *    BillingStreet: string
- *    BillingCity: string
- *    BillingState: string
- *    BillingPostalCode: string
- *    County__c: string
  *  }
  * }[]} prf2023ContactsQuery
  */
@@ -2469,6 +2469,11 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
   //   Infrastructure_Cost_per_Charger_from_PRF__c,
   //   Charger_Cost_Includes_Installation__c,
   //   Infrastructure_Owner_Contact_ID__c
+  //   Vendor_Address__c,
+  //   Vendor_City__c,
+  //   Vendor_State_Abbreviation__c,
+  //   Vendor_Zip__c,
+  //   County__c
   // FROM
   //   Line_Item__c
   // WHERE
@@ -2506,6 +2511,11 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
         Infrastructure_Cost_per_Charger_from_PRF__c: 1,
         Charger_Cost_Includes_Installation__c: 1,
         Infrastructure_Owner_Contact_ID__c: 1,
+        Vendor_Address__c: 1,
+        Vendor_City__c: 1,
+        Vendor_State_Abbreviation__c: 1,
+        Vendor_Zip__c: 1,
+        County__c: 1,
       },
     )
     .execute(async (err, records) => ((await err) ? err : records));
@@ -2541,11 +2551,6 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
   //   Phone,
   //   Account.Id,
   //   Account.Name
-  //   Account.BillingStreet,
-  //   Account.BillingCity,
-  //   Account.BillingState,
-  //   Account.BillingPostalCode,
-  //   Account.County__c
   // FROM
   //   Contact
   // WHERE
@@ -2571,11 +2576,6 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
               Phone: 1,
               "Account.Id": 1,
               "Account.Name": 1,
-              "Account.BillingStreet": 1,
-              "Account.BillingCity": 1,
-              "Account.BillingState": 1,
-              "Account.BillingPostalCode": 1,
-              "Account.County__c": 1,
             },
           )
           .execute(async (err, records) => ((await err) ? err : records));

--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -1432,6 +1432,11 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
               Infrastructure_Cost_per_Charger_from_PRF__c,
               Charger_Cost_Includes_Installation__c,
               Infrastructure_Owner_Contact_ID__c,
+              Vendor_Address__c,
+              Vendor_City__c,
+              Vendor_State_Abbreviation__c,
+              Vendor_Zip__c,
+              County__c,
             } = prf2023InfrastructureRecord;
 
             const ownerRecord = prf2023ContactsQuery.find((contact) => {
@@ -1463,11 +1468,11 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
                 org_contact_fname: ownerRecord?.FirstName,
                 org_contact_lname: ownerRecord?.LastName,
               },
-              infra_address: ownerRecord?.Account?.BillingStreet,
-              infra_city: ownerRecord?.Account?.BillingCity,
-              infra_state: ownerRecord?.Account?.BillingState,
-              infra_zip: ownerRecord?.Account?.BillingPostalCode,
-              infra_county: ownerRecord?.Account?.County__c,
+              infra_address: Vendor_Address__c,
+              infra_city: Vendor_City__c,
+              infra_state: Vendor_State_Abbreviation__c,
+              infra_zip: Vendor_Zip__c,
+              infra_county: County__c,
             };
           },
         );


### PR DESCRIPTION
## Related Issues:
* CSBAPP-614

## Main Changes:
* Update BAP query for fetching data for 2023 CRF infrastructure address fields.

## Steps To Test:
1. Create a new 2023 CRF.
2. Ensure the infrastructure address fields match what was used in the corresponding 2023 PRF:  
`data.infra_infrastructure[].infra_address`  
`data.infra_infrastructure[].infra_city`  
`data.infra_infrastructure[].infra_state`  
`data.infra_infrastructure[].infra_zip`  
`data.infra_infrastructure[].infra_county`  
