### PR TITLE
Feature/downgrade formio packages

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -9,11 +9,11 @@
       "version": "8.0.0",
       "license": "CC0-1.0",
       "dependencies": {
-        "@formio/bootstrap": "3.2.1",
-        "@formio/js": "5.3.1",
-        "@formio/premium": "3.1.1",
+        "@formio/bootstrap": "3.1.4",
+        "@formio/js": "5.2.6",
+        "@formio/premium": "3.0.11",
         "@formio/react": "6.1.0",
-        "@formio/uswds": "2.7.1",
+        "@formio/uswds": "2.6.5",
         "@fortawesome/fontawesome-free": "7.0.1",
         "@headlessui/react": "2.2.9",
         "@heroicons/react": "2.2.0",
@@ -62,13 +62,15 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
       "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.1.1",
         "@csstools/css-color-parser": "^4.0.2",
@@ -85,6 +87,7 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
@@ -97,13 +100,15 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.0"
       },
@@ -126,6 +131,7 @@
         }
       ],
       "license": "MIT-0",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -145,6 +151,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -168,6 +175,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
         "@csstools/css-calc": "^3.1.1"
@@ -217,7 +225,8 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0"
+      "license": "MIT-0",
+      "peer": true
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "4.0.0",
@@ -810,6 +819,7 @@
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
@@ -876,9 +886,9 @@
       "license": "MIT"
     },
     "node_modules/@formio/bootstrap": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.2.1.tgz",
-      "integrity": "sha512-6B0mQolATnic9P7YWVBqDuFO3hloiD9mUsz//nuwirqT25WKvgC+lbKboa9IVz36f96xW1J99FvGdtYmEd6kvA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.4.tgz",
+      "integrity": "sha512-hcIsoLy55UzdDeZC59TPW5CycIRkr7wg7BMsFyWltRI8pQJs4d7vNPC4nGPddzqFnkQtm3Vf1Va4e0ETTIfXhA==",
       "license": "MIT"
     },
     "node_modules/@formio/core": {
@@ -886,7 +896,6 @@
       "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.6.1.tgz",
       "integrity": "sha512-WfFZCreXJYviXnWbLWoF67Oxi0pQDZ+1bXNEFORODPt/lXSuYenfUDbrFFY9eCIB9Mxqt4UY4P8X+8Eg1eRVrg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browser-cookies": "^1.2.0",
         "core-js": "^3.39.0",
@@ -911,14 +920,13 @@
       }
     },
     "node_modules/@formio/js": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.3.1.tgz",
-      "integrity": "sha512-7ylXakhpgH4hz4+xUZp35tmb1jDUZQChVHhWi0xqPan7xRLREcooIX5S5CKRNxHrDOUrunirUbIgnGO/8Qr3CA==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.2.6.tgz",
+      "integrity": "sha512-59LI0wwjTNcYIDz8AxzQnhAadIz5GkjwC8kgNMmVkLi+Ay1V4bjA/jrY9X78qDa78pPXwea/wB0YCRy+E/veuQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@formio/bootstrap": "^3.2.1",
-        "@formio/core": "^2.6.1",
+        "@formio/bootstrap": "^3.1.4",
+        "@formio/core": "^2.5.4",
         "@formio/text-mask-addons": "^3.8.0-formio.4",
         "@formio/vanilla-text-mask": "^5.1.1-formio.1",
         "abortcontroller-polyfill": "^1.7.5",
@@ -979,9 +987,9 @@
       "license": "MIT"
     },
     "node_modules/@formio/premium": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.1.1.tgz",
-      "integrity": "sha512-GffAcvmfpyPOrR8V0JaAv06ZGDnnDio593mtUJ56rFhrwTphkeSg8K4z489RNGWrz4T5eSLF5KJMtmu0lkVx+g==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.0.11.tgz",
+      "integrity": "sha512-7ECFou9yW86rVwHVYHkmp93YUbcSMvveC6rM0NYQPBiaKGbaMlV0oIU9re/sq0oOhz/TIRY5OiajwCW9cE6FIQ==",
       "license": "UNLICENSED",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
@@ -996,7 +1004,7 @@
         "vanilla-picker": "^2.12.3"
       },
       "peerDependencies": {
-        "@formio/js": "^5.3.1"
+        "@formio/js": "^5.2.6"
       }
     },
     "node_modules/@formio/react": {
@@ -1024,12 +1032,12 @@
       "license": "Unlicense"
     },
     "node_modules/@formio/uswds": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.7.1.tgz",
