### PR TITLE
Feature/update openapi docs and version numbers

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -13,7 +13,7 @@ jobs:
     environment: production
 
     env:
-      APP_VERSION: 8.0.1
+      APP_VERSION: 8.1.0
       CLOUD_SPACE: production
       SERVER_BASE_PATH: /csb
 

--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app-client",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@formio/bootstrap": "3.1.4",

--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app-client",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app-client",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "description": "U.S. EPA CSB Rebate Forms Application (client app)",
   "homepage": ".",
   "license": "CC0-1.0",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epa-csb-rebate-forms-app",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "license": "CC0-1.0",
       "devDependencies": {
         "@playwright/test": "1.55.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "description": "U.S. EPA CSB Rebate Forms Application",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",

--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epa-csb-rebate-forms-app-server",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epa-csb-rebate-forms-app-server",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "license": "CC0-1.0",
       "dependencies": {
         "axios": "1.12.2",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epa-csb-rebate-forms-app-server",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "description": "U.S. EPA CSB Rebate Forms Application (server app)",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",

--- a/docs/csb-openapi.json
+++ b/docs/csb-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "epa-csb-server",
-    "version": "8.0.0",
+    "version": "8.1.0",
     "license": {
       "name": "CC0-1.0"
     },
@@ -180,6 +180,10 @@
                     "formioProjectName": {
                       "type": "string",
                       "example": "forms"
+                    },
+                    "formioPremiumKey": {
+                      "type": "string",
+                      "example": "secret"
                     },
                     "rebateYear": {
                       "type": "string",


### PR DESCRIPTION
## Related Issues:
* CSBAPP-655

## Main Changes:
* Update OpenAPI docs to reflect moving formio premium API key from the client app to the server app (now returned in the private config API – see #655).
* Increment app version numbers to v8.1.0

## Steps To Test:
1. No functional changes (just surrounding documentation). That said, feel free to navigate to any page of the app – all should function normally.
