### PR TITLE
feature/update bap query for 2023 crf orgs address data

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -588,6 +588,11 @@ const { submissionPeriodOpen } = require("../config/formio");
  *    attributes: { type: "Account", url: string }
  *    Id: string
  *    Name: string
+ *    BillingStreet: string
+ *    BillingCity: string
+ *    BillingState: string
+ *    BillingPostalCode: string
+ *    County__c: string
  *  }
  * }[]} prf2023ContactsQuery
  */
@@ -2550,7 +2555,12 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
   //   Email,
   //   Phone,
   //   Account.Id,
-  //   Account.Name
+  //   Account.Name,
+  //   Account.BillingStreet,
+  //   Account.BillingCity,
+  //   Account.BillingState,
+  //   Account.BillingPostalCode,
+  //   Account.County__c
   // FROM
   //   Contact
   // WHERE
@@ -2576,6 +2586,11 @@ async function queryBapFor2023CRFData(req, prfReviewItemId) {
               Phone: 1,
               "Account.Id": 1,
               "Account.Name": 1,
+              "Account.BillingStreet": 1,
+              "Account.BillingCity": 1,
+              "Account.BillingState": 1,
+              "Account.BillingPostalCode": 1,
+              "Account.County__c": 1,
             },
           )
           .execute(async (err, records) => ((await err) ? err : records));


### PR DESCRIPTION
## Related Issues:
* CSBAPP-614

## Main Changes:
Follow up to #634 – Update BAP query for fetching data for 2023 CRF organization address fields (re-add the contact address fields to the BAP query that were removed in the last PR).

## Steps To Test:
1. Create a new 2023 CRF.
2. Ensure the organization address fields match what was used in the corresponding 2023 PRF:  
`data.org_organizations[]._org_address_1`  
`data.org_organizations[]._org_address_2`  
`data.org_organizations[]._org_county`  
`data.org_organizations[]._org_city`  
`data.org_organizations[]._org_state`  
`data.org_organizations[]._org_zip`  