-      "integrity": "sha512-CS35+8RWJoP+zS6JqjM4Eq5E7hdnijyqwDQARjyRjxzBPZNgYoxIhoEg5j9mkijGcWwrOe9uH77oq/gBi6OgjQ==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.6.5.tgz",
+      "integrity": "sha512-ztJn4wqxBluS0DeHJDxaEvI7Y9NXNKavL0nDM7LMSz94KB7dBognIPA3kzpPNChYq7R7uqXJNu1O9Vz993scDg==",
       "license": "OSLv3",
       "peerDependencies": {
-        "@formio/js": "^5.3.1"
+        "@formio/js": "^5.2.6"
       }
     },
     "node_modules/@formio/vanilla-text-mask": {
@@ -1266,7 +1274,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -2620,7 +2627,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
       "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.2"
       },
@@ -2743,7 +2749,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.16.tgz",
       "integrity": "sha512-WBM/nDbEZmDUORKnh5i1bTnAz6vTohUf9b8esSMu+b24+srbaxa04UbJgWx78CVfNXA20sNu0odEIluZDFdCog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2754,7 +2759,6 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2817,7 +2821,6 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -3116,7 +3119,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3139,6 +3141,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -3219,6 +3222,7 @@
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
@@ -3482,6 +3486,7 @@
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -3495,6 +3500,7 @@
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
       "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
@@ -3520,6 +3526,7 @@
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
         "whatwg-url": "^16.0.0"
@@ -3554,7 +3561,8 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.1",
@@ -3699,6 +3707,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -3765,7 +3774,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4235,6 +4243,7 @@
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
       },
@@ -4257,6 +4266,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -4270,6 +4280,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -4422,7 +4433,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/iselement": {
       "version": "1.1.4",
@@ -4931,6 +4943,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -5234,7 +5247,8 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6059,6 +6073,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -6243,7 +6258,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6253,7 +6267,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6400,6 +6413,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6510,6 +6524,7 @@
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -6656,7 +6671,8 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tabbable": {
       "version": "6.2.0",
@@ -6669,8 +6685,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.3",
@@ -6749,7 +6764,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6770,6 +6784,7 @@
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
       "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tldts-core": "^7.0.25"
       },
@@ -6781,7 +6796,8 @@
       "version": "7.0.25",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
       "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -6810,6 +6826,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tldts": "^7.0.5"
       },
@@ -6822,6 +6839,7 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -6906,7 +6924,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6944,6 +6961,7 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
       "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -7110,7 +7128,6 @@
       "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7204,7 +7221,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7217,6 +7233,7 @@
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -7229,6 +7246,7 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -7238,6 +7256,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -7247,6 +7266,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
@@ -7277,6 +7297,7 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7285,7 +7306,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/yallist": {
       "version": "5.0.0",
@@ -7329,12 +7351,14 @@
     "@acemir/cssom": {
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "peer": true
     },
     "@asamuzakjp/css-color": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
       "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "peer": true,
       "requires": {
         "@csstools/css-calc": "^3.1.1",
         "@csstools/css-color-parser": "^4.0.2",
@@ -7347,6 +7371,7 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "peer": true,
       "requires": {
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
@@ -7358,12 +7383,14 @@
     "@asamuzakjp/nwsapi": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "peer": true
     },
     "@bramus/specificity": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "peer": true,
       "requires": {
         "css-tree": "^3.0.0"
       }
@@ -7371,18 +7398,21 @@
     "@csstools/color-helpers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "peer": true
     },
     "@csstools/css-calc": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
       "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "peer": true,
       "requires": {}
     },
     "@csstools/css-color-parser": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
       "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "peer": true,
       "requires": {
         "@csstools/color-helpers": "^6.0.2",
         "@csstools/css-calc": "^3.1.1"
@@ -7398,7 +7428,8 @@
     "@csstools/css-syntax-patches-for-csstree": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.0.tgz",
-      "integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA=="
+      "integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==",
+      "peer": true
     },
     "@csstools/css-tokenizer": {
       "version": "4.0.0",
@@ -7673,6 +7704,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "peer": true,
       "requires": {}
     },
     "@floating-ui/core": {
@@ -7716,15 +7748,14 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
     "@formio/bootstrap": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.2.1.tgz",
-      "integrity": "sha512-6B0mQolATnic9P7YWVBqDuFO3hloiD9mUsz//nuwirqT25WKvgC+lbKboa9IVz36f96xW1J99FvGdtYmEd6kvA=="
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap/-/bootstrap-3.1.4.tgz",
+      "integrity": "sha512-hcIsoLy55UzdDeZC59TPW5CycIRkr7wg7BMsFyWltRI8pQJs4d7vNPC4nGPddzqFnkQtm3Vf1Va4e0ETTIfXhA=="
     },
     "@formio/core": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@formio/core/-/core-2.6.1.tgz",
       "integrity": "sha512-WfFZCreXJYviXnWbLWoF67Oxi0pQDZ+1bXNEFORODPt/lXSuYenfUDbrFFY9eCIB9Mxqt4UY4P8X+8Eg1eRVrg==",
