### PR TITLE
Feature/apply save button validation override

### DIFF
--- a/app/client/src/routes/crf2022.tsx
+++ b/app/client/src/routes/crf2022.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
+import { type Webform } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -147,6 +148,20 @@ function CloseOutRequestForm(props: { email: string }) {
    * field data in the form has changed).
    */
   const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  const formInstance = useRef<Webform | null>(null);
+
+  /**
+   * After saving a draft, reset Formio webform's submitted property so
+   * untouched fields do not show validation errors.
+   */
+  function clearWebformSubmittedFlag() {
+    const instance = formInstance.current;
+
+    if (instance) {
+      instance.submitted = false;
+    }
+  }
 
   if (!staticContent || !privateConfigData || !bapSamData) {
     return <Loading />;
@@ -307,6 +322,9 @@ function CloseOutRequestForm(props: { email: string }) {
             readOnly: formIsReadOnly,
             noAlerts: true,
           }}
+          onFormReady={(instance: Webform) => {
+            formInstance.current = instance;
+          }}
           onSubmit={(onSubmitParam: Submission) => {
             if (formIsReadOnly) return;
 
@@ -396,6 +414,10 @@ function CloseOutRequestForm(props: { email: string }) {
                 });
               },
               onSettled: (_data, _error, _payload, _context) => {
+                if (onSubmitParam.state === "draft") {
+                  queueMicrotask(clearWebformSubmittedFlag);
+                }
+
                 dataIsPosting.current = false;
                 formIsBeingSubmitted.current = false;
               },

--- a/app/client/src/routes/crf2023.tsx
+++ b/app/client/src/routes/crf2023.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
+import { type Webform } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -147,6 +148,20 @@ function CloseOutRequestForm(props: { email: string }) {
    * field data in the form has changed).
    */
   const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  const formInstance = useRef<Webform | null>(null);
+
+  /**
+   * After saving a draft, reset Formio webform's submitted property so
+   * untouched fields do not show validation errors.
+   */
+  function clearWebformSubmittedFlag() {
+    const instance = formInstance.current;
+
+    if (instance) {
+      instance.submitted = false;
+    }
+  }
 
   if (!staticContent || !privateConfigData || !bapSamData) {
     return <Loading />;
@@ -317,6 +332,9 @@ function CloseOutRequestForm(props: { email: string }) {
             readOnly: formIsReadOnly,
             noAlerts: true,
           }}
+          onFormReady={(instance: Webform) => {
+            formInstance.current = instance;
+          }}
           onSubmit={(onSubmitParam: Submission) => {
             if (formIsReadOnly) return;
 
@@ -406,6 +424,10 @@ function CloseOutRequestForm(props: { email: string }) {
                 });
               },
               onSettled: (_data, _error, _payload, _context) => {
+                if (onSubmitParam.state === "draft") {
+                  queueMicrotask(clearWebformSubmittedFlag);
+                }
+
                 dataIsPosting.current = false;
                 formIsBeingSubmitted.current = false;
               },

--- a/app/client/src/routes/frf2022.tsx
+++ b/app/client/src/routes/frf2022.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
+import { type Webform } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -164,6 +165,20 @@ function FundingRequestForm(props: { email: string }) {
    * field data in the form has changed).
    */
   const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  const formInstance = useRef<Webform | null>(null);
+
+  /**
+   * After saving a draft, reset Formio webform's submitted property so
+   * untouched fields do not show validation errors.
+   */
+  function clearWebformSubmittedFlag() {
+    const instance = formInstance.current;
+
+    if (instance) {
+      instance.submitted = false;
+    }
+  }
 
   if (!staticContent || !privateConfigData || !bapSamData) {
     return <Loading />;
@@ -464,6 +479,9 @@ function FundingRequestForm(props: { email: string }) {
             readOnly: formIsReadOnly,
             noAlerts: true,
           }}
+          onFormReady={(instance: Webform) => {
+            formInstance.current = instance;
+          }}
           onSubmit={(onSubmitParam: Submission) => {
             if (formIsReadOnly) return;
 
@@ -556,6 +574,10 @@ function FundingRequestForm(props: { email: string }) {
                 });
               },
               onSettled: (_data, _error, _payload, _context) => {
+                if (onSubmitParam.state === "draft") {
+                  queueMicrotask(clearWebformSubmittedFlag);
+                }
+
                 dataIsPosting.current = false;
                 formIsBeingSubmitted.current = false;
               },

