### PR TITLE
Feature/update bap school district info query

### DIFF
--- a/app/server/app/utilities/bap.js
+++ b/app/server/app/utilities/bap.js
@@ -2646,7 +2646,8 @@ async function queryForCSBRebateSchoolDistrictInfo(req, rebateId) {
   //     FROM
   //       Object_Item_Contacts__r
   //     WHERE
-  //       Contact_Type__c = 'School District Contact'
+  //       Contact_Type__c = 'School District Contact' AND
+  //       Active__c = true
   //     ORDER BY
   //       CreatedDate DESC
   //     LIMIT 1
@@ -2664,7 +2665,8 @@ async function queryForCSBRebateSchoolDistrictInfo(req, rebateId) {
   //       Order_Requests__r
   //     WHERE
   //       RecordType.DeveloperName = 'CSB_Change_Request' AND
-  //       Request_Type__c = 'School District Changes'
+  //       Request_Type__c = 'School District Changes' AND
+  //       Change_Status__c = 'Accepted'
   //     ORDER BY
   //       CreatedDate DESC
   //     LIMIT 1
@@ -2706,6 +2708,7 @@ async function queryForCSBRebateSchoolDistrictInfo(req, rebateId) {
     })
     .where({
       Contact_Type__c: "School District Contact",
+      Active__c: true,
     })
     .sort({ CreatedDate: -1 })
     .limit(1)
@@ -2724,6 +2727,7 @@ async function queryForCSBRebateSchoolDistrictInfo(req, rebateId) {
     .where({
       "RecordType.DeveloperName": "CSB_Change_Request",
       Request_Type__c: "School District Changes",
+      Change_Status__c: "Accepted",
     })
     .sort({ CreatedDate: -1 })
     .limit(1)


### PR DESCRIPTION
## Related Issues:
* CSBAPP-663

## Main Changes:
* Update BAP query for fetching school district info with latest query logic provided by the BAP team.

## Steps To Test:
1. Navigate to a 2023 close out form.
2. Advance through the form until you're on the page that makes a request for fetching the school district info from the BAP.
3. Trigger the request and ensure you're getting results back (check the browser dev tools network tab).
