### PR TITLE
Feature/update parsing of bap billingstreet field

### DIFF
--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -1243,9 +1243,13 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
 
         const prf2023RecordJson = JSON.parse(CSB_Snapshot__r.JSON_Snapshot__c);
 
-        const [schoolDistrictStreetAddress1, schoolDistrictStreetAddress2] = (
-          CSB_School_District__r?.BillingStreet ?? "\n"
-        ).split("\n");
+        /** Handle BillingStreet field seperated by newline or comma. */
+        const [schoolDistrictStreetAddress1, schoolDistrictStreetAddress2] =
+          CSB_School_District__r?.BillingStreet?.includes("\n")
+            ? CSB_School_District__r.BillingStreet.split("\n")
+            : CSB_School_District__r?.BillingStreet?.includes(",")
+              ? CSB_School_District__r.BillingStreet.split(",")
+              : [CSB_School_District__r?.BillingStreet || "", ""];
 
         const org_organizations = prf2023ContactsQuery.reduce(
           (array, contact) => {
@@ -1288,9 +1292,13 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
              * "org_organizations" array, and it hasn't already been added.
              */
             if (jsonOrg && !orgAlreadyAdded) {
-              const [orgStreetAddress1, orgStreetAddress2] = (
-                BillingStreet ?? "\n"
-              ).split("\n");
+              /** Handle BillingStreet field seperated by newline or comma. */
+              const [orgStreetAddress1, orgStreetAddress2] =
+                BillingStreet.includes("\n")
+                  ? BillingStreet.split("\n")
+                  : BillingStreet.includes(",")
+                    ? BillingStreet.split(",")
+                    : [BillingStreet, ""];
 
               array.push({
                 org_number: jsonOrg.org_number,
@@ -1517,12 +1525,8 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
             _bap_alternate_phone: Alternate_Applicant__r?.Phone,
             _bap_district_id: CSB_School_District__r?.Id,
             _bap_district_nces_id: CSB_NCES_ID__c,
-            _bap_district_name: CSB_School_District__r?.Name,
-            _bap_district_address_1: schoolDistrictStreetAddress1 || "",
-            _bap_district_address_2: schoolDistrictStreetAddress2 || "",
-            _bap_district_city: CSB_School_District__r?.BillingCity,
-            _bap_district_state: CSB_School_District__r?.BillingState,
-            _bap_district_zip: CSB_School_District__r?.BillingPostalCode,
+            _bap_district_address_1: schoolDistrictStreetAddress1,
+            _bap_district_address_2: schoolDistrictStreetAddress2,
             _bap_district_priority: Org_District_Prioritized__c,
             _bap_district_priority_reason: {
               highNeed: Prioritized_as_High_Need__c,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-633

## Main Changes:
Update parsing of `BillingStreet` fields returned in BAP query for 2023 CRF data to handle either an escaped new line character or a comma for separating the multiple address lines that were combined into the single `BillingStreet` field.

## Steps To Test:
1. Navigate to the dashboard.
2. Create a 2023 CRF.
3. Ensure the two address lines for school districts and organizations properly display.