--- a/app/client/src/routes/frf2023.tsx
+++ b/app/client/src/routes/frf2023.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
+import { type Webform } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -148,6 +149,20 @@ function FundingRequestForm(props: { email: string }) {
    * field data in the form has changed).
    */
   const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  const formInstance = useRef<Webform | null>(null);
+
+  /**
+   * After saving a draft, reset Formio webform's submitted property so
+   * untouched fields do not show validation errors.
+   */
+  function clearWebformSubmittedFlag() {
+    const instance = formInstance.current;
+
+    if (instance) {
+      instance.submitted = false;
+    }
+  }
 
   if (!staticContent || !privateConfigData || !bapSamData) {
     return <Loading />;
@@ -447,6 +462,9 @@ function FundingRequestForm(props: { email: string }) {
             readOnly: formIsReadOnly,
             noAlerts: true,
           }}
+          onFormReady={(instance: Webform) => {
+            formInstance.current = instance;
+          }}
           onSubmit={(onSubmitParam: Submission) => {
             if (formIsReadOnly) return;
 
@@ -533,6 +551,10 @@ function FundingRequestForm(props: { email: string }) {
                 });
               },
               onSettled: (_data, _error, _payload, _context) => {
+                if (onSubmitParam.state === "draft") {
+                  queueMicrotask(clearWebformSubmittedFlag);
+                }
+
                 dataIsPosting.current = false;
                 formIsBeingSubmitted.current = false;
               },

--- a/app/client/src/routes/frf2024.tsx
+++ b/app/client/src/routes/frf2024.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
+import { type Webform } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -148,6 +149,20 @@ function FundingRequestForm(props: { email: string }) {
    * field data in the form has changed).
    */
   const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  const formInstance = useRef<Webform | null>(null);
+
+  /**
+   * After saving a draft, reset Formio webform's submitted property so
+   * untouched fields do not show validation errors.
+   */
+  function clearWebformSubmittedFlag() {
+    const instance = formInstance.current;
+
+    if (instance) {
+      instance.submitted = false;
+    }
+  }
 
   if (!staticContent || !privateConfigData || !bapSamData) {
     return <Loading />;
@@ -447,6 +462,9 @@ function FundingRequestForm(props: { email: string }) {
             readOnly: formIsReadOnly,
             noAlerts: true,
           }}
+          onFormReady={(instance: Webform) => {
+            formInstance.current = instance;
+          }}
           onSubmit={(onSubmitParam: Submission) => {
             if (formIsReadOnly) return;
 
@@ -533,6 +551,10 @@ function FundingRequestForm(props: { email: string }) {
                 });
               },
               onSettled: (_data, _error, _payload, _context) => {
+                if (onSubmitParam.state === "draft") {
+                  queueMicrotask(clearWebformSubmittedFlag);
+                }
+
                 dataIsPosting.current = false;
                 formIsBeingSubmitted.current = false;
               },

--- a/app/client/src/routes/prf2022.tsx
+++ b/app/client/src/routes/prf2022.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
+import { type Webform } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -147,6 +148,20 @@ function PaymentRequestForm(props: { email: string }) {
    * field data in the form has changed).
    */
   const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  const formInstance = useRef<Webform | null>(null);
+
+  /**
+   * After saving a draft, reset Formio webform's submitted property so
+   * untouched fields do not show validation errors.
+   */
+  function clearWebformSubmittedFlag() {
+    const instance = formInstance.current;
+
+    if (instance) {
+      instance.submitted = false;
+    }
+  }
 
   if (!staticContent || !privateConfigData || !bapSamData) {
     return <Loading />;
@@ -334,6 +349,9 @@ function PaymentRequestForm(props: { email: string }) {
             readOnly: formIsReadOnly,
             noAlerts: true,
           }}
+          onFormReady={(instance: Webform) => {
+            formInstance.current = instance;
+          }}
           onSubmit={(onSubmitParam) => {
             if (formIsReadOnly) return;
 
@@ -424,6 +442,10 @@ function PaymentRequestForm(props: { email: string }) {
                 });
               },
               onSettled: (_data, _error, _payload, _context) => {
+                if (onSubmitParam.state === "draft") {
+                  queueMicrotask(clearWebformSubmittedFlag);
+                }
+
                 dataIsPosting.current = false;
                 formIsBeingSubmitted.current = false;
               },