-      "peer": true,
       "requires": {
         "browser-cookies": "^1.2.0",
         "core-js": "^3.39.0",
@@ -7750,13 +7781,12 @@
       }
     },
     "@formio/js": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.3.1.tgz",
-      "integrity": "sha512-7ylXakhpgH4hz4+xUZp35tmb1jDUZQChVHhWi0xqPan7xRLREcooIX5S5CKRNxHrDOUrunirUbIgnGO/8Qr3CA==",
-      "peer": true,
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@formio/js/-/js-5.2.6.tgz",
+      "integrity": "sha512-59LI0wwjTNcYIDz8AxzQnhAadIz5GkjwC8kgNMmVkLi+Ay1V4bjA/jrY9X78qDa78pPXwea/wB0YCRy+E/veuQ==",
       "requires": {
-        "@formio/bootstrap": "^3.2.1",
-        "@formio/core": "^2.6.1",
+        "@formio/bootstrap": "^3.1.4",
+        "@formio/core": "^2.5.4",
         "@formio/text-mask-addons": "^3.8.0-formio.4",
         "@formio/vanilla-text-mask": "^5.1.1-formio.1",
         "abortcontroller-polyfill": "^1.7.5",
@@ -7815,9 +7845,9 @@
       }
     },
     "@formio/premium": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.1.1.tgz",
-      "integrity": "sha512-GffAcvmfpyPOrR8V0JaAv06ZGDnnDio593mtUJ56rFhrwTphkeSg8K4z489RNGWrz4T5eSLF5KJMtmu0lkVx+g==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@formio/premium/-/premium-3.0.11.tgz",
+      "integrity": "sha512-7ECFou9yW86rVwHVYHkmp93YUbcSMvveC6rM0NYQPBiaKGbaMlV0oIU9re/sq0oOhz/TIRY5OiajwCW9cE6FIQ==",
       "requires": {
         "@juggle/resize-observer": "^3.4.0",
         "@zxing/library": "^0.21.2",
@@ -7848,9 +7878,9 @@
       "integrity": "sha512-vhkeIyuL+1rtC9S4IW8O3JCwroPtvJrkrcMO4wyELNqMIgQRKbiyBAitZfUP4tY04xdB5lxAinbzdwb+NMdX6w=="
     },
     "@formio/uswds": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.7.1.tgz",
