### PR TITLE
Feature/update github actions workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -76,6 +76,7 @@ jobs:
       FORMIO_BASE_URL: ${{ secrets.FORMIO_BASE_URL }}
       FORMIO_PROJECT_NAME: ${{ secrets.FORMIO_PROJECT_NAME }}
       FORMIO_API_KEY: ${{ secrets.FORMIO_API_KEY }}
+      FORMIO_PREMIUM_KEY: ${{ secrets.FORMIO_PREMIUM_KEY }}
       FORMIO_PKG_AUTH_TOKEN: ${{ secrets.FORMIO_PKG_AUTH_TOKEN }}
       BAP_REST_API_VERSION: ${{ secrets.BAP_REST_API_VERSION }}
       BAP_CLIENT_ID: ${{ secrets.BAP_CLIENT_ID }}
@@ -180,6 +181,7 @@ jobs:
           cf set-env $APP_NAME "FORMIO_BASE_URL" "$FORMIO_BASE_URL" > /dev/null
           cf set-env $APP_NAME "FORMIO_PROJECT_NAME" "$FORMIO_PROJECT_NAME" > /dev/null
           cf set-env $APP_NAME "FORMIO_API_KEY" "$FORMIO_API_KEY" > /dev/null
+          cf set-env $APP_NAME "FORMIO_PREMIUM_KEY" "$FORMIO_PREMIUM_KEY" > /dev/null
           cf set-env $APP_NAME "BAP_REST_API_VERSION" "$BAP_REST_API_VERSION" > /dev/null
           cf set-env $APP_NAME "BAP_CLIENT_ID" "$BAP_CLIENT_ID" > /dev/null
           cf set-env $APP_NAME "BAP_CLIENT_SECRET" "$BAP_CLIENT_SECRET" > /dev/null

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -76,6 +76,7 @@ jobs:
       FORMIO_BASE_URL: ${{ secrets.FORMIO_BASE_URL }}
       FORMIO_PROJECT_NAME: ${{ secrets.FORMIO_PROJECT_NAME }}
       FORMIO_API_KEY: ${{ secrets.FORMIO_API_KEY }}
+      FORMIO_PREMIUM_KEY: ${{ secrets.FORMIO_PREMIUM_KEY }}
       FORMIO_PKG_AUTH_TOKEN: ${{ secrets.FORMIO_PKG_AUTH_TOKEN }}
       BAP_REST_API_VERSION: ${{ secrets.BAP_REST_API_VERSION }}
       BAP_CLIENT_ID: ${{ secrets.BAP_CLIENT_ID }}
@@ -180,6 +181,7 @@ jobs:
           cf set-env $APP_NAME "FORMIO_BASE_URL" "$FORMIO_BASE_URL" > /dev/null
           cf set-env $APP_NAME "FORMIO_PROJECT_NAME" "$FORMIO_PROJECT_NAME" > /dev/null
           cf set-env $APP_NAME "FORMIO_API_KEY" "$FORMIO_API_KEY" > /dev/null
+          cf set-env $APP_NAME "FORMIO_PREMIUM_KEY" "$FORMIO_PREMIUM_KEY" > /dev/null
           cf set-env $APP_NAME "BAP_REST_API_VERSION" "$BAP_REST_API_VERSION" > /dev/null
           cf set-env $APP_NAME "BAP_CLIENT_ID" "$BAP_CLIENT_ID" > /dev/null
           cf set-env $APP_NAME "BAP_CLIENT_SECRET" "$BAP_CLIENT_SECRET" > /dev/null


### PR DESCRIPTION
## Related Issues:
* CSBAPP-647

## Main Changes:
Quick follow-up to #655 – Update GitHub Actions dev and staging workflow files to set `FORMIO_PR…EMIUM_KEY` server app env. Fixes an oversight in the last pull request, as the values still need to be set on the server.

## Steps To Test:
Same as before:
1. Navigate to a 2023 FRF form submission, as it uses a premium Form.io component (the NCES lookup, which is a Form.io data source component). Really any form that uses a Form.io premium component would also work.
2. Ensure the data source component works as expected and an error message isn't being shown indicating the premium components key is needed for it's use (NOTE: it will either work as expected, or it won't and the the message will be displayed in red text).
