### PR TITLE
Feature/update github actions cf binary download url

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Set up Cloud Foundry CLI
         run: |
-          curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&version=v7&source=github'
+          curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=8.18.3&source=github-rel'
           sudo dpkg -i cf-cli_amd64.deb
           cf -v
           cf api https://api.fr.cloud.gov

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Set up Cloud Foundry CLI
         run: |
-          curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&version=v7&source=github'
+          curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=8.18.3&source=github-rel'
           sudo dpkg -i cf-cli_amd64.deb
           cf -v
           cf api https://api.fr.cloud.gov


### PR DESCRIPTION
## Related Issues:
* CSBAPP-666

## Main Changes:
Update URL of Cloud Foundry CLI binary in GitHub Actions workflows, so project can deploy to Cloud.gov.

## Steps To Test:
1. N/A (GitHub Action should now succeed, as expected, and update should be deployed to dev site).

## TODO:
- [x] Update PR with Jira ticket number once it's been created.
