### PR TITLE
Feature/re add school district fields

### DIFF
--- a/app/server/app/utilities/formio.js
+++ b/app/server/app/utilities/formio.js
@@ -1525,8 +1525,12 @@ function fetchDataForCRFSubmission({ rebateYear, req, res }) {
             _bap_alternate_phone: Alternate_Applicant__r?.Phone,
             _bap_district_id: CSB_School_District__r?.Id,
             _bap_district_nces_id: CSB_NCES_ID__c,
+            _bap_district_name: CSB_School_District__r?.Name,
             _bap_district_address_1: schoolDistrictStreetAddress1,
             _bap_district_address_2: schoolDistrictStreetAddress2,
+            _bap_district_city: CSB_School_District__r?.BillingCity,
+            _bap_district_state: CSB_School_District__r?.BillingState,
+            _bap_district_zip: CSB_School_District__r?.BillingPostalCode,
             _bap_district_priority: Org_District_Prioritized__c,
             _bap_district_priority_reason: {
               highNeed: Prioritized_as_High_Need__c,


### PR DESCRIPTION
## Related Issues:
* CSBAPP-633

## Main Changes:
Quick follow up to #642 – add school district fields that accidentally got removed in last commit.

## Steps To Test:
Same as in #642:
1. Navigate to the dashboard.
2. Create a 2023 CRF.
3. Ensure the two address lines for school districts and organizations properly display.