--- a/app/client/src/routes/prf2023.tsx
+++ b/app/client/src/routes/prf2023.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
+import { type Webform } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -147,6 +148,20 @@ function PaymentRequestForm(props: { email: string }) {
    * field data in the form has changed).
    */
   const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  const formInstance = useRef<Webform | null>(null);
+
+  /**
+   * After saving a draft, reset Formio webform's submitted property so
+   * untouched fields do not show validation errors.
+   */
+  function clearWebformSubmittedFlag() {
+    const instance = formInstance.current;
+
+    if (instance) {
+      instance.submitted = false;
+    }
+  }
 
   if (!staticContent || !privateConfigData || !bapSamData) {
     return <Loading />;
@@ -329,6 +344,9 @@ function PaymentRequestForm(props: { email: string }) {
             readOnly: formIsReadOnly,
             noAlerts: true,
           }}
+          onFormReady={(instance: Webform) => {
+            formInstance.current = instance;
+          }}
           onSubmit={(onSubmitParam: Submission) => {
             if (formIsReadOnly) return;
 
@@ -419,6 +437,10 @@ function PaymentRequestForm(props: { email: string }) {
                 });
               },
               onSettled: (_data, _error, _payload, _context) => {
+                if (onSubmitParam.state === "draft") {
+                  queueMicrotask(clearWebformSubmittedFlag);
+                }
+
                 dataIsPosting.current = false;
                 formIsBeingSubmitted.current = false;
               },

--- a/app/client/src/routes/prf2024.tsx
+++ b/app/client/src/routes/prf2024.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router";
 import { useQueryClient, useQuery, useMutation } from "@tanstack/react-query";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
+import { type Webform } from "@formio/js";
 import { type FormProps, type Submission, Form } from "@formio/react";
 import clsx from "clsx";
 import { cloneDeep, isEqual } from "lodash";
@@ -147,6 +148,20 @@ function PaymentRequestForm(props: { email: string }) {
    * field data in the form has changed).
    */
   const lastSuccesfullySubmittedData = useRef<{ [field: string]: unknown }>({});
+
+  const formInstance = useRef<Webform | null>(null);
+
+  /**
+   * After saving a draft, reset Formio webform's submitted property so
+   * untouched fields do not show validation errors.
+   */
+  function clearWebformSubmittedFlag() {
+    const instance = formInstance.current;
+
+    if (instance) {
+      instance.submitted = false;
+    }
+  }
 
   if (!staticContent || !privateConfigData || !bapSamData) {
     return <Loading />;
@@ -329,6 +344,9 @@ function PaymentRequestForm(props: { email: string }) {
             readOnly: formIsReadOnly,
             noAlerts: true,
           }}
+          onFormReady={(instance: Webform) => {
+            formInstance.current = instance;
+          }}
           onSubmit={(onSubmitParam: Submission) => {
             if (formIsReadOnly) return;
 
@@ -419,6 +437,10 @@ function PaymentRequestForm(props: { email: string }) {
                 });
               },
               onSettled: (_data, _error, _payload, _context) => {
+                if (onSubmitParam.state === "draft") {
+                  queueMicrotask(clearWebformSubmittedFlag);
+                }
+
                 dataIsPosting.current = false;
                 formIsBeingSubmitted.current = false;
               },


### PR DESCRIPTION
## Related Issues:
* CSBAPP-652

## Main Changes:
Update forms to reset Form.io webform's submitted property after saving a draft so untouched fields do not show validation errors.

## Steps To Test:
1. Navigate to any form. Advance past the first page and click the "Save" button.
2. Ensure form validation isn't triggered for any untouched form fields.
3. Repeat for each form.
4. NOTE: this is easiest to see visually when you test a PRF or CRF, as those forms are pre-filled with some data from the previous form submission (FRF or PRF respectively). So best test would be to create an FRF with multiple buses. Then create a PRF and advance to the bus page/section of the form. Then click the "Save" button, and ensure any bus fields that you haven't yet gotten to (to fill in the additional required fields) don't show up highlighted red (the bus fields are within an edit grid, but each edit grid item would highlight red if validation was triggered and any required fields within were not filled out).

## TODO:
- [ ] In the future, if Formio itself is updated to handle this, we should consider removing this code from each form component as it will no longer be necessary then.
