### PR TITLE
Feature/update github action csb rebate year

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -41,7 +41,7 @@ jobs:
       # SAML_PRIVATE_KEY: ${{ secrets.SAML_PRIVATE_KEY }}
       JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
       JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
-      CSB_REBATE_YEAR: 2024
+      CSB_REBATE_YEAR: 2023
       CSB_LOGIN_ENABLED: true
       CSB_2022_FRF_OPEN: true
       CSB_2022_PRF_OPEN: true

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -41,7 +41,7 @@ jobs:
       SAML_PRIVATE_KEY: ${{ secrets.SAML_PRIVATE_KEY }}
       JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
       JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
-      CSB_REBATE_YEAR: 2024
+      CSB_REBATE_YEAR: 2023
       CSB_LOGIN_ENABLED: true
       CSB_2022_FRF_OPEN: true
       CSB_2022_PRF_OPEN: true


### PR DESCRIPTION
## Related Issues:
* CSBAPP-637

## Main Changes:
* Update `CSB_REBATE_YEAR` value to 2023 in dev and staging github actions workflows

## Steps To Test:
1. Navigate to the dashboard.
2. Ensure the "Rebate Year" selected option defaults to 2023.