-      "integrity": "sha512-CS35+8RWJoP+zS6JqjM4Eq5E7hdnijyqwDQARjyRjxzBPZNgYoxIhoEg5j9mkijGcWwrOe9uH77oq/gBi6OgjQ==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@formio/uswds/-/uswds-2.6.5.tgz",
+      "integrity": "sha512-ztJn4wqxBluS0DeHJDxaEvI7Y9NXNKavL0nDM7LMSz94KB7dBognIPA3kzpPNChYq7R7uqXJNu1O9Vz993scDg==",
       "requires": {}
     },
     "@formio/vanilla-text-mask": {
@@ -8015,8 +8045,7 @@
     "@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@radix-ui/primitive": {
       "version": "1.1.3",
@@ -8693,7 +8722,6 @@
       "version": "5.90.2",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
       "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
-      "peer": true,
       "requires": {
         "@tanstack/query-core": "5.90.2"
       }
@@ -8777,7 +8805,6 @@
       "version": "19.1.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.16.tgz",
       "integrity": "sha512-WBM/nDbEZmDUORKnh5i1bTnAz6vTohUf9b8esSMu+b24+srbaxa04UbJgWx78CVfNXA20sNu0odEIluZDFdCog==",
-      "peer": true,
       "requires": {
         "csstype": "^3.0.2"
       }
@@ -8787,7 +8814,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
-      "peer": true,
       "requires": {}
     },
     "@types/trusted-types": {
@@ -8830,7 +8856,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.45.0.tgz",
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -9003,8 +9028,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -9016,7 +9040,8 @@
     "agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "peer": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -9075,6 +9100,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "peer": true,
       "requires": {
         "require-from-string": "^2.0.2"
       }
@@ -9253,6 +9279,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "peer": true,
       "requires": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -9262,6 +9289,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
       "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "peer": true,
       "requires": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
@@ -9283,6 +9311,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "peer": true,
       "requires": {
         "whatwg-mimetype": "^5.0.0",
         "whatwg-url": "^16.0.0"
@@ -9304,7 +9333,8 @@
     "decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "peer": true
     },
     "decode-named-character-reference": {
       "version": "1.0.1",
@@ -9420,7 +9450,8 @@
     "entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "peer": true
     },
     "esbuild": {
       "version": "0.25.0",
@@ -9466,7 +9497,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9798,6 +9828,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "peer": true,
       "requires": {
         "@exodus/bytes": "^1.6.0"
       }
@@ -9811,6 +9842,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "peer": true,
       "requires": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -9820,6 +9852,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "peer": true,
       "requires": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -9915,7 +9948,8 @@
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "peer": true
     },
     "iselement": {
       "version": "1.1.4",
@@ -10218,7 +10252,8 @@
     "lru-cache": {
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "peer": true
     },
     "magic-string": {
       "version": "0.30.19",
@@ -10443,7 +10478,8 @@
     "mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "peer": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -10928,6 +10964,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "peer": true,
       "requires": {
         "entities": "^6.0.0"
       }
@@ -11035,14 +11072,12 @@
     "react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
-      "peer": true
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ=="
     },
     "react-dom": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
-      "peer": true,
       "requires": {
         "scheduler": "^0.26.0"
       }
@@ -11140,7 +11175,8 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "peer": true
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -11203,6 +11239,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "peer": true,
       "requires": {
         "xmlchars": "^2.2.0"
       }
@@ -11301,7 +11338,8 @@
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "peer": true
     },
     "tabbable": {
       "version": "6.2.0",
@@ -11312,8 +11350,7 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "tapable": {
       "version": "2.2.3",
@@ -11360,8 +11397,7 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
           "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -11377,6 +11413,7 @@
       "version": "7.0.25",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
       "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
+      "peer": true,
       "requires": {
         "tldts-core": "^7.0.25"
       }
@@ -11384,7 +11421,8 @@
     "tldts-core": {
       "version": "7.0.25",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
-      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw=="
+      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
+      "peer": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -11407,6 +11445,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "peer": true,
       "requires": {
         "tldts": "^7.0.5"
       }
@@ -11415,6 +11454,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "peer": true,
       "requires": {
         "punycode": "^2.3.1"
       }
@@ -11469,8 +11509,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "typescript-eslint": {
       "version": "8.45.0",
@@ -11487,7 +11526,8 @@
     "undici": {
       "version": "7.22.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg=="
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "peer": true
     },
     "unified": {
       "version": "11.0.5",
@@ -11597,7 +11637,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
       "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -11619,8 +11658,7 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
           "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -11628,6 +11666,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "peer": true,
       "requires": {
         "xml-name-validator": "^5.0.0"
       }
@@ -11635,17 +11674,20 @@
     "webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "peer": true
     },
     "whatwg-mimetype": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "peer": true
     },
     "whatwg-url": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "peer": true,
       "requires": {
         "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
@@ -11664,12 +11706,14 @@
     "xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "peer": true
     },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "peer": true
     },
     "yallist": {
       "version": "5.0.0",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -36,11 +36,11 @@
     "vite": "7.1.7"
   },
   "dependencies": {
-    "@formio/bootstrap": "3.2.1",
-    "@formio/js": "5.3.1",
-    "@formio/premium": "3.1.1",
+    "@formio/bootstrap": "3.1.4",
+    "@formio/js": "5.2.6",
+    "@formio/premium": "3.0.11",
     "@formio/react": "6.1.0",
-    "@formio/uswds": "2.7.1",
+    "@formio/uswds": "2.6.5",
     "@fortawesome/fontawesome-free": "7.0.1",
     "@headlessui/react": "2.2.9",
     "@heroicons/react": "2.2.0",


### PR DESCRIPTION
## Related Issues:
* CSBAPP-639

## Main Changes:
Follow-up to #651 – Downgrade Formio packages to match versions included in [Formio API server v9.6.8](https://github.com/formio/enterprise-release/blob/master/API-Server-Change-Log.md#api-server-version-968). After the Formio API server was upgraded to v9.7.2, performance was worse than before, so the packages on the API server were rolled back to v9.6.8. This update downgrades the web application's packages to again be in sync with the Formio packages on the API server.

## Steps To Test:
Same as before:

1. Navigate to the dashboard.
2. Open a submission with 25 buses.
3. Test if the package updates fixes the performance issue around interacting with the submission.
4. Test all other forms across the app and ensure there aren't any regressions related to the package updates